### PR TITLE
Removed use of preg_replace with /e modifier

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Exception\ModelManagerException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\DBAL\DBALException;
 
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Exception\PropertyAccessDeniedException;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
@@ -519,7 +520,7 @@ class ModelManager implements ModelManagerInterface
      */
     protected function camelize($property)
     {
-        return preg_replace(array('/(^|_)+(.)/e', '/\.(.)/e'), array("strtoupper('\\2')", "'_'.strtoupper('\\1')"), $property);
+        return Container::camelize($property);
     }
 
     /**


### PR DESCRIPTION
Updated ModelManager::camelize() to use Container::camelize(), mirroring the method used in the main SonataAdminBundle. This removes the deprecated (security risk) usage of preg_replace with the /e modifier which can evaluate risky code.