### PR TITLE
Inner join related entities

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -252,7 +252,7 @@ class ProxyQuery implements ProxyQueryInterface
             $newAlias .= '_' . $associationMapping['fieldName'];
             if (!in_array($newAlias, $this->entityJoinAliases)) {
                 $this->entityJoinAliases[] = $newAlias;
-                $this->queryBuilder->leftJoin(sprintf('%s.%s', $alias, $associationMapping['fieldName']), $newAlias);
+                $this->queryBuilder->innerJoin(sprintf('%s.%s', $alias, $associationMapping['fieldName']), $newAlias);
             }
 
             $alias = $newAlias;


### PR DESCRIPTION
When doctrine filters like `SoftDeleteable` adds filter constraint to a query that joins a soft-deleted entity, `LEFT JOIN` will negate the effect of added constraints. The page will result in an error because code down the line cannot fetch the entity that is soft-deleted.

Switch to `INNER JOIN` fixes this problem.