### PR TITLE
Sets starting z-index to 9998 in dialogs so the topbar does not obscure close button

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -113,7 +113,7 @@ This code manage the many-to-[one|many] association field popup
                         jQuery('a', field_dialog_{{ id }}).die('click');
                         jQuery('form', field_dialog_{{ id }}).die('submit');
                     },
-					zIndex: 9998,
+                    zIndex: 9998,
                 });
             }
         });
@@ -160,7 +160,7 @@ This code manage the many-to-[one|many] association field popup
                         jQuery('a', field_dialog_{{ id }}).die('click');
                         jQuery('form', field_dialog_{{ id }}).die('submit');
                     },
-					zIndex: 9998,
+                    zIndex: 9998,
                 });
             }
         });


### PR DESCRIPTION
If the size of the form is larger than the size of your screen, the "x" at the top to close the dialog gets obscured behind the top bar.  This is because twitter's bootstrap.css sets the topbar to z-index "10000", and by default the jquery-ui dialogs are set to "1000".  I have set the zIndex property in the dialog to be "9998", which makes sure the dialog box is visible above the top nav.

This is very critical, as for smaller browsers and bigger forms, this is the ONLY way to get out of that form (other than pressing escape, which is not intuitive to many users).

It would be great to use Twitter Bootstrap Modals instead of JqueryUI Dialogs as a future enhancement.
