### PR TITLE
Small fix for many_to_one edit block

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
-                {% if sonata_admin.admin.id(sonata_admin.value) %}
+                {% if sonata_admin.value and sonata_admin.admin.id(sonata_admin.value) %}
                     {% render url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),


### PR DESCRIPTION
When creating a new empty gallery block edit fails since we use sonata_admin.value without checking
if it is set first.
