### PR TITLE
Update jQuery sortable options

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -103,6 +103,7 @@ file that was distributed with this source code.
                         axis: 'y',
                         opacity: 0.6,
                         items: 'tr',
+                        cancel: ':input, [contenteditable]',
                         stop: apply_position_value_{{ id }}
                     });
 


### PR DESCRIPTION
Prevents sorting if you start dragging on inputs (input, select, textarea...) or editable elements ([contenteditable attribute](http://www.w3schools.com/tags/att_global_contenteditable.asp))

This fixes a bug in my case where I cannot select text in a wysiwyg editor.

See http://api.jqueryui.com/sortable/#option-cancel
