### PR TITLE
Added custom labels and possibility to remove button sonata_type form types

### DIFF
--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -121,7 +121,7 @@ display a ``User`` field.
 The AdminBundle provides 2 options:
 
  - ``sonata_type_model``: the ``User`` list is set in a select widget with an add button to create a new ``User``
- - ``sonata_type_model_list``: the ``User`` list is set in a model where you can search, select and delete a ``User``
+ - ``sonata_type_model_list``: the ``User`` list is set in a model where you can search, select and delete a ``User``.
 
 .. code-block:: php
 
@@ -141,7 +141,12 @@ The AdminBundle provides 2 options:
             $formMapper
                 ->with('General')
                     ->add('enabled', null, array('required' => false))
-                    ->add('author', 'sonata_type_model_list')
+                    ->add('author', 'sonata_type_model_list', array(
+                        'btn_add'       => 'Add author',      //Specify a custom label
+                        'btn_list'      => 'button.list',     //which will be translated
+                        'btn_delete'    => false,             //or hide the button.
+                        'btn_catalogue' => 'SonataNewsBundle' //Custom translation domain for buttons
+                    ))
                     ->add('title')
                     ->add('abstract')
                     ->add('content')

--- a/Resources/views/CRUD/edit_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_many.html.twig
@@ -16,15 +16,15 @@ file that was distributed with this source code.
         </span>
 
         <span id="field_actions_{{ id }}" class="field-actions">
-            {% if sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') %}
+            {% if sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                 <a
                     href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                     onclick="return start_field_dialog_form_add_{{ id }}(this);"
                     class="btn sonata-ba-action"
-                    title="{{ 'link_add'|trans({}, 'SonataAdminBundle') }}"
+                    title="{{ btn_add|trans({}, btn_catalogue) }}"
                     >
                     <i class="icon-plus"></i>
-                    {{ 'link_add'|trans({}, 'SonataAdminBundle') }}
+                    {{ btn_add|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
         </span>

--- a/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -39,38 +39,38 @@ file that was distributed with this source code.
 
         <span id="field_actions_{{ id }}" class="field-actions">
             <span class="btn-group">
-                {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
+                {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_list %}
                     <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
                         onclick="return start_field_dialog_form_list_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_list'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_list|trans({}, btn_catalogue) }}"
                         >
                         <i class="icon-list"></i>
-                        {{ 'link_list'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_list|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
 
-                {% if sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') %}
+                {% if sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                     <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_dialog_form_add_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_add'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_add|trans({}, btn_catalogue) }}"
                         >
                         <i class="icon-plus"></i>
-                        {{ 'link_add'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
             </span>
 
             <span class="btn-group">
-                {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
+                {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_delete %}
                     <a  href=""
                         onclick="return remove_selected_element_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_delete'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_delete|trans({}, btn_catalogue) }}"
                         >
                         <i class="icon-off"></i>
-                        {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_delete|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
             </span>

--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -82,16 +82,16 @@ file that was distributed with this source code.
 
         {% if sonata_admin.edit == 'inline' %}
 
-            {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') %}
+            {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                 <span id="field_actions_{{ id }}" >
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_retrieve_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_add'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_add|trans({}, btn_catalogue) }}"
                         >
                         <i class="icon-plus"></i>
-                        {{ 'link_add'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
                 </span>
             {% endif %}
@@ -136,15 +136,15 @@ file that was distributed with this source code.
 
         {% else %}
             <span id="field_actions_{{ id }}" >
-                {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') %}
+                {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_dialog_form_add_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_add'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_add|trans({}, btn_catalogue) }}"
                         >
                         <i class="icon-plus"></i>
-                        {{ 'link_add'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
             </span>

--- a/Resources/views/CRUD/edit_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_one.html.twig
@@ -39,38 +39,38 @@ file that was distributed with this source code.
 
         <span id="field_actions_{{ id }}" class="field-actions">
             <span class="btn-group">
-                {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasroute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
+                {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasroute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_list %}
 
                     <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
                         onclick="return start_field_dialog_form_list_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_list'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_list|trans({}, btn_catalogue) }}"
                         >
                         <i class="icon-list"></i>
-                        {{ 'link_list'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_list|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
 
-                {% if sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') %}
+                {% if sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                     <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_dialog_form_add_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_add'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_add|trans({}, btn_catalogue) }}"
                         >
                         <i class="icon-plus"></i>
-                        {{ 'link_add'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
             </span>
 
-            {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
+            {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_delete %}
                 <a  href=""
                     onclick="return remove_selected_element_{{ id }}(this);"
                     class="btn sonata-ba-action"
-                    title="{{ 'link_delete'|trans({}, 'SonataAdminBundle') }}"
+                    title="{{ btn_delete|trans({}, btn_catalogue) }}"
                     >
                     <i class="icon-off"></i>
-                    {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}
+                    {{ btn_delete|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
         </span>

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -68,38 +68,38 @@ file that was distributed with this source code.
             </span>
 
             <span class="btn-group">
-                {% if sonata_admin.field_description.associationadmin.hasroute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
+                {% if sonata_admin.field_description.associationadmin.hasroute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_list %}
                     <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
                         onclick="return start_field_dialog_form_list_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_list'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_list|trans({}, btn_catalogue) }}"
                             >
                         <i class="icon-list"></i>
-                        {{ 'link_list'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_list|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
 
-                {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') %}
+                {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                     <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_dialog_form_add_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_add'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_add|trans({}, btn_catalogue) }}"
                             >
                         <i class="icon-plus"></i>
-                        {{ 'link_add'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
             </span>
 
             <span class="btn-group">
-                {% if sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') %}
+                {% if sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') and btn_delete %}
                     <a  href=""
                         onclick="return remove_selected_element_{{ id }}(this);"
                         class="btn sonata-ba-action"
-                        title="{{ 'link_delete'|trans({}, 'SonataAdminBundle') }}"
+                        title="{{ btn_delete|trans({}, btn_catalogue) }}"
                             >
                         <i class="icon-off"></i>
-                        {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}
+                        {{ btn_delete|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
             </span>


### PR DESCRIPTION
On 'sonata_type' form fields, add the possibility of changing the "add new", "list" and "delete" buttons labels, when they are present. If set to false, the button is not displayed. Defaults were added so that no BC ocurrs. Docs updated. 

These changes are also affect SonataAdmin, so the corresponding PR will also need to be merged on it in too. After these changes have been reviewed, I'll copy them to SonataDoctrineMongoDBAdminBundle.
