### PR TITLE
Removed td reference in the script for the 'many' associations

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -34,7 +34,7 @@ This code manage the many-to-[one|many] association field popup
 
         Admin.log('[{{ id }}|field_dialog_form_list_link] handle link click in a list');
 
-        var element = jQuery(this).parents('#field_dialog_{{ id }} td.sonata-ba-list-field');
+        var element = jQuery(this).parents('#field_dialog_{{ id }} .sonata-ba-list-field');
 
         // the user does click on a row column
         if (element.length == 0) {


### PR DESCRIPTION
This change allows modification of the template of the list while still using the sonata js scripts.
