### PR TITLE
Update hidden input by adding newly added option to selectbox of orm-man...

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -251,6 +251,9 @@ This code manage the many-to-[one|many] association field popup
                            in this case we update the hidden input, and call the change event to
                            retrieve the post information
                         #}
+                        if (jQuery('#{{ id }}').is('select')) {
+                            jQuery('#{{ id }}').append('<option value="'+data.objectId+'">dummy</option>');
+                        }
                         jQuery('#{{ id }}').val(data.objectId);
                         jQuery('#{{ id }}').change();
 


### PR DESCRIPTION
When adding a new media item inline while editing a block, the select box is not updated after adding the new media. Current behaviour, the very first item gets selected. Commit adds the new id to the list.

