### PR TITLE
[Pager] Reset orderBy in order to avoid 'Mixing of GROUP columns'

### DIFF
--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -35,6 +35,7 @@ class Pager extends BasePager
             $countQuery->setParameters($this->getParameters());
         }
 
+        $countQuery->resetDQLPart('orderBy');
         $countQuery->select(sprintf('count(DISTINCT %s.%s) as cnt', $countQuery->getRootAlias(), current($this->getCountColumn())));
 
         return $countQuery->getSingleScalarResult();


### PR DESCRIPTION
In some situation having an orderBy in the query raise the "Mixing of GROUP column" Doctrine exception in trying to get results count.

Eg:
```
[2013-04-22 11:11:56] request.CRITICAL: Doctrine\DBAL\DBALException: An exception occurred while executing 'SELECT count(DISTINCT r0_.id) AS sclr0 FROM race_entry r0_ LEFT JOIN race r1_
ON r0_.race_id = r1_.id LEFT JOIN user u2_ ON r0_.createdBy_id = u2_.id ORDER BY r0_.totalPoints DESC, r0_.totalSeconds ASC':
SQLSTATE[42000]: Syntax error or access violation: 1140 Mixing of GROUP columns (MIN(),MAX(),COUNT(),...) with no GROUP columns is illegal if there is no GROUP BY clause (uncaught except
ion) at /usr/local/webserver/php_sites.com/test/deploy/releases/20130422090406/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php line 47 [] []
```

Is it possible to merge also to branch 2.1?