### PR TITLE
[Fix] One-to-many inline edit view issue when used with INDEX BY 

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
                         <table class="table table-bordered">
                             <thead>
                                 <tr>
-                                    {% for field_name, nested_field in form.children|first.children %}
+                                    {% for field_name, nested_field in (form.children|first).children %}
                                         {% if field_name == '_delete' %}
                                             <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                                         {% else %}


### PR DESCRIPTION
If we inline one-to-many edit using table, then it takes headers for this table from form's child with key ```0```. However, if we use ```INDEX BY``` in our query, then children might not have key ```0``` and we end up with error ```Key "0" for array with keys "en" does not exist in SonataDoctrineORMAdminBundle:CRUD:edit_orm_one_to_many.html.twig at line 25```
To fix this instead of  ```0``` key we have to take first key from children keys and use it.