### PR TITLE
Bug Fix for one to one associations using type sonata_type_admin

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_one.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
     {{ value|render_relation_element(sonata_admin.field_description) }}
 {% elseif sonata_admin.edit == 'inline' %}
     {% for field_description in sonata_admin.field_description.associationadmin.formfielddescriptions %}
-        {{ form_row(form.offsetGet(field_description.name)) }}
+        {{ form_row(form.children[field_description.name]) }}
     {% endfor %}
 {% else %}
     <div id="field_container_{{ id }}" class="field-container">


### PR DESCRIPTION
form.get() returns a string and no longer an object due to lastest changes in symfony master branch
form.offsetGet(field_description.name) will return the FormView object.
