### PR TITLE
Make sure that the simplethings entity audit truely is optional

### DIFF
--- a/Resources/config/audit.xml
+++ b/Resources/config/audit.xml
@@ -14,7 +14,7 @@
 
             <argument>sonata.admin_doctrine_orm.block.audit</argument>
             <argument type="service" id="templating" />
-            <argument type="service" id="simplethings_entityaudit.reader" />
+            <argument type="service" id="simplethings_entityaudit.reader" on-invalid="ignore" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
The service "sonata.admin_doctrine_orm.block.audit" has a dependency on a non-existent service "simplethings_entityaudit.reader".
