### PR TITLE
Add `dataType: 'html'` to all ajax calls

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -45,6 +45,7 @@ This code manage the many-to-[one|many] association field popup
             jQuery.ajax({
                 type: 'GET',
                 url: jQuery(this).attr('href'),
+                dataType: 'html',
                 success: function(html) {
                     Admin.log('[{{ id }}|field_dialog_form_list_link] callback success, attach valid js event');
 
@@ -405,6 +406,7 @@ This code manage the many-to-[one|many] association field popup
                     'uniqid': associationadmin.uniqid,
                     'code': associationadmin.code
                 })}}'.replace('OBJECT_ID', jQuery(this).val()),
+                dataType: 'html',
                 success: function(html) {
                     jQuery('#field_widget_{{ id }}').html(html);
                 }


### PR DESCRIPTION
Fixing pull request https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/246. Adding `dataType` to all AJAX calls that are of HTML type.
