### PR TITLE
small doc fix to make MD create a double dash rather than one big one

### DIFF
--- a/Resources/doc/tutorial/creating_your_first_admin_class/installation.rst
+++ b/Resources/doc/tutorial/creating_your_first_admin_class/installation.rst
@@ -31,8 +31,9 @@ the following lines to the file ``deps``::
       git=http://github.com/sonata-project/SonataDoctrineORMAdminBundle.git
       target=/bundles/Sonata/DoctrineORMAdminBundle
 
+and run:
 
-and run::
+.. code-block:: bash
 
   bin/vendors install
 
@@ -84,7 +85,9 @@ code to your application's routing file:
 
 The last step is to generate the blog bundle in which we will work.
 
-  php app/console generate:bundle \-\-namespace=Tutorial/BlogBundle
+.. code-block:: bash
+
+  php app/console generate:bundle --namespace=Tutorial/BlogBundle
 
 And we enable it:
 


### PR DESCRIPTION
Fixes a hard-to-spot problem for copy-and-pasters.
