### PR TITLE
If no operator is specified, don't filter

### DIFF
--- a/Filter/NumberFilter.php
+++ b/Filter/NumberFilter.php
@@ -30,7 +30,7 @@ class NumberFilter extends Filter
         $operator = $this->getOperator($type);
 
         if (!$operator) {
-            $operator = '=';
+            return;
         }
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME


### PR DESCRIPTION
Previously, "=" would be used as the operator instead. But if the user didn't specify an operator, it's safer to assume she doesn't want to filter at all.

This issue arose for me using with HTML `type="range"` input, which always submits a value (even if the user doesn't touch the input field--in which case the starting value is used). So, without doing anything, SonataAdmin would insist on only showing content objects who had that value = 0, forcing me to manually set the filter to ">=" on each page load.