### PR TITLE
Fix access to form first child in inline edit

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
                         <table class="table table-bordered">
                             <thead>
                                 <tr>
-                                    {% for field_name, nested_field in form.children[0].children %}
+                                    {% for field_name, nested_field in form.children|first.children %}
                                         {% if field_name == '_delete' %}
                                             <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                                         {% else %}


### PR DESCRIPTION
Use case : I use KnpDoctrineBehaviors and I'm trying to edit translations via a sonata_type_collection form type (inline). The problem is that the translation collection is indexed by locale, not by integers (which may also happen in others cases).
