### PR TITLE
Change Pager.php for support pgsql

### DIFF
--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -37,7 +37,7 @@ class Pager extends BasePager
 
         $countQuery->select(sprintf('count(DISTINCT %s.%s) as cnt', $countQuery->getRootAlias(), current($this->getCountColumn())));
 
-        return $countQuery->getSingleScalarResult();
+        return $countQuery->resetDQLPart('orderBy')->getSingleScalarResult();
     }
 
     /**


### PR DESCRIPTION
In pgsql, the pager launchs this Exception ...

An exception has been thrown during the rendering of a template ("An exception occurred while executing 'SELECT count(DISTINCT n0_.id) AS sclr0 FROM news__post n0_ LEFT JOIN news__post_tag n2_ ON n0_.id = n2_.post_id LEFT JOIN classification__tag c1_ ON c1_.id = n2_.tag_id AND (c1_.enabled = true) LEFT JOIN fos_user_user f3_ ON n0_.author_id = f3_.id AND (f3_.enabled = true) WHERE n0_.enabled = ? ORDER BY n0_.publication_date_start DESC' with params ["true"]:

Resetting dql OrderBy fix the bug
