### PR TITLE
fix deprecated calls

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -200,7 +200,7 @@ class ModelManager implements ModelManagerInterface
             $class = get_class($class);
         }
 
-        $em = $this->registry->getEntityManagerForClass($class);
+        $em = $this->registry->getManagerForClass($class);
 
         if (!$em) {
             throw new \RuntimeException(sprintf('No entity manager defined for class %s', $class));


### PR DESCRIPTION
`getEntityManagerForClass`is deprecated since Symfony 2.1. In my simple case it reduce the warnings from > 100 to 14 ;)
