### PR TITLE
Fix another order by bug (pgsql)

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -54,6 +54,8 @@ class ProxyQuery implements ProxyQueryInterface
                 $sortBy = $queryBuilder->getRootAlias() . '.' . $sortBy;
             }
             $queryBuilder->addOrderBy($sortBy, $this->getSortOrder());
+        } else {
+            $queryBuilder->resetDQLPart( 'orderBy' );
         }
 
         return $this->getFixedQueryBuilder($queryBuilder)->getQuery()->execute($params, $hydrationMode);


### PR DESCRIPTION
Without this reset, a sonata sandbox launchs this exception ....

An exception has been thrown during the rendering of a template ("An exception occurred while executing 'SELECT DISTINCT n0_.id AS id0 FROM news__post n0_ LEFT JOIN news__post_tag n2_ ON n0_.id = n2_.post_id LEFT JOIN classification__tag c1_ ON c1_.id = n2_.tag_id LEFT JOIN fos_user_user f3_ ON n0_.author_id = f3_.id ORDER BY n0_.publication_date_start DESC':

SQLSTATE[42P10]: Invalid column reference: 7 ERROR: para SELECT DISTINCT, las expresiones en ORDER BY deben aparecer en la lista de resultados
LINE 1: ..._user_user f3_ ON n0_.author_id = f3_.id ORDER BY n0_.public...
^") in SonataNewsBundle:Block:recent_posts.html.twig at line 22.

![captura de pantalla de 2014-06-05 23 30 32](https://cloud.githubusercontent.com/assets/155036/3196108/a55e55b6-ed22-11e3-9f17-b1fdd0430a83.png)
