### PR TITLE
Fixed small internet explorer js error.

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -118,7 +118,7 @@ This code manage the many-to-[one|many] association field popup
                         jQuery('a', field_dialog_{{ id }}).die('click');
                         jQuery('form', field_dialog_{{ id }}).die('submit');
                     },
-                    zIndex: 9998,
+                    zIndex: 9998
                 });
             }
         });


### PR DESCRIPTION
Removed a trailing comma from an object throwing an error.
Must also be applied in master.
