### PR TITLE
fixed missing escaping

### DIFF
--- a/Resources/views/CRUD/list_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_one.html.twig
@@ -14,9 +14,9 @@ file that was distributed with this source code.
 {% block field %}
     {% if value %}
         {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT') %}
-            <a href="{{ field_description.associationadmin.generateObjectUrl('edit', value) }}">{{ value|render_relation_element(field_description) }}</a>
+            <a href="{{ field_description.associationadmin.generateObjectUrl('edit', value) }}">{{ value|render_relation_element(field_description)|e }}</a>
         {% else %}
-            {{ value|render_relation_element(field_description) }}
+            {{ value|render_relation_element(field_description)|e }}
         {% endif %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
This fixes missing escaping in template used by Twig filter marked as HTML safe.
