### PR TITLE
Fix jQuery 1.7.1 dataType for one-to-many association list button

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -77,6 +77,7 @@ This code manage the many-to-[one|many] association field popup
         // retrieve the form element from the related admin generator
         jQuery.ajax({
             url: a.attr('href'),
+            dataType: 'html',
             success: function(html) {
 
                 Admin.log('[{{ id }}|field_dialog_form_list] retrieving the list content');


### PR DESCRIPTION
Subj :)
It seems, you've forgotten to add this line during migration to jQuery 1.7.1
