### PR TITLE
Fixed the triggering of the "sonata.add_element" event.

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_association_script.html.twig
@@ -41,10 +41,8 @@ This code manage the one-to-many association field popup
             type: "POST",
             data: { _xml_http_request: true },
             success: function(html) {
-                jQuery('#field_container_{{ id }}')
-                    .replaceWith(html) // replace the html
-                    .trigger('sonata.add_element')
-                ;
+                jQuery('#field_container_{{ id }}').replaceWith(html); // replace the html
+                jQuery('#sonata-ba-field-container-{{ id }}').trigger('sonata.add_element');
             }
         });
 


### PR DESCRIPTION
The call to `jQuery('#field_container_{{ id }}').replaceWith(html)` removes all previously bound events so the `.trigger()` function will do nothing.

This commit moves the triggering from `#field_container_{{ id }}` to `#sonata-ba-field-container-{{ id }}` which in fact is the element used [here](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/master/Resources/views/CRUD/edit_orm_one_to_many.html.twig#L118).
