### PR TITLE
hiding sortable field

### DIFF
--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -172,6 +172,15 @@ defining one of these options:
   - ``inline``: ``table|standard``, the fields are displayed into table
   - ``sortable``: if the model has a position field, you can enable a drag and
     drop sortable effect by setting ``sortable=field_name``
+    NOTE - child admin class should have sortable field added in configureFormFields.
+    If you want to hide it - use hidden attribute
+
+.. code-block:: php
+
+protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->add('position',null,array('attr'=>array("hidden" => true)))
 
 .. code-block:: php
 

--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -26,7 +26,7 @@ file that was distributed with this source code.
                                         {% if field_name == '_delete' %}
                                             <th>{% trans from 'SonataAdminBundle' %}action_delete{% endtrans %}</th>
                                         {% else %}
-                                            <th>{{ nested_field.get('sonata_admin').admin.trans(nested_field.vars.label) }}</th>
+                                            {% if nested_field.vars.attr.hidden is not defined %}<th>{{ nested_field.get('sonata_admin').admin.trans(nested_field.vars.label) }}</th>{% endif %}
                                         {% endif %}
                                     {% endfor %}
                                 </tr>
@@ -35,7 +35,7 @@ file that was distributed with this source code.
                                 {% for nested_group_field_name, nested_group_field in form.getChildren() %}
                                     <tr>
                                         {% for field_name, nested_field in nested_group_field.getChildren() %}
-                                            <td class="sonata-ba-td-{{ id }}-{{ field_name  }}{% if nested_field.vars.errors|length > 0 %} clearfix error{% endif %}">
+                                            <td class="sonata-ba-td-{{ id }}-{{ field_name  }}{% if nested_field.vars.errors|length > 0 %} error{% endif %}"{% if nested_field.vars.attr.hidden is defined %} style="display: none;"{% endif %}>
                                                 {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined %}
                                                     {{ form_widget(nested_field) }}
 


### PR DESCRIPTION
In order to use sortable field in sonata_type_collection it need to be visible, which is really 

annoying.
I have created small patch, so such a code will work

protected function configureFormFields(FormMapper $formMapper)
    {
        $formMapper
            ->add('position',null,array('attr'=>array("hidden" => true)))
