### PR TITLE
Don't show sonata_type_model_hidden fields when rendering edit_orm_one_to_many.html.twig

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -26,7 +26,7 @@ file that was distributed with this source code.
                                         {% if field_name == '_delete' %}
                                             <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                                         {% else %}
-                                            <th {{ nested_field.vars['required']  ? 'class="required"' : '' }}{% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %} style="display:none;"{% endif %}>
+                                            <th {{ nested_field.vars['required']  ? 'class="required"' : '' }}{% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) or (sonata_admin.field_description.associationadmin.formfielddescriptions[field_name].getType() == 'sonata_type_model_hidden') %} style="display:none;"{% endif %}>
                                                 {{ nested_field.vars['sonata_admin'].admin.trans(nested_field.vars.label) }}
                                             </th>
                                         {% endif %}
@@ -37,20 +37,22 @@ file that was distributed with this source code.
                                 {% for nested_group_field_name, nested_group_field in form.children %}
                                     <tr>
                                         {% for field_name, nested_field in nested_group_field.children %}
-                                            <td class="sonata-ba-td-{{ id }}-{{ field_name  }} control-group{% if nested_field.vars.errors|length > 0 %} error{% endif %}"{% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %} style="display:none;"{% endif %}>
-                                                {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined %}
-                                                    {{ form_widget(nested_field) }}
+                                            {% if not (sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined and sonata_admin.field_description.associationadmin.formfielddescriptions[field_name].getType() == 'sonata_type_model_hidden') %}
+                                                <td class="sonata-ba-td-{{ id }}-{{ field_name  }} control-group{% if nested_field.vars.errors|length > 0 %} error{% endif %}"{% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %} style="display:none;"{% endif %}>
+                                                    {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined %}
+                                                        {{ form_widget(nested_field) }}
 
-                                                    {% set dummy = nested_group_field.setrendered %}
-                                                {% else %}
-                                                    {{ form_widget(nested_field) }}
-                                                {% endif %}
-                                                {% if nested_field.vars.errors|length > 0 %}
-                                                    <div class="help-inline sonata-ba-field-error-messages">
-                                                        {{ form_errors(nested_field) }}
-                                                    </div>
-                                                {% endif %}
-                                            </td>
+                                                        {% set dummy = nested_group_field.setrendered %}
+                                                    {% else %}
+                                                        {{ form_widget(nested_field) }}
+                                                    {% endif %}
+                                                    {% if nested_field.vars.errors|length > 0 %}
+                                                        <div class="help-inline sonata-ba-field-error-messages">
+                                                            {{ form_errors(nested_field) }}
+                                                        </div>
+                                                    {% endif %}
+                                                </td>
+                                            {% endif %}
                                         {% endfor %}
                                     </tr>
                                 {% endfor %}


### PR DESCRIPTION
Changed edit_orm_one_to_many.html.twig to not show the sonata_type_model_hidden fields when rendering
