### PR TITLE
Added missing "show" templates 

### DIFF
--- a/Builder/ShowBuilder.php
+++ b/Builder/ShowBuilder.php
@@ -63,17 +63,7 @@ class ShowBuilder implements ShowBuilderInterface
         $this->fixFieldDescription($admin, $fieldDescription);
         $admin->addShowFieldDescription($fieldDescription->getName(), $fieldDescription);
 
-        switch($fieldDescription->getMappingType()) {
-            case ClassMetadataInfo::MANY_TO_ONE:
-            case ClassMetadataInfo::MANY_TO_MANY:
-            case ClassMetadataInfo::ONE_TO_MANY:
-            case ClassMetadataInfo::ONE_TO_ONE:
-                // todo
-                return;
-            default:
-                $list->add($fieldDescription);
-        }
-
+        $list->add($fieldDescription);
     }
 
     /**

--- a/Resources/views/CRUD/show_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_many.html.twig
@@ -1,0 +1,30 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+
+{% block field%}
+    <ul class="sonata-ba-show-many-to-many">
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('edit')%}
+        {% for element in value%}
+            <li>
+                <a href="{{ field_description.associationadmin.generateObjectUrl('edit', element) }}">{{ element|render_relation_element(field_description) }}</a>
+            </li>
+        {% endfor %}
+    {% else %}
+        {% for element in value%}
+            <li>
+                {{ element|render_relation_element(field_description) }}
+            </li>
+        {% endfor %}
+    {% endif %}
+    </ul>
+{% endblock %}

--- a/Resources/views/CRUD/show_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_one.html.twig
@@ -1,0 +1,22 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+
+{% block field %}
+    {% if value %}
+        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT') %}
+            <a href="{{ field_description.associationadmin.generateObjectUrl('edit', value) }}">{{ value|render_relation_element(field_description) }}</a>
+        {% else %}
+            {{ value|render_relation_element(field_description) }}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/Resources/views/CRUD/show_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_one_to_many.html.twig
@@ -1,0 +1,26 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+
+{% block field%}
+    <ul class="sonata-ba-show-one-to-many">
+    {% if field_description.hasassociationadmin and field_description.associationadmin.isGranted('EDIT') and field_description.associationadmin.hasRoute('edit') %}
+        {% for element in value%}
+            <li><a href="{{ field_description.associationadmin.generateObjectUrl('edit', element) }}">{{ element|render_relation_element(field_description) }}</a></li>
+        {% endfor %}
+    {% else %}
+        {% for element in value%}
+            <li>{{ element|render_relation_element(field_description) }}</li>
+        {% endfor %}
+    {% endif %}
+    </ul>
+{% endblock %}

--- a/Resources/views/CRUD/show_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_one_to_one.html.twig
@@ -1,0 +1,22 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+
+{% block field %}
+    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) %}
+        {% if field_description.hasAssociationAdmin and field_description.associationadmin.isGranted('EDIT') and field_description.associationadmin.hasRoute('edit') %}
+            <a href="{{ field_description.associationadmin.generateObjectUrl('edit', value) }}">{{ value|render_relation_element(field_description) }}</a>
+        {% else %}
+            {{ value|render_relation_element(field_description) }}
+        {% endif %}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
This commit adds the missing "show" templates. 

When configuring our admin class with configureShowFields, the relation fields were not showing. This fixes that for every kind of relations (many to many, many to one, one to many, one to one).
