### PR TITLE
added field-container css classes

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_many.html.twig
@@ -10,12 +10,12 @@ file that was distributed with this source code.
 #}
 
 {% if sonata_admin.field_description.associationadmin %}
-    <div id="field_container_{{ id }}">
+    <div id="field_container_{{ id }}" class="field-container">
         <span id="field_widget_{{ id }}" >
             {{ form_widget(form) }}
         </span>
 
-        <span id="field_actions_{{ id }}" >
+        <span id="field_actions_{{ id }}" class="field-actions">
             {% if sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') %}
                 <a
                     href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"

--- a/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
         {{ form_row(form.getChild(field_description.name))}}
     {% endfor %}
 {% else %}
-    <div id="field_container_{{ id }}">
+    <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" >
                 {% if sonata_admin.admin.id(sonata_admin.value) %}
@@ -38,7 +38,7 @@ file that was distributed with this source code.
             </span>
         {% endif %}
 
-        <span id="field_actions_{{ id }}" >
+        <span id="field_actions_{{ id }}" class="field-actions">
 
             {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
                 <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"

--- a/Resources/views/CRUD/edit_orm_one_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_association_script.html.twig
@@ -48,6 +48,7 @@ This code manage the one-to-many association field popup
 									jQuery(form).attr('encoding', 'multipart/form-data');
 								}
                 jQuery('#sonata-ba-field-container-{{ id }}').trigger('sonata.add_element');
+                jQuery('#field_container_{{ id }}').trigger('sonata.add_element');
             }
         });
 

--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -14,7 +14,7 @@ file that was distributed with this source code.
     {% endfor %}
 {% else %}
 
-    <div id="field_container_{{ id }}">
+    <div id="field_container_{{ id }}" class="field-container">
         <span id="field_widget_{{ id }}" >
             {% if sonata_admin.edit == 'inline' %}
                 {% if sonata_admin.inline == 'table' %}

--- a/Resources/views/CRUD/edit_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_one.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
         {{ form_row(form.getChild(field_description.name)) }}
     {% endfor %}
 {% else %}
-    <div id="field_container_{{ id }}">
+    <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" >
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
@@ -37,7 +37,7 @@ file that was distributed with this source code.
                 {{ form_widget(form) }}
             </span>
         {% endif %}
-        <span id="field_actions_{{ id }}" >
+        <span id="field_actions_{{ id }}" class="field-actions">
 
             {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasroute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
 


### PR DESCRIPTION
The `field_add_*` function triggers the `sonata.add_element` on an element `'#sonata-ba-field-container-{{ id }}'` which does not exist in the `edit_orm_on_to_many` fields.

I've triggered an additional event on the correct field to execute javascript after elements have been added to this field.

Also, i've added the css class `field-container`.
