### PR TITLE
implement dummy version of getUrlsafeIdentifier

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -296,6 +296,17 @@ class ModelManager implements ModelManagerInterface
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * The ORM implementation does nothing special but you still should use
+     * this method when using the id in a URL to allow for future improvements.
+     */
+    public function getUrlsafeIdentifier($entity)
+    {
+        return $this->getNormalizedIdentifier($entity);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function addIdentifiersToQuery($class, ProxyQueryInterface $queryProxy, array $idx)


### PR DESCRIPTION
this is to implement the change in the ModelManagerInterface. https://github.com/sonata-project/SonataAdminBundle/pull/968

or should we urlencode the normalized identifier or something?
