### PR TITLE
Fixed pretty errors in many association script

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -312,7 +312,9 @@ This code manage the many-to-[one|many] association field popup
         return false;
     }
 
-    Admin.add_pretty_errors(field_dialog_{{ id }});
+    // In some cases, the variable field_dialog_{{ id }} may not be initialized
+    if (field_dialog_{{ id }})
+        Admin.add_pretty_errors(field_dialog_{{ id }});
 
 
     {% if sonata_admin.edit == 'list' %}


### PR DESCRIPTION
In the `edit_orm_many_association_script.html.twig` script on line 316, the `Admin.add_pretty_errors` JavaScript function (located in `base.js`) is called with the `field_dialog_{{ id }}` parameter. It is there to convert form error messages into pretty qtip bubbles.

I found that in some cases, the `field_dialog_{{ id }}` variable is not yet initialized when the call is issued (e.g. when the "Add new" button in a many-to-one relationship is clicked and the target form also contains a many-to-one relationship). When the variable is not initialized, the following line of code in `base.js` (line 31) is called with `false` as the `subject` parameter:

```
jQuery('div.sonata-ba-field-error', subject).each(function(index, element) { ...
```

If that parameter is false, jQuery selects all elements in the entire document instead of only those which are siblings of the `subject` element. This causes the error bubbles to come up in modal jQuery dialogs which are used when adding an element to many-to-one relationships. Those bubbles are not readable because their z-index is way lower than the background div of the dialog underlay. It's kind of difficult to explain, but you can reproduce the problem when editing entities with many-to-one relationships to entities which also contain such a relationship.

I fixed this by adding a check whether the variable is already initialized before calling `Admin.add_pretty_errors`.
