### PR TITLE
[export] Fix exception SELECT DISTINCT': Error: '' is not defined.

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -419,7 +419,9 @@ class ModelManager implements ModelManagerInterface
         $query->setMaxResults($maxResult);
 
         if ($query instanceof ProxyQueryInterface) {
-            $query->addOrderBy($query->getSortBy(), $query->getSortOrder());
+            if ($query->getSortBy()) {
+                $query->addOrderBy($query->getSortBy(), $query->getSortOrder());
+            }
 
             $query = $query->getQuery();
         }


### PR DESCRIPTION
I am not sure this is the right fix so lets discuss it here. After I updated vendors (symfony\doctrine\sonata-admin 2.2.7 => https://github.com/formapro-forks/SonataDoctrineORMAdminBundle/commit/18ea96f455a4ea3dd2b3ae1cdeca36e7279ea83f) export functionally stopped to work. I've got next exception:

```
Doctrine\ORM\Query\QueryException: [Semantical Error] line 0, col -1 near 'SELECT DISTINCT': Error: '' is not defined.

/home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:63
    /home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:483
    /home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:708
    /home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:283
    /home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:351
    /home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:255
    /home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:267
    /home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/AbstractQuery.php:745
    /home/vagrant/projects/foo/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:576
    /home/vagrant/projects/foo/vendor/sonata-project/exporter/lib/Exporter/Source/DoctrineORMQuerySourceIterator.php:148
    /home/vagrant/projects/foo/vendor/sonata-project/exporter/lib/Exporter/Handler.php:40
```

in the admin I am overwriting `createQuery` method:

```php
<?php

    /**
     * {@inheritDoc}
     */
    public function createQuery($context = 'list')
    {
        $query = parent::createQuery($context);

        $query->getQueryBuilder()
            ->andWhere('o.isEmployer = 1')
            ->add('orderBy', 'o.creationTime DESC')
        ;

        return $query;
    }
```

so in the [exporter's source class](https://github.com/sonata-project/exporter/blob/master/lib/Exporter/Source/DoctrineORMQuerySourceIterator.php#L52) I expected to see one dql but got another one:

```
SELECT DISTINCT o FROM Foo\\Member o ORDER BY
```

As you see the order section was empty and it was overwritten [here](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/master/Model/ModelManager.php#L422).

I think we should not set order by if it is empty? don't we?