### PR TITLE
ModelManager::find allow none string id

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -184,7 +184,11 @@ class ModelManager implements ModelManagerInterface
             return null;
         }
 
-        $values = array_combine($this->getIdentifierFieldNames($class), explode(self::ID_SEPARATOR, $id));
+
+        $values = array_combine(
+            $this->getIdentifierFieldNames($class),
+            is_string($id) ? explode(self::ID_SEPARATOR, $id) : array($id)
+        );
 
         return $this->getEntityManager($class)->getRepository($class)->find($values);
     }


### PR DESCRIPTION
Updated ModelManager::find to only explode the id argument if it is a string. This is according to the [Sonata\AdminBundle\Model\ModelManagerInterface::find](https://github.com/sonata-project/SonataAdminBundle/blob/master/Model/ModelManagerInterface.php#L74) doc block (id = mixed).

Possible BC break if someone relies on string casting.