### PR TITLE
[WIP] Add class column

### DIFF
--- a/Admin/FieldDescription.php
+++ b/Admin/FieldDescription.php
@@ -94,6 +94,10 @@ class FieldDescription extends BaseFieldDescription
      */
     public function getValue($object)
     {
+        if ($this->getType() == 'class') {
+            return \array_search(\get_class($object), $this->getOption('classes'));
+        }
+
         foreach ($this->parentAssociationMappings as $parentAssociationMapping) {
             $object = $this->getFieldValue($object, $parentAssociationMapping['fieldName']);
         }

--- a/Builder/ListBuilder.php
+++ b/Builder/ListBuilder.php
@@ -88,11 +88,15 @@ class ListBuilder implements ListBuilderInterface
      */
     public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription)
     {
+
+        $fieldDescription->setAdmin($admin);
+
         if ($fieldDescription->getName() == '_action') {
             $this->buildActionFieldDescription($fieldDescription);
         }
-
-        $fieldDescription->setAdmin($admin);
+        else if ($fieldDescription->getName() == '_class') {
+            $this->buildClassFieldDescription($fieldDescription);
+        }
 
         if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
             list($metadata, $lastPropertyName, $parentAssociationMappings) = $admin->getModelManager()->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
@@ -193,6 +197,22 @@ class ListBuilder implements ListBuilderInterface
             }
 
             $fieldDescription->setOption('actions', $actions);
+        }
+
+        return $fieldDescription;
+    }
+
+    /**
+     * @param \Sonata\AdminBundle\Admin\FieldDescriptionInterface $fieldDescription
+     *
+     * @return \Sonata\AdminBundle\Admin\FieldDescriptionInterface
+     */
+    public function buildClassFieldDescription(FieldDescriptionInterface $fieldDescription)
+    {
+        $fieldDescription->setType('class');
+
+        if (null === $fieldDescription->getOption('name')) {
+            $fieldDescription->setOption('name', 'Class');
         }
 
         return $fieldDescription;


### PR DESCRIPTION
Hi !

After submitting sonata-project/SonataAdminBundle#815 in order to support inherited classes, I come with this PR that add a class column into the datagrid.

Example:

``` php
<?php
$list->add('_class', 'class', array(
    'classes' => $this->getSubClasses(),
));
```

This is a working hackish draft, I am still waiting for feedback ;)

TODO: add doc.
