### PR TITLE
Do not replace html if response is empty

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_association_script.html.twig
@@ -42,6 +42,10 @@ This code manage the one-to-many association field popup
             dataType: 'html',
             data: { _xml_http_request: true },
             success: function(html) {
+                if (!html.length) {
+                    return;
+                }
+
                 jQuery('#field_container_{{ id }}').replaceWith(html); // replace the html
                 if(jQuery('input[type="file"]', form).length > 0) {
                     jQuery(form).attr('enctype', 'multipart/form-data');


### PR DESCRIPTION
If the form has a file input, then the jQuery Form plugin won't handle correctly the response status and will enter in the success callback even if there is an error (see http://stackoverflow.com/questions/3995355/jquery-form-plugin-no-error-handling/7019723#7019723)

This fix checks the response length before replacing the html with a potential empty response.
