### PR TITLE
Fixed sort by direction caused by untransformed $values['_sort_by']

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -381,9 +381,10 @@ class ModelManager implements ModelManagerInterface
     {
         $values = $datagrid->getValues();
 
-        if ($fieldDescription->getName() == $values['_sort_by']) {
+        if ($fieldDescription->getName() == $values['_sort_by']->getName()) {
             if ($values['_sort_order'] == 'ASC') {
                 $values['_sort_order'] = 'DESC';
+		$values['_sort_by'] = $fieldDescription->getName();
             } else {
                 $values['_sort_order'] = 'ASC';
             }


### PR DESCRIPTION
Fixed bug which made it impossible to sort columns in descending order because the field description name was being compared against a $values['sort_by'], which is actually a FieldDescriptionInterface.
