### PR TITLE
Fixed a bug where form didn't switch to multipart/form-data when necessary

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_association_script.html.twig
@@ -43,7 +43,7 @@ This code manage the one-to-many association field popup
             data: { _xml_http_request: true },
             success: function(html) {
                 jQuery('#field_container_{{ id }}').replaceWith(html); // replace the html
-                if(jQuery(form + 'input[type="file"]').length > 0) {
+                if(jQuery('input[type="file"]', form).length > 0) {
                     jQuery(form).attr('enctype', 'multipart/form-data');
                     jQuery(form).attr('encoding', 'multipart/form-data');
                 }


### PR DESCRIPTION
Hello!

I noticed that the form enctype is not correctly switched to `multipart/form-data` if a file input is added to a one-to-many collection in Sonata Admin. This is because a jQuery selector is not used correctly. The jQuery docs at http://api.jquery.com/jQuery/ state:

`jQuery( selector [, context] )`

The `context` in this case is the `form` variable which is instantiated on line 31:

`var form = jQuery(this).closest('form');`

So line 46 should be:

`if(jQuery('input[type="file"]', form).length > 0)`

I've tested this in the master branch and it works.
