### PR TITLE
Typo TagAdmin / CommentAdmin

### DIFF
--- a/Resources/doc/tutorial/creating_your_first_admin_class/defining_admin_class.rst
+++ b/Resources/doc/tutorial/creating_your_first_admin_class/defining_admin_class.rst
@@ -234,7 +234,7 @@ Tweak the CommentAdmin class
 .. code-block:: php
 
     <?php
-    // src/Tutorial/BlogBundle/Admin/TagAdmin.php
+    // src/Tutorial/BlogBundle/Admin/CommentAdmin.php
     namespace Tutorial\BlogBundle\Admin;
 
     use Sonata\AdminBundle\Admin\Admin;


### PR DESCRIPTION
There is a little typo TagAdmin => CommentAdmin (in the "Tweak the CommentAdmin class" section)
