### PR TITLE
Fixes: dragging sortable table rows into nested tables.

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -134,7 +134,7 @@ file that was distributed with this source code.
                     jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody').sortable({
                         axis: 'y',
                         opacity: 0.6,
-                        items: 'tr',
+                        items: '> tr',
                         stop: apply_position_value_{{ id }}
                     });
 


### PR DESCRIPTION
If you have nested tables inside the one-to-many table cells, items:
'tr' adds sortable behavior to nested table rows as well.  This, in
particular, means that you can drag top-level table rows into the nested
table. '> tr' restricts sortable behavior to rows which are direct
children of the sortable table body.

See, for example: http://api.jqueryui.com/sortable/#option-items
