### PR TITLE
Allow to disable audit for certain entity

### DIFF
--- a/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -40,13 +40,12 @@ class AddAuditEntityCompilerPass implements CompilerPassInterface
                 continue;
             }
 
-            if(isset($attributes[0]['audit']) && $attributes[0]['audit'] == 'false') {
-                continue;
-            }
-            
-            $definition = $container->getDefinition($id);
+            if(isset($attributes[0]['audit']) && $attributes[0]['audit'] == 'true') {
+                
+                $definition = $container->getDefinition($id);
 
-            $autitedEntities[] = $this->getModelName($container, $definition->getArgument(1));
+                $autitedEntities[] = $this->getModelName($container, $definition->getArgument(1));
+            }
         }
 
         $autitedEntities = array_unique($autitedEntities);


### PR DESCRIPTION
My change will allow to disable audit for certain entities. 

To keep backward compatibility, i didn't remove "by default" auditing, even if I found that very annoying to have by default all your entity being audited. 
