### PR TITLE
Fix an issue where rendering of the n-1 crud element would sometimes fail

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
-                {% if sonata_admin.admin.id(sonata_admin.value) %}
+                {% if sonata_admin.value and sonata_admin.admin.id(sonata_admin.value) %}
                     {% render url('sonata_admin_short_object_information',{
                             'code':     sonata_admin.field_description.associationadmin.code,
                             'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),


### PR DESCRIPTION
This fixes a bug i stumbled upon in the sonata sandbox. If you create a new gallery block in the container container block and try to edit it, a twig exception gets thrown, i traced it down to the rendering of the relationship element which fails for gallery blocks which do not have at least GalleryID=false in their settings.