### PR TITLE
composer.json update to require doctrine/orm ~2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "doctrine/orm": "~2.4",
+        "doctrine/orm": "~2.3",
         "symfony/form": "~2.3",
         "symfony/security": "~2.3",
         "symfony/console": "~2.3",


### PR DESCRIPTION
As stated by me in the issue #335 I think that it's wrong to require **doctrine/orm ~2.4** because **doctrine/doctrine-bundle** (which is included in Symfony2 Standard Edition) requires **doctrine/dbal ~2.3** which requires **doctrine/orm ~2.3**.

So trying to install sonata-project/doctrine-orm-admin-bundle on a Symfony project will not work and the error message will be _doctrine/orm ~2.4 -> no matching package found_.

This PR fixes this.
