### PR TITLE
Instead of loader gif show placeholder text when deleting item in sonata_type_model_list

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -378,21 +378,30 @@ This code manage the many-to-[one|many] association field popup
         jQuery('#{{ id }}').on('change', function(event) {
 
             Admin.log('[{{ id }}] update the label');
-
-            jQuery('#field_widget_{{ id }}').html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
-            jQuery.ajax({
-                type: 'GET',
-                url: '{{ url('sonata_admin_short_object_information', {
-                    'objectId': 'OBJECT_ID',
-                    'uniqid': associationadmin.uniqid,
-                    'code': associationadmin.code,
-                    'linkParameters': sonata_admin.field_description.options.link_parameters
-                })}}'.replace('OBJECT_ID', jQuery(this).val()),
-                dataType: 'html',
-                success: function(html) {
-                    jQuery('#field_widget_{{ id }}').html(html);
-                }
-            });
+            
+            var field_widget = jQuery('#field_widget_{{ id }}');
+            var current_id   = jQuery(this).val();
+            
+            if (current_id == "") {
+                // Unselected the object
+                field_widget.html('<span class="inner-field-short-description">' + field_widget.data("placeholder") + '</span>');
+            } else {
+                // Selected a new object
+                field_widget.html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
+                jQuery.ajax({
+                    type: 'GET',
+                    url: '{{ url('sonata_admin_short_object_information', {
+                        'objectId': 'OBJECT_ID',
+                        'uniqid': associationadmin.uniqid,
+                        'code': associationadmin.code,
+                        'linkParameters': sonata_admin.field_description.options.link_parameters
+                    })}}'.replace('OBJECT_ID', current_id),
+                    dataType: 'html',
+                    success: function(html) {
+                        field_widget.html(html);
+                    }
+                });
+            }
         });
 
     {% endif %}

--- a/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -18,7 +18,11 @@ file that was distributed with this source code.
 {% else %}
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
-            <span id="field_widget_{{ id }}" class="field-short-description">
+            {% set placeholder = '' %}
+            {% if sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                {% set placeholder = sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') %}
+            {% endif %}
+            <span id="field_widget_{{ id }}" class="field-short-description" data-placeholder="{{ placeholder }}">
                 {% if sonata_admin.admin.id(sonata_admin.value) %}
                     {% render url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
@@ -26,9 +30,9 @@ file that was distributed with this source code.
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.options.link_parameters
                     }) %}
-                {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                {% else %}
                     <span class="inner-field-short-description">
-                        {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                        {{ placeholder }}
                     </span>
                 {% endif %}
             </span>

--- a/Resources/views/CRUD/edit_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_one.html.twig
@@ -18,7 +18,11 @@ file that was distributed with this source code.
 {% else %}
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
-            <span id="field_widget_{{ id }}" class="field-short-description">
+            {% set placeholder = '' %}
+            {% if sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                {% set placeholder = sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') %}
+            {% endif %}
+            <span id="field_widget_{{ id }}" class="field-short-description" data-placeholder="{{ placeholder }}">
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
                     {% render url('sonata_admin_short_object_information',{
                         'code':     sonata_admin.field_description.associationadmin.code,
@@ -26,9 +30,9 @@ file that was distributed with this source code.
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.options.link_parameters
                     }) %}
-                {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                {% else %}
                     <span class="inner-field-short-description">
-                        {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                        {{ placeholder }}
                     </span>
                 {% endif %}
             </span>

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -56,7 +56,11 @@ file that was distributed with this source code.
 {% block sonata_type_model_list_widget %}
     <div id="field_container_{{ id }}" class="field-container">
         <span id="field_actions_{{ id }}" class="field-actions">
-            <span id="field_widget_{{ id }}" class="field-short-description">
+            {% set placeholder = '' %}
+            {% if sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                {% set placeholder = sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') %}
+            {% endif %}
+            <span id="field_widget_{{ id }}" class="field-short-description" data-placeholder="{{ placeholder }}">
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
                     {% render url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
@@ -64,9 +68,9 @@ file that was distributed with this source code.
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.options.link_parameters
                     }) %}
-                {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                {% else %}
                     <span class="inner-field-short-description">
-                        {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                        {{ placeholder }}
                     </span>
                 {% endif %}
             </span>


### PR DESCRIPTION
When hitting the "Delete" button on a sonata_type_model_list element, the loader gif shows up and stays, because the request to the sonata_admin_short_object_information URL  without an object ID returns an error and not a short description. 

This patch catches the case and shows the placeholder text instead.