### PR TITLE
Fix bug when use multiple ChoiceFilter with integer values in choices ar...

### DIFF
--- a/Filter/ChoiceFilter.php
+++ b/Filter/ChoiceFilter.php
@@ -31,7 +31,7 @@ class ChoiceFilter extends Filter
                 return;
             }
 
-            if (in_array('all', $data['value'])) {
+            if (in_array('all', $data['value'], true)) {
                 return;
             }
 


### PR DESCRIPTION
This PR fixes a ChoiceFilter bug: when use multiple filter with integer values in choices array and one of  value is 0(int), the filter didn't apply (listed all items in the datagrid).
