### PR TITLE
Fix error in many to one template

### DIFF
--- a/Resources/views/CRUD/show_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_one.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
 {% block field %}
-    {% if value %}
+    {% if value and value.id is defined and value.id %}
         {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT') %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
         {% else %}


### PR DESCRIPTION
Sometimes we got something like this Proxies\__CG__\Acme\AdminBundle\Entity\Sample with id == null as value, if we try to generate url for this object, we got excpetion with message: 
``` 
"Parameter "id" for route "admin_acme_admin_sample_edit" must match "[^/]++" ("" given)
 to generate a corresponding URL." 
``` 
 I fixed this bug.

PS:
I got this error then create list like:
``` php
   // StreetAdmin.php
    protected function configureListFields(ListMapper $list)
    {
        $list->add('city.country');
        $list->add('city');
        $list->addIdentifier('name');

        parent::configureListFields($list);
    }
```

``` php
    // Entity\Street.php
    /**
     * @var City
     *
     * @ORM\ManyToOne(targetEntity="City", inversedBy="streets", cascade={"persist"})
     * @ORM\JoinColumn(name="city_id", referencedColumnName="id", onDelete="CASCADE")
     */
    protected $city;
```
``` php
    // Entity\City.php
    /**
     * @var Street[]|ArrayCollection
     *
     * @ORM\OneToMany(targetEntity="Street", mappedBy="city")
     */
    protected $streets;
```

PS:
Travis failed with Symfony 2.2, it's not my bug, honestly =) 