### PR TITLE
Use addOrderBy instead of orderBy in ProxyQuery

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -53,7 +53,7 @@ class ProxyQuery implements ProxyQueryInterface
             if (strpos($sortBy, '.') === false) { // add the current alias
                 $sortBy = $queryBuilder->getRootAlias() . '.' . $sortBy;
             }
-            $queryBuilder->orderBy($sortBy, $this->getSortOrder());
+            $queryBuilder->addOrderBy($sortBy, $this->getSortOrder());
         }
 
         return $this->getFixedQueryBuilder($queryBuilder)->getQuery()->execute($params, $hydrationMode);


### PR DESCRIPTION
This update allows to add a priority sort order, like this :

```
public function createQuery($context = 'list')
{
    $query = parent::createQuery($context);

     if ('list' === $context) {
        $query->orderBy('c.myField');
     }

    return $query;
}
```

What do you think ?
