### PR TITLE
implemented isActive for all DoctrineORM filters

### DIFF
--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -37,7 +37,7 @@ class CallbackFilter extends Filter
             throw new \RuntimeException(sprintf('Please provide a valid callback option "filter" for field "%s"', $this->getName()));
         }
 
-        call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $data);
+        $this->active = call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $data);
     }
 
     /**

--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -15,6 +15,8 @@ use Sonata\AdminBundle\Filter\Filter as BaseFilter;
 
 abstract class Filter extends BaseFilter
 {
+    protected $active = false;
+
     public function apply($queryBuilder, $value)
     {
         $this->value = $value;
@@ -36,5 +38,13 @@ abstract class Filter extends BaseFilter
         } else {
             $queryBuilder->andWhere($parameter);
         }
+
+        // filter is active since it's added to the queryBuilder
+        $this->active = true;
+    }
+
+    public function isActive()
+    {
+        return $this->active;
     }
 }

--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -88,9 +88,10 @@ Callback
 ^^^^^^^^
 
 To create a custom callback filter, two methods need to be implemented; one to
-define the field type and one to define how to use the field's value. In this
-example, ``getWithOpenCommentField`` and ``getWithOpenCommentFilter`` implement
-this functionality.
+define the field type and one to define how to use the field's value. The
+latter shall return wether the filter actually is applied to the queryBuilder
+or not. In this example, ``getWithOpenCommentField`` and ``getWithOpenCommentFilter``
+implement this functionality.
 
 .. code-block:: php
 
@@ -124,6 +125,8 @@ this functionality.
                         $queryBuilder->leftJoin(sprintf('%s.comments', $alias), 'c');
                         $queryBuilder->andWhere('c.status = :status');
                         $queryBuilder->setParameter('status', Comment::STATUS_MODERATE);
+
+                        return true;
                     },
                     'field_type' => 'checkbox'
                 ))
@@ -139,5 +142,7 @@ this functionality.
             $queryBuilder->leftJoin(sprintf('%s.comments', $alias), 'c');
             $queryBuilder->andWhere('c.status = :status');
             $queryBuilder->setParameter('status', Comment::STATUS_MODERATE);
+
+            return true;
         }
     }

--- a/Tests/Filter/BooleanFilterTest.php
+++ b/Tests/Filter/BooleanFilterTest.php
@@ -32,6 +32,7 @@ class BooleanFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array(null, 'test'));
 
         $this->assertEquals(array(), $builder->query);
+        $this->assertEquals(false, $filter->isActive());
     }
 
     public function testFilterNo()
@@ -45,6 +46,7 @@ class BooleanFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('alias.field = :field_name'), $builder->query);
         $this->assertEquals(array('field_name' => 0), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function testFilterYes()
@@ -58,6 +60,7 @@ class BooleanFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('alias.field = :field_name'), $builder->query);
         $this->assertEquals(array('field_name' => 1), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function testFilterArray()
@@ -70,5 +73,6 @@ class BooleanFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('type' => null, 'value' => array(BooleanType::TYPE_NO)));
 
         $this->assertEquals(array('in_alias.field', 'alias.field IN ("0")'), $builder->query);
+        $this->assertEquals(true, $filter->isActive());
     }
 }

--- a/Tests/Filter/CallbackFilterTest.php
+++ b/Tests/Filter/CallbackFilterTest.php
@@ -24,6 +24,7 @@ class CallbackFilterTest extends \PHPUnit_Framework_TestCase
             'callback' => function($builder, $alias, $field, $value) {
                 $builder->andWhere(sprintf('CUSTOM QUERY %s.%s', $alias, $field));
                 $builder->setParameter('value', $value);
+                return true;
             }
         ));
 
@@ -31,6 +32,7 @@ class CallbackFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('CUSTOM QUERY alias.field'), $builder->query);
         $this->assertEquals(array('value' => 'myValue'), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function testFilterMethod()
@@ -46,11 +48,13 @@ class CallbackFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('CUSTOM QUERY alias.field'), $builder->query);
         $this->assertEquals(array('value' => 'myValue'), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function customCallback($builder, $alias, $field, $value) {
         $builder->andWhere(sprintf('CUSTOM QUERY %s.%s', $alias, $field));
         $builder->setParameter('value', $value);
+        return true;
     }
 
     /**

--- a/Tests/Filter/ChoiceFilterTest.php
+++ b/Tests/Filter/ChoiceFilterTest.php
@@ -28,6 +28,7 @@ class ChoiceFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array());
 
         $this->assertEquals(array(), $builder->query);
+        $this->assertEquals(false, $filter->isActive());
     }
 
     public function testFilterArray()
@@ -40,6 +41,7 @@ class ChoiceFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('type' => ChoiceType::TYPE_CONTAINS, 'value' => array('1', '2')));
 
         $this->assertEquals(array('in_alias.field', 'alias.field IN ("1,2")'), $builder->query);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function testFilterScalar()
@@ -53,6 +55,6 @@ class ChoiceFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('alias.field = :field_name'), $builder->query);
         $this->assertEquals(array('field_name' => '1'), $builder->parameters);
-
+        $this->assertEquals(true, $filter->isActive());
     }
 }

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -99,4 +99,10 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         $filter = new FilterTest_Filter();
         $filter->getFieldName();
     }
+
+    public function testIsActive()
+    {
+        $filter = new FilterTest_Filter();
+        $this->assertEquals(false, $filter->isActive());
+    }
 }

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -42,6 +42,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array());
 
         $this->assertEquals(array(), $builder->query);
+        $this->assertEquals(false, $filter->isActive());
     }
 
     public function testFilterArray()
@@ -54,6 +55,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('type' => ChoiceType::TYPE_CONTAINS, 'value' => array('1', '2')));
 
         $this->assertEquals(array('in_alias.field', 'alias.field IN ("1,2")'), $builder->query);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function testFilterScalar()
@@ -67,6 +69,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('alias.field = :field_name'), $builder->query);
         $this->assertEquals(array('field_name' => 2), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     /**
@@ -89,6 +92,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->initialize('field_name', array('mapping_type' => ClassMetadataInfo::ONE_TO_ONE));
 
         $filter->apply(new QueryBuilder, 'asd');
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function testAssociationWithValidMapping()
@@ -104,5 +108,6 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->apply($builder, array('type' => ChoiceType::TYPE_CONTAINS, 'value' => 'asd'));
 
         $this->assertEquals(array('o.field_name', 's_field_name.id = :field_name'), $builder->query);
+        $this->assertEquals(true, $filter->isActive());
     }
 }

--- a/Tests/Filter/NumberFilterTest.php
+++ b/Tests/Filter/NumberFilterTest.php
@@ -27,6 +27,7 @@ class NumberFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', 'asds');
 
         $this->assertEquals(array(), $builder->query);
+        $this->assertEquals(false, $filter->isActive());
     }
 
     public function testFilterInvalidOperator()
@@ -39,6 +40,7 @@ class NumberFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('type' => 'foo'));
 
         $this->assertEquals(array(), $builder->query);
+        $this->assertEquals(false, $filter->isActive());
     }
 
     public function testFilter()
@@ -65,5 +67,6 @@ class NumberFilterTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals($expected, $builder->query);
+        $this->assertEquals(true, $filter->isActive());
     }
 }

--- a/Tests/Filter/StringFilterTest.php
+++ b/Tests/Filter/StringFilterTest.php
@@ -27,6 +27,7 @@ class StringFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', '');
 
         $this->assertEquals(array(), $builder->query);
+        $this->assertEquals(false, $filter->isActive());
     }
 
     public function testContains()
@@ -48,6 +49,7 @@ class StringFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('value' => 'asd', 'type' => null));
         $this->assertEquals(array('alias.field LIKE :field_name'), $builder->query);
         $this->assertEquals(array('field_name' => 'asd'), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function testNotContains()
@@ -61,6 +63,7 @@ class StringFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('value' => 'asd', 'type' => ChoiceType::TYPE_NOT_CONTAINS));
         $this->assertEquals(array('alias.field NOT LIKE :field_name'), $builder->query);
         $this->assertEquals(array('field_name' => 'asd'), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
     }
 
     public function testEquals()
@@ -74,5 +77,6 @@ class StringFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('value' => 'asd', 'type' => ChoiceType::TYPE_EQUAL));
         $this->assertEquals(array('alias.field = :field_name'), $builder->query);
         $this->assertEquals(array('field_name' => 'asd'), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
     }
 }


### PR DESCRIPTION
- refactored callback filters to return wether they actually modify the queryBuilder
- for the other filter types, if applyWhere is called, then filter is active
- updated documentation
- updated tests

related PR for AdminBundle:
https://github.com/sonata-project/SonataAdminBundle/pull/578
