### PR TITLE
Creating a new entity with an ajax popup from a 'list', bugfix

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -228,33 +228,29 @@ This code manage the many-to-[one|many] association field popup
                 if (data.result == 'ok') {
                     field_dialog_{{ id }}.dialog('close');
 
-                    {% if sonata_admin.field_description.options.edit == 'list' %}
-                        {#
-                           in this case we update the hidden input, and call the change event to
-                           retrieve the post information
-                        #}
-                        jQuery('#{{ id }}').val(data.objectId);
-                        jQuery('#{{ id }}').change();
-
-                    {% else %}
-
-                        // reload the form element
-                        jQuery('#field_widget_{{ id }}').closest('form').ajaxSubmit({
-                            url: '{{ url('sonata_admin_retrieve_form_element', {
-                                'elementId': id,
-                                'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
-                                'uniqid':    sonata_admin.admin.root.uniqid,
-                                'code':      sonata_admin.admin.root.code
-                            }) }}',
-                            data: {_xml_http_request: true },
-                            type: 'POST',
-                            success: function(html) {
-                                jQuery('#field_container_{{ id }}').replaceWith(html);
-                                jQuery('#{{ id }} option[value="' + data.objectId + '"]').attr('selected', 'selected');
-                            }
-                        });
-
-                    {% endif %}
+                    // reload the form element
+                    jQuery('#field_widget_{{ id }}').closest('form').ajaxSubmit({
+                        url: '{{ url('sonata_admin_retrieve_form_element', {
+                            'elementId': id,
+                            'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
+                            'uniqid':    sonata_admin.admin.root.uniqid,
+                            'code':      sonata_admin.admin.root.code
+                        }) }}',
+                        data: {_xml_http_request: true },
+                        type: 'POST',
+                        success: function(html) {
+                            jQuery('#field_container_{{ id }}').replaceWith(html);
+                            jQuery('#{{ id }} option[value="' + data.objectId + '"]').attr('selected', 'selected');
+                            
+                            {% if sonata_admin.field_description.options.edit == 'list' %}
+                                {#
+                                   in this case we update the hidden input, and call the change event to
+                                   retrieve the post information
+                                #}
+                                jQuery('#{{ id }}').change();
+                            {% endif %}
+                        }
+                    });
 
                     return;
                 }


### PR DESCRIPTION
Creating a new entity with an ajax popup from a 'list' type does not
update the hidden select element to include the new item.

This unifies the code so that lists require just an extra change() event to be fired, for the short_object_description to be updated.

How to reproduce: 
many/one-to-many relation with 'edit' => 'list' in the settings. 
Creating a new entity will close the popup without selecting an element and will fire a short_object_description ajax call with an empty objectId.

This might be affecting 2.0 as well but can't test it effectively.
