### PR TITLE
Check EDIT permission for admin object instead of admin only

### DIFF
--- a/Resources/views/CRUD/list_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_many.html.twig
@@ -12,13 +12,26 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('edit')%}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') %}
         {% for element in value%}
-            <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a>{% if not loop.last %}, {% endif %}
+            {%- if field_description.associationadmin.isGranted('edit', value) -%}
+                {{ block('relation_link') }}
+            {%- else -%}
+                {{ block('relation_value') }}
+            {%- endif -%}
+            {% if not loop.last %}, {% endif %}
         {% endfor %}
     {% else %}
         {% for element in value%}
-            {{ element|render_relation_element(field_description) }}{% if not loop.last %}, {% endif %}
+            {{ block('relation_value') }}{% if not loop.last %}, {% endif %}
         {% endfor %}
     {% endif %}
 {% endblock %}
+
+{%- block relation_link -%}
+    <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a>
+{%- endblock -%}
+
+{%- block relation_value -%}
+    {{ element|render_relation_element(field_description) }}
+{%- endblock -%}

--- a/Resources/views/CRUD/list_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_one.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     {% if value %}
-        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT') %}
+        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT', value) %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
         {% else %}
             {{ value|render_relation_element(field_description) }}

--- a/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -12,13 +12,26 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% if field_description.hasassociationadmin and field_description.associationadmin.isGranted('EDIT') and field_description.associationadmin.hasRoute('edit') %}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('EDIT') %}
         {% for element in value%}
-            <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a>{% if not loop.last %}, {% endif %}
+            {%- if field_description.associationadmin.isGranted('edit', value) -%}
+                {{ block('relation_link') }}
+            {%- else -%}
+                {{ block('relation_value') }}
+            {%- endif -%}
+            {% if not loop.last %}, {% endif %}
         {% endfor %}
     {% else %}
         {% for element in value%}
-            {{ element|render_relation_element(field_description) }}{% if not loop.last %}, {% endif %}
+            {{ block('relation_value') }}{% if not loop.last %}, {% endif %}
         {% endfor %}
     {% endif %}
 {% endblock %}
+
+{%- block relation_link -%}
+    <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a>
+{%- endblock -%}
+
+{%- block relation_value -%}
+    {{ element|render_relation_element(field_description) }}
+{%- endblock -%}

--- a/Resources/views/CRUD/list_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_one.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.isGranted('EDIT') and field_description.associationadmin.hasRoute('edit') %}
+    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.isGranted('EDIT', value) and field_description.associationadmin.hasRoute('edit') %}
         <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
     {% else %}
         {{ value|render_relation_element(field_description) }}


### PR DESCRIPTION
This is useful when ACL is used or when the user implements custom permission voters for specific objects. It's similar to #251 and in addition takes all orm relation list fields into account.
