### PR TITLE
[sonata:admin:generate-object-acl] wrong argument type in DoctrineORMAdminBundle/Util/ObjectAclManipulator.php

### DIFF
--- a/Util/ObjectAclManipulator.php
+++ b/Util/ObjectAclManipulator.php
@@ -58,7 +58,7 @@ class ObjectAclManipulator extends BaseObjectAclManipulator
 
                 if ((++$i % $batchSize) == 0) {
 
-                    list($batchAdded, $batchUpdated) = $this->configureAcls($admin, $oids, $securityIdentity);
+                    list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, $oids, $securityIdentity);
                     $countAdded += $batchAdded;
                     $countUpdated += $batchUpdated;
                     $oids = array();
@@ -72,7 +72,7 @@ class ObjectAclManipulator extends BaseObjectAclManipulator
             }
 
             if (count($oids) > 0) {
-                list($batchAdded, $batchUpdated) = $this->configureAcls($admin, $oids, $securityIdentity);
+                list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, $oids, $securityIdentity);
                 $countAdded += $batchAdded;
                 $countUpdated += $batchUpdated;
             }


### PR DESCRIPTION
resulting from changes made to SonataAdminBundle Util/ObjectAclManipulator.php on commit
f657f659f1a50fa26084e2ea98a25e1997ec4400
