### PR TITLE
Add diff function to Audit reader, AuditReaderInterface in admin-bundle ...

### DIFF
--- a/Model/AuditReader.php
+++ b/Model/AuditReader.php
@@ -57,4 +57,11 @@ class AuditReader implements AuditReaderInterface
     {
         return $this->auditReader->findRevisions($className, $id);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function diff($className, $id, $oldRevision, $newRevision){
+        return $this->auditReader->diff($className, $id, $oldRevision, $newRevision);
+    }
 }


### PR DESCRIPTION
In order to use the diff function, the default `AuditReader` should actually support the diff function. This function is automatically supported, since it directly accesses the AuditReader of the EntityAudit repository: https://github.com/simplethings/EntityAudit/blob/master/src/SimpleThings/EntityAudit/AuditReader.php
