### PR TITLE
length param of ORM Column annotation wants an integer, not a string

### DIFF
--- a/Resources/doc/tutorial/creating_your_first_admin_class/defining_entities.rst
+++ b/Resources/doc/tutorial/creating_your_first_admin_class/defining_entities.rst
@@ -36,7 +36,7 @@ Post
         protected $id;
 
         /**
-         * @ORM\Column(type="string", length="255")
+         * @ORM\Column(type="string", length=255)
          *
          * @Assert\NotBlank()
          * @Assert\Length(min="10", max="255")


### PR DESCRIPTION
Fixes an error generating entities.
