### PR TITLE
Installation instructions

### DIFF
--- a/Resources/doc/reference/audit.rst
+++ b/Resources/doc/reference/audit.rst
@@ -1,7 +1,7 @@
 Audit
 =====
 
-The bundle provides a support for the ``EntityAuditBundle`` from https://github.com/simplethings/EntityAudit.
+The bundle provides optional support for the ``EntityAuditBundle`` from https://github.com/simplethings/EntityAudit.
 
 How it works
 ------------
@@ -24,6 +24,30 @@ points in time.
 This extension hooks into the SchemaTool generation process so that it will automatically create the necessary
 DDL statements for your audited entities.
 
+Installation
+------------
+
+The audit functionality is provided by an optional, separate bundle that you need to install:
+
+.. code-block:: bash
+
+    php composer.phar require simplethings/entity-audit-bundle
+    
+    
+Next, be sure to enable the bundle in your AppKernel.php file:
+
+.. code-block:: php
+
+    <?php
+    // app/AppKernel.php
+    public function registerBundles()
+    {
+        return array(
+            // ...
+            new SimpleThings\EntityAudit\SimpleThingsEntityAuditBundle(),
+            // ...
+        );
+    }
 
 Configuration
 -------------

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -1,25 +1,31 @@
 Installation
 ============
 
-First install the Sonata Admin Bundle which provides Core functionalities. The ``EntityAudit`` is an optional
-history feature (https://github.com/simplethings/EntityAudit).
+First install the SonataAdminBundle which provides Core functionalities.
+Follow `these <http://sonata-project.org/bundles/admin/master/doc/reference/installation.html>`_ instructions to do so.
 
-Download bundles
-----------------
+Download the bundle
+-------------------
 
-Use composer ::
+Use composer:
+
+.. code-block:: bash
 
     php composer.phar require sonata-project/doctrine-orm-admin-bundle
 
-    # optional bundle
-    php composer.phar require simplethings/entity-audit-bundle
+You'll be asked to type in a version constraint. 'dev-master' will usually get you the latest
+version. Check `packagist <https://packagist.org/packages/sonata-project/doctrine-orm-admin-bundle>`_
+for older versions:
+
+.. code-block:: bash
+
+    Please provide a version constraint for the sonata-project/doctrine-orm-admin-bundle requirement: dev-master
 
 
-Configuration
--------------
+Enable the bundle
+-----------------
 
-Next, be sure to enable the bundles in your autoload.php and AppKernel.php
-files:
+Next, be sure to enable the bundle in your AppKernel.php file:
 
 .. code-block:: php
 
@@ -30,7 +36,6 @@ files:
         return array(
             // ...
             new Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle(),
-            new SimpleThings\EntityAudit\SimpleThingsEntityAuditBundle(),
             // ...
         );
     }


### PR DESCRIPTION
https://github.com/sonata-project/SonataAdminBundle/issues/1520

Kept the same information, just moved the optional EntityAuditBundle install instruction to the 'audit' file, to avoid confusion for new users visiting this instructions page from SonataAdminBundle's installation instructions page.

Added more detailed information for the install process
