### PR TITLE
Allow for ACL style permission checks in list view

### DIFF
--- a/Resources/views/CRUD/list_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_many.html.twig
@@ -12,9 +12,14 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('edit')%}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') %}
+        {% set global_permission = field_description.associationadmin.isGranted('edit') %}
         {% for element in value%}
-            <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a>{% if not loop.last %}, {% endif %}
+            {% if global_permission or field_description.associationadmin.isGranted('EDIT', element) %}
+                <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a>{% if not loop.last %}, {% endif %}
+            {% else %}
+                {{ element|render_relation_element(field_description) }}{% if not loop.last %}, {% endif %}
+            {% endif %}
         {% endfor %}
     {% else %}
         {% for element in value%}

--- a/Resources/views/CRUD/list_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_one.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     {% if value %}
-        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT') %}
+        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT', value) %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
         {% else %}
             {{ value|render_relation_element(field_description) }}


### PR DESCRIPTION
This change allows an edit link in more situations for many_to_many and many_to_one associations in the list view.

This should not be a BC break, as its only about showing a link. If after this you get a link for something that should not be editable, you already have a serious vulnerability if somebody guesses the id and directly goes to edit.

If you hacked permissions into your CRUD controller then this will be a problem. You should use security voters that look at the model class to decide individual access.

If we agree this is the right thing to do, i guess i should also update the other orm list fields.