### PR TITLE
Update defining_entities.rst : expects a(n) integer, but got string

### DIFF
--- a/Resources/doc/tutorial/creating_your_first_admin_class/defining_entities.rst
+++ b/Resources/doc/tutorial/creating_your_first_admin_class/defining_entities.rst
@@ -36,10 +36,10 @@ Post
         protected $id;
 
         /**
-         * @ORM\Column(type="string", length="255")
+         * @ORM\Column(type="string", length=255)
          *
          * @Assert\NotBlank()
-         * @Assert\Length(min="10", max="255")
+         * @Assert\Length(min="10", max=255)
          */
         protected $title;
 


### PR DESCRIPTION
[Doctrine\Common\Annotations\AnnotationException]  
  [Type Error] Attribute "length" of @ORM\Column declared on property Tutorial\BlogBundle\Entity\Post::$title expects a(n) integer, but got string.
