### PR TITLE
Use form groups tabs for inline editing in non-table mode

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -58,19 +58,47 @@ file that was distributed with this source code.
                         </table>
                     {% endif %}
                 {% elseif form.children|length > 0 %}
+                    {% set associationAdmin = sonata_admin.field_description.associationadmin %}
+
                     <div>
-                        {% for nested_group_field_name, nested_group_field in form.children %}
-                            {% for field_name, nested_field in nested_group_field.children %}
-                                {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined %}
-                                    {{ form_row(nested_field, {
-                                        'inline': 'natural',
-                                        'edit'  : 'inline'
-                                    }) }}
-                                    {% set dummy = nested_group_field.setrendered %}
-                                {% else %}
-                                    {{ form_row(nested_field) }}
-                                {% endif %}
-                            {% endfor %}
+                        {% for nested_group_field in form.children %}
+                            <ul class="nav nav-tabs">
+                                {% for name, form_group in associationAdmin.formgroups %}
+                                    <li class="{% if loop.first %}active{% endif %}">
+                                        <a href="#{{ associationAdmin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}" data-toggle="tab">
+                                            <i class="icon-exclamation-sign has-errors hide"></i>
+                                            {{ associationAdmin.trans(name, {}, form_group.translation_domain) }}
+                                        </a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+
+                            <div class="tab-content">
+                                {% for name, form_group in associationAdmin.formgroups %}
+                                    <div class="tab-pane {% if loop.first %}active{% endif %}" id="{{ associationAdmin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}">
+                                        <fieldset>
+                                            <div class="sonata-ba-collapsed-fields">
+                                                {% for field_name in form_group.fields %}
+                                                    {% set nested_field = nested_group_field.children[field_name] %}
+                                                    {% if associationAdmin.formfielddescriptions[field_name] is defined %}
+                                                        {{ form_row(nested_field, {
+                                                            'inline': 'natural',
+                                                            'edit'  : 'inline'
+                                                        }) }}
+                                                        {% set dummy = nested_group_field.setrendered %}
+                                                    {% else %}
+                                                        {{ form_row(nested_field) }}
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </div>
+                                        </fieldset>
+                                    </div>
+                                {% endfor %}
+                            </div>
+
+                            {% if nested_group_field['_delete'] is defined %}
+                                {{ form_row(nested_group_field['_delete']) }}
+                            {% endif %}
                         {% endfor %}
                     </div>
                 {% endif %}


### PR DESCRIPTION
Here is an example :

![collection-tabs](https://f.cloud.github.com/assets/663607/1535533/70806960-4ca5-11e3-8547-2891f41b8afe.PNG)
