### PR TITLE
Remove csrf_protection in FilterTypeGuesser.php

### DIFF
--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -85,9 +85,6 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             case 'bigint':
             case 'smallint':
                 $options['field_type'] = 'number';
-                $options['field_options'] = array(
-                    'csrf_protection' => false
-                );
 
                 return new TypeGuess('doctrine_orm_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'string':


### PR DESCRIPTION
The filter guesser force disabling of csrf_protection for integers. This is already done in `Builder\DatagridBuild::getBaseDatagrid`.

This PR is required for sonata-project/SonataAdminBundle#725
