### PR TITLE
Fix for invalid option input_type when using date filters

### DIFF
--- a/Filter/AbstractDateFilter.php
+++ b/Filter/AbstractDateFilter.php
@@ -122,7 +122,9 @@ abstract class AbstractDateFilter extends Filter
      */
     public function getDefaultOptions()
     {
-        return array();
+        return array(
+            'input_type' => 'datetime'
+        );
     }
 
     /**
@@ -144,7 +146,6 @@ abstract class AbstractDateFilter extends Filter
             'field_type'    => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label'         => $this->getLabel(),
-            'input_type'    => 'datetime'
         ));
     }
 }


### PR DESCRIPTION
Move default input_type option from renderSettings to getDefaultOptions on AbstractDateFilter.

 Believe based on the docs this is where the option should be defaulted, and it's causing an error where it is - https://github.com/sonata-project/SonataAdminBundle/issues/905

Think this is an alternative fix to https://github.com/sonata-project/SonataAdminBundle/pull/917 - which I think is sidestepping the issue rather than fixing it by preventing the error. Think this addresses the cause.
