### PR TITLE
Fix for float filter

### DIFF
--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -78,6 +78,8 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                 return new TypeGuess('doctrine_orm_date', $options, Guess::HIGH_CONFIDENCE);
             case 'decimal':
             case 'float':
+                $options['field_type'] = 'number';
+
                 return new TypeGuess('doctrine_orm_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'integer':
             case 'bigint':


### PR DESCRIPTION
Fixed float/decimal filters - without this it tries to use false as the form element type, which causes an exception from the form component - making it impossible to use float.
