### PR TITLE
[Filter] fixed choice filter when the selected choice is '0'

### DIFF
--- a/Filter/ChoiceFilter.php
+++ b/Filter/ChoiceFilter.php
@@ -46,7 +46,7 @@ class ChoiceFilter extends Filter
 
         } else {
 
-            if (empty($data['value']) || $data['value'] == 'all') {
+            if ($data['value'] === '' || $data['value'] === null || $data['value'] === false || $data['value'] == 'all') {
                 return;
             }
 


### PR DESCRIPTION
This PR fixes a filter bug: when a choice key is 0 in a `ChoiceFilter`, the filter didn't work (listed all items in the datagrid). Now it is fixed.
