### PR TITLE
Additional fix for many association association script (bug in SonataMedia Gallery)

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -89,8 +89,8 @@ This code manage the many-to-[one|many] association field popup
 
                 // capture the submit event to make an ajax call, ie : POST data to the
                 // related create admin
-                jQuery('a', field_dialog_{{ id }}).on('click', field_dialog_form_list_link_{{ id }});
-                jQuery('form', field_dialog_{{ id }}).on('submit', function(event) {
+                jQuery(field_dialog_{{ id }}).on('click', 'a',  field_dialog_form_list_link_{{ id }});
+                jQuery(field_dialog_{{ id }}).on('submit', 'form', function(event) {
                     event.preventDefault();
 
                     var form = jQuery(this);
@@ -118,7 +118,7 @@ This code manage the many-to-[one|many] association field popup
                         jQuery('a', field_dialog_{{ id }}).off('click');
                         jQuery('form', field_dialog_{{ id }}).off('submit');
                     },
-                    zIndex: 9998,
+                    zIndex: 9998
                 });
             }
         });


### PR DESCRIPTION
Similar to @zeliard91's fix in [pull request #209](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/209). This corrects an issue where clicking "tabs" at the top of the media modal window would result in a page load instead of updating the modal's html. 

![screen-shot-2013-04-30-at-12 13 14-pm](https://f.cloud.github.com/assets/199645/444999/506fa5b2-b1b1-11e2-9d13-d9356078a600.jpg)

This is related to sonata-project/SonataDoctrineORMAdminBundle#191 and sonata-project/SonataAdminBundle#1267.
