### PR TITLE
fix sonata_admin_model and the select2 refresh issue

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -246,7 +246,7 @@ This code manage the many-to-[one|many] association field popup
                             dataType: 'html',
                             type: 'POST',
                             success: function(html) {
-                                jQuery('#field_container_content_{{ id }}').replaceWith(html);
+                                jQuery('#field_container_{{ id }}').replaceWith(html);
                                 var newElement = jQuery('#{{ id }} [value="' + data.objectId + '"]');
                                 if (newElement.is("input")) {
                                     newElement.attr('checked', 'checked');


### PR DESCRIPTION
This should fix the wrong jquery cibling and correct the select2 options refresh with the added entity.
"field_container_" is the correct prefix to perform the 
jQuery('#field_container_{{ id }}').replaceWith(html);
