### PR TITLE
Replace deprecased jQuery 1.9 .live and .die methods

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -89,8 +89,8 @@ This code manage the many-to-[one|many] association field popup
 
                 // capture the submit event to make an ajax call, ie : POST data to the
                 // related create admin
-                jQuery('a', field_dialog_{{ id }}).live('click', field_dialog_form_list_link_{{ id }});
-                jQuery('form', field_dialog_{{ id }}).live('submit', function(event) {
+                jQuery('a', field_dialog_{{ id }}).on('click', field_dialog_form_list_link_{{ id }});
+                jQuery('form', field_dialog_{{ id }}).on('submit', function(event) {
                     event.preventDefault();
 
                     var form = jQuery(this);
@@ -115,8 +115,8 @@ This code manage the many-to-[one|many] association field popup
                     title: '{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}',
                     close: function(event, ui) {
                         // make sure we have a clean state
-                        jQuery('a', field_dialog_{{ id }}).die('click');
-                        jQuery('form', field_dialog_{{ id }}).die('submit');
+                        jQuery('a', field_dialog_{{ id }}).off('click');
+                        jQuery('form', field_dialog_{{ id }}).off('submit');
                     },
                     zIndex: 9998,
                 });
@@ -150,8 +150,8 @@ This code manage the many-to-[one|many] association field popup
 
                 // capture the submit event to make an ajax call, ie : POST data to the
                 // related create admin
-                jQuery('a', field_dialog_{{ id }}).live('click', field_dialog_form_action_{{ id }});
-                jQuery('form', field_dialog_{{ id }}).live('submit', field_dialog_form_action_{{ id }});
+                jQuery('a', field_dialog_{{ id }}).on('click', field_dialog_form_action_{{ id }});
+                jQuery('form', field_dialog_{{ id }}).on('submit', field_dialog_form_action_{{ id }});
 
                 // open the dialog in modal mode
                 field_dialog_{{ id }}.dialog({
@@ -164,8 +164,8 @@ This code manage the many-to-[one|many] association field popup
                     close: function(event, ui) {
                         Admin.log('[{{ id }}|field_dialog_form_add] dialog closed - removing `live` events');
                         // make sure we have a clean state
-                        jQuery('a', field_dialog_{{ id }}).die('click');
-                        jQuery('form', field_dialog_{{ id }}).die('submit');
+                        jQuery('a', field_dialog_{{ id }}).off('click');
+                        jQuery('form', field_dialog_{{ id }}).off('submit');
                     },
                     zIndex: 9998
                 });
@@ -367,7 +367,7 @@ This code manage the many-to-[one|many] association field popup
         #}
 
         // update the label
-        jQuery('#{{ id }}').live('change', function(event) {
+        jQuery('#{{ id }}').on('change', function(event) {
 
             Admin.log('[{{ id }}] update the label');
 


### PR DESCRIPTION
.live and .die methods are removed from jQuery 1.9.x .
Replaced:
.live -> .on
.die -> .off

SonataAdminBundle is valid with jQuery 1.9.x, SonataDoctrineORMAdminBundle not.
