### PR TITLE
Added limit to the number of elements added with sonata_type_collection

### DIFF
--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -206,6 +206,7 @@ You can easily add a new ``galleryHasMedias`` row by defining one of these optio
 * ``edit``: ``inline|standard``, the inline mode allows you to add new rows,
 * ``inline``: ``table|standard``, the fields are displayed into table,
 * ``sortable``: if the model has a position field, you can enable a drag and drop sortable effect by setting ``sortable=field_name``.
+* ``limit``: ``<an integer>`` if defined, limits the number of elements that can be added, after which the "Add new" button will not be displayed
 
 .. code-block:: php
 
@@ -229,7 +230,8 @@ You can easily add a new ``galleryHasMedias`` row by defining one of these optio
                 ->add('galleryHasMedias', 'sonata_type_collection', array(), array(
                     'edit' => 'inline',
                     'inline' => 'table',
-                    'sortable'  => 'position'
+                    'sortable' => 'position',
+                    'limit' => 3
                 ))
             ;
         }

--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -120,7 +120,7 @@ file that was distributed with this source code.
 
         {% if sonata_admin.edit == 'inline' %}
 
-            {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+            {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add and ( sonata_admin.field_description.options.limit is not defined or form.children|length < sonata_admin.field_description.options.limit ) %}
                 <span id="field_actions_{{ id }}" >
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
@@ -208,7 +208,7 @@ file that was distributed with this source code.
 
         {% else %}
             <span id="field_actions_{{ id }}" >
-                {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+                {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add and ( sonata_admin.field_description.options.limit is not defined or form.children|length < sonata_admin.field_description.options.limit ) %}
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
                         onclick="return start_field_dialog_form_add_{{ id }}(this);"


### PR DESCRIPTION
A 'limit' option can be passed to 'sonata_type_collection' form fields to limit the number of fields that can be added. This works by removing the "add" button after that amount of elements have been added. No actual enforcing is done when persisting entities.

Docs have been updated