### PR TITLE
Add `dataType: 'html'` to ajax call

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -272,6 +272,7 @@ This code manage the many-to-[one|many] association field popup
                                 'code':      sonata_admin.admin.root.code
                             }) }}',
                             data: {_xml_http_request: true },
+                            dataType: 'html',
                             type: 'POST',
                             success: function(html) {
                                 jQuery('#field_container_{{ id }}').replaceWith(html);


### PR DESCRIPTION
Fix firefox AJAX bug similar to https://github.com/sonata-project/SonataAdminBundle/pull/1477
