### PR TITLE
Fix javascript parse error

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -247,6 +247,7 @@ This code manage the many-to-[one|many] association field popup
                                 'code':      sonata_admin.admin.root.code
                             }) }}',
                             data: {_xml_http_request: true },
+                            dataType: 'html',
                             type: 'POST',
                             success: function(html) {
                                 jQuery('#field_container_{{ id }}').replaceWith(html);


### PR DESCRIPTION
If "dataType" is not defined, the ajaxSubmit function returns a parse error, the "success" callback is not called and the field is not updated.
