### PR TITLE
acl: fix generate object acl command - only first batch size was saved

### DIFF
--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -9,8 +9,6 @@
     </parameters>
 
     <services>
-        <service id="sonata.admin.manipulator.acl.object.orm" class="%sonata.admin.manipulator.acl.object.orm.class%" >
-            <argument type="service" id="sonata.admin.security.handler" />
-        </service>
+        <service id="sonata.admin.manipulator.acl.object.orm" class="%sonata.admin.manipulator.acl.object.orm.class%" />
     </services>
 </container>

--- a/Util/ObjectAclManipulator.php
+++ b/Util/ObjectAclManipulator.php
@@ -56,23 +56,22 @@ class ObjectAclManipulator extends BaseObjectAclManipulator
                 // detach from Doctrine, so that it can be Garbage-Collected immediately
                 $em->detach($row[0]);
 
-                if ((++$i % $batchSize) == 0) {
+                $count++;
 
-                    list($batchAdded, $batchUpdated) = $this->configureAcls($admin, $oids, $securityIdentity);
+                if (($count % $batchSize) == 0) {
+                    list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, $oids, $securityIdentity);
                     $countAdded += $batchAdded;
                     $countUpdated += $batchUpdated;
                     $oids = array();
                 }
 
-                if ((++$i % $batchSizeOutput) == 0) {
+                if (($count % $batchSizeOutput) == 0) {
                     $output->writeln(sprintf('   - generated class ACEs%s for %s objects (added %s, updated %s)', $objectOwnersMsg, $count, $countAdded, $countUpdated));
                 }
-
-                $count++;
             }
 
             if (count($oids) > 0) {
-                list($batchAdded, $batchUpdated) = $this->configureAcls($admin, $oids, $securityIdentity);
+                list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, $oids, $securityIdentity);
                 $countAdded += $batchAdded;
                 $countUpdated += $batchUpdated;
             }


### PR DESCRIPTION
fixed `app/console sonata:admin:generate-object-acl`, it did not work or produced errors for:
- objects with existing object ACLs
- or when more then 20 (batch size) ACLs for the same class where created
