### PR TITLE
Corrected Issue #114. Sort order doesn't change when clicked

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -381,7 +381,7 @@ class ModelManager implements ModelManagerInterface
     {
         $values = $datagrid->getValues();
 
-        if ($fieldDescription->getName() == $values['_sort_by']) {
+        if ($fieldDescription->getName() == $values['_sort_by']->getName()) {
             if ($values['_sort_order'] == 'ASC') {
                 $values['_sort_order'] = 'DESC';
             } else {


### PR DESCRIPTION
Sort order doesn't change when clicked in List table header.
In getSortParameters() function object of type FieldDescription was compared to string. So this never checked.

```
if ($fieldDescription->getName() == $values['_sort_by']) {
```

instead of

```
if ($fieldDescription->getName() == $values['_sort_by']->getName()) {
```
