### PR TITLE
Add a dropdown menu in form (sonata_type_model)

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_many.html.twig
@@ -15,17 +15,36 @@ file that was distributed with this source code.
             {{ form_widget(form) }}
         </span>
 
-        <span id="field_actions_{{ id }}" class="field-actions">
+        <span id="field_actions_{{ id }}" class="field-actions btn-group">
             {% if sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
-                <a
-                    href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
-                    onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                    class="btn sonata-ba-action"
-                    title="{{ btn_add|trans({}, btn_catalogue) }}"
-                    >
-                    <i class="icon-plus"></i>
-                    {{ btn_add|trans({}, btn_catalogue) }}
-                </a>
+                {% if sonata_admin.field_description.associationadmin.subclasses is empty %}
+                    <a
+                        href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                        class="btn sonata-ba-action"
+                        title="{{ btn_add|trans({}, btn_catalogue) }}"
+                        >
+                        <i class="icon-plus"></i>
+                        {{ btn_add|trans({}, btn_catalogue) }}
+                    </a>
+                {% else %}
+                    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+                        <i class="icon-plus"></i>
+                        {{ btn_add|trans({}, btn_catalogue) }}
+                        <span class="caret"></span>
+                    </a>
+                    <ul class="dropdown-menu">
+                        {% for subclass in sonata_admin.field_description.associationadmin.subclasses|keys %}
+                            <li>
+                                <a 
+                                    onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                                    accesskey=""
+                                    title="{{ subclass|trans({}, sonata_admin.field_description.associationadmin.translationdomain) }}"
+                                    href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, sonata_admin.field_description.associationadmin.translationdomain) }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
             {% endif %}
         </span>
 

--- a/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -54,14 +54,33 @@ file that was distributed with this source code.
                 {% endif %}
 
                 {% if sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
-                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
-                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                        class="btn sonata-ba-action"
-                        title="{{ btn_add|trans({}, btn_catalogue) }}"
-                        >
-                        <i class="icon-plus"></i>
-                        {{ btn_add|trans({}, btn_catalogue) }}
-                    </a>
+                    {% if sonata_admin.field_description.associationadmin.subclasses is empty %}
+                        <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                            onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                            class="btn sonata-ba-action"
+                            title="{{ btn_add|trans({}, btn_catalogue) }}"
+                            >
+                            <i class="icon-plus"></i>
+                            {{ btn_add|trans({}, btn_catalogue) }}
+                        </a>
+                    {% else %}
+                        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+                            <i class="icon-plus"></i>
+                            {{ btn_add|trans({}, btn_catalogue) }}
+                            <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            {% for subclass in sonata_admin.field_description.associationadmin.subclasses|keys %}
+                                <li>
+                                    <a 
+                                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                                        accesskey=""
+                                        title="{{ subclass|trans({}, sonata_admin.field_description.associationadmin.translationdomain) }}"
+                                        href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, sonata_admin.field_description.associationadmin.translationdomain) }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
                 {% endif %}
             </span>
 

--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -135,17 +135,35 @@ file that was distributed with this source code.
             {% include 'SonataDoctrineORMAdminBundle:CRUD:edit_orm_one_association_script.html.twig' %}
 
         {% else %}
-            <span id="field_actions_{{ id }}" >
+            <span id="field_actions_{{ id }}" class="field-actions btn-group">
                 {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
-                    <a
-                        href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
-                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                        class="btn sonata-ba-action"
-                        title="{{ btn_add|trans({}, btn_catalogue) }}"
-                        >
-                        <i class="icon-plus"></i>
-                        {{ btn_add|trans({}, btn_catalogue) }}
-                    </a>
+                    {% if sonata_admin.field_description.associationadmin.subclasses is empty %}
+                        <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                            onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                            class="btn sonata-ba-action"
+                            title="{{ btn_add|trans({}, btn_catalogue) }}"
+                            >
+                            <i class="icon-plus"></i>
+                            {{ btn_add|trans({}, btn_catalogue) }}
+                        </a>
+                    {% else %}
+                        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+                            <i class="icon-plus"></i>
+                            {{ btn_add|trans({}, btn_catalogue) }}
+                            <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            {% for subclass in sonata_admin.field_description.associationadmin.subclasses|keys %}
+                                <li>
+                                    <a 
+                                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                                        accesskey=""
+                                        title="{{ subclass|trans({}, sonata_admin.field_description.associationadmin.translationdomain) }}"
+                                        href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, sonata_admin.field_description.associationadmin.translationdomain) }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
                 {% endif %}
             </span>
 

--- a/Resources/views/CRUD/edit_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_one.html.twig
@@ -55,14 +55,33 @@ file that was distributed with this source code.
                 {% endif %}
 
                 {% if sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
-                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
-                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                        class="btn sonata-ba-action"
-                        title="{{ btn_add|trans({}, btn_catalogue) }}"
-                        >
-                        <i class="icon-plus"></i>
-                        {{ btn_add|trans({}, btn_catalogue) }}
-                    </a>
+                    {% if sonata_admin.field_description.associationadmin.subclasses is empty %}
+                        <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                            onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                            class="btn sonata-ba-action"
+                            title="{{ btn_add|trans({}, btn_catalogue) }}"
+                            >
+                            <i class="icon-plus"></i>
+                            {{ btn_add|trans({}, btn_catalogue) }}
+                        </a>
+                    {% else %}
+                        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+                            <i class="icon-plus"></i>
+                            {{ btn_add|trans({}, btn_catalogue) }}
+                            <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu">
+                            {% for subclass in sonata_admin.field_description.associationadmin.subclasses|keys %}
+                                <li>
+                                    <a 
+                                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                                        accesskey=""
+                                        title="{{ subclass|trans({}, sonata_admin.field_description.associationadmin.translationdomain) }}"
+                                        href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, sonata_admin.field_description.associationadmin.translationdomain) }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                   {% endif %}
                 {% endif %}
             </span>
 


### PR DESCRIPTION
Dropdown menu is displayed if the associated entity has subclasses.

Maybe we can add a new one (or modify ```Resources/views/Button/create_button_html.twig```) to support this feature and reduce ```edit_orm_*.html.twig``` code.