### PR TITLE
Slow list action with complicated filters.

### DIFF
--- a/Filter/Filter.php
+++ b/Filter/Filter.php
@@ -24,10 +24,11 @@ abstract class Filter extends BaseFilter
     public function apply($queryBuilder, $value)
     {
         $this->value = $value;
+        if($value && $value["value"]) {
+            list($alias, $field) = $this->association($queryBuilder, $value);
 
-        list($alias, $field) = $this->association($queryBuilder, $value);
-
-        $this->filter($queryBuilder, $alias, $field, $value);
+            $this->filter($queryBuilder, $alias, $field, $value);
+        }
     }
 
     /**


### PR DESCRIPTION
We have admin class for large entities database (with around 500,000 records), and a lot of the different filters in it.
listAction loads very slowly (around 16 seconds). When I remove all filters it loads in 0.4 seconds.

One of the problems I founded - each filter add Join table (even if filter is inactive and joined entities is not used).
So final pager query looks like

```
SELECT 
  count(DISTINCT s0_.id) AS sclr0 
FROM 
  entity s0_ 
  LEFT JOIN filterEntity1 s1_ ON s0_.shop_id = s1_.id 
....
  LEFT JOIN filterEntityN s1_ ON s0_.shop_id = s1_.id 
```

That query take 1-2 seconds to execute.

I am not sure, if its clean solution, but this PR decrease pager query time to 0.1 sec
