### PR TITLE
[FormContractor][type=admin] 'edit' option defaults to 'admin' if not defined

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -130,7 +130,7 @@ class FormContractor implements FormContractorInterface
             }
 
             $options['data_class']=$fieldDescription->getAssociationAdmin()->getClass();
-            $fieldDescription->setOption('edit','admin');
+            $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
         } else if ($type == 'sonata_type_collection') {
 
             if (!$fieldDescription->getAssociationAdmin()) {


### PR DESCRIPTION
Fix #104

@rodrigobb confirmed that this fix works in #70.

Unit tests OK. 
