### PR TITLE
Fix typo in Exception message

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -104,7 +104,7 @@ class FormContractor implements FormContractorInterface
             }
 
             if (!in_array($fieldDescription->getMappingType(), array(ClassMetadataInfo::ONE_TO_ONE, ClassMetadataInfo::MANY_TO_ONE ))) {
-                throw new \RuntimeException(sprintf('You are trying to add `sonata_type_admin` field `%s` which is not One-To-One or  Many-To-One. Maybe you want `sonata_model_list` instead?', $fieldDescription->getName()));
+                throw new \RuntimeException(sprintf('You are trying to add `sonata_type_admin` field `%s` which is not One-To-One or  Many-To-One. Maybe you want `sonata_type_collection` instead?', $fieldDescription->getName()));
             }
 
             $options['data_class'] = $fieldDescription->getAssociationAdmin()->getClass();


### PR DESCRIPTION
Since sonata_model_list doesn't exist it looks like sonata_type_collection or sonata_type_model_list was meant.