### PR TITLE
add placeholder for empty short description fields

### DIFF
--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -73,6 +73,40 @@ Types available
 If no type is set, the Admin class will use the one set in the doctrine mapping
 definition.
 
+Short Object Placeholder
+------------------------
+
+When using Many-to-One or One-to-One relations with Sonata Type fields, a short
+object description is used to represent the target object. If no object is selected,
+a 'No selection' placeholder will be used. If you want to customize this placeholder,
+you can use the corresponding option in the form field definition:
+
+.. code-block:: php
+
+    <?php
+    namespace Sonata\NewsBundle\Admin;
+
+    use Sonata\AdminBundle\Admin\Admin;
+    use Sonata\AdminBundle\Form\FormMapper;
+
+    class PostAdmin extends Admin
+    {
+        protected function configureFormFields(FormMapper $formMapper)
+        {
+            $formMapper
+                ->with('General')
+                    ->add('enabled', null, array('required' => false))
+                    ->add('author', 'sonata_type_model_list', array(
+                    ), array(
+                        'placeholder' => 'No author selected'
+                    ))
+
+            ;
+        }
+    }
+
+This placeholder is translated using the SonataAdminBundle catalogue.
+
 Advanced Usage: File Management
 -------------------------------
 
@@ -146,6 +180,8 @@ The AdminBundle provides 2 options:
                         'btn_list'      => 'button.list',     //which will be translated
                         'btn_delete'    => false,             //or hide the button.
                         'btn_catalogue' => 'SonataNewsBundle' //Custom translation domain for buttons
+                    ), array(
+                        'placeholder' => 'No author selected'
                     ))
                     ->add('title')
                     ->add('abstract')
@@ -162,6 +198,8 @@ The AdminBundle provides 2 options:
             ;
         }
     }
+
+
 
 Advanced Usage: One-to-many
 ---------------------------

--- a/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -26,6 +26,10 @@ file that was distributed with this source code.
                             'uniqid':   sonata_admin.field_description.associationadmin.uniqid
                         }
                     )%}
+                {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                    <span class="inner-field-short-description">
+                        {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                    </span>
                 {% endif %}
             </span>
             <span style="display: none" >

--- a/Resources/views/CRUD/edit_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_one.html.twig
@@ -26,6 +26,10 @@ file that was distributed with this source code.
                             'uniqid':   sonata_admin.field_description.associationadmin.uniqid
                         }
                     )%}
+                {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                    <span class="inner-field-short-description">
+                        {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                    </span>
                 {% endif %}
             </span>
             <span style="display: none" >

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -64,6 +64,10 @@ file that was distributed with this source code.
                             'uniqid':   sonata_admin.field_description.associationadmin.uniqid
                         }
                     )%}
+                {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                    <span class="inner-field-short-description">
+                        {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                    </span>
                 {% endif %}
             </span>
 


### PR DESCRIPTION
Added a placeholder for fields where short_field_description would be used, but is null. Implemented by adding a default value in FieldDescripton's options, that can be optionally set to false to hide the placeholder, or given any value by the user. Updated docs, translation for english and unit test.

A minor BC occurs, as the placeholder has a default non null value. Requires merge of the matching SonataAdminBundle PR.
