### PR TITLE
Add audit 'force' option

### DIFF
--- a/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -31,6 +31,7 @@ class AddAuditEntityCompilerPass implements CompilerPassInterface
         }
 
         $auditedEntities = $container->getParameter('simplethings.entityaudit.audited_entities');
+        $force = $container->getParameter('sonata_doctrine_orm_admin.audit.force');
 
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
 
@@ -38,7 +39,11 @@ class AddAuditEntityCompilerPass implements CompilerPassInterface
                 continue;
             }
 
-            if (isset($attributes[0]['audit']) && $attributes[0]['audit'] == false) {
+            if (true === $force && isset($attributes[0]['audit']) && false === $attributes[0]['audit']) {
+                continue;
+            }
+
+            if (false === $force && (!isset($attributes[0]['audit']) || false === $attributes[0]['audit'])) {
                 continue;
             }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,12 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('entity_manager')->defaultNull()->end()
+                ->arrayNode('audit')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('force')->defaultTrue()->end()
+                    ->end()
+                ->end()
                 ->arrayNode('templates')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/SonataDoctrineORMAdminExtension.php
+++ b/DependencyInjection/SonataDoctrineORMAdminExtension.php
@@ -36,6 +36,10 @@ class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
     {
         $configs = $this->fixTemplatesConfiguration($configs, $container);
 
+        $configuration = new Configuration();
+        $processor     = new Processor();
+        $config        = $processor->processConfiguration($configuration, $configs);
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('doctrine_orm.xml');
         $loader->load('doctrine_orm_filter_types.xml');
@@ -44,13 +48,11 @@ class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
 
         if (isset($bundles['SimpleThingsEntityAuditBundle'])) {
             $loader->load('audit.xml');
+
+            $container->setParameter('sonata_doctrine_orm_admin.audit.force', $config['audit']['force']);
         }
 
         $loader->load('security.xml');
-
-        $configuration = new Configuration();
-        $processor     = new Processor();
-        $config        = $processor->processConfiguration($configuration, $configs);
 
         $container->setParameter('sonata_doctrine_orm_admin.entity_manager', $config['entity_manager']);
 

--- a/Resources/doc/reference/audit.rst
+++ b/Resources/doc/reference/audit.rst
@@ -55,9 +55,16 @@ Next, be sure to enable the bundle in your `AppKernel.php` file:
 Configuration
 -------------
 
-If the ``EntityAuditBundle`` is enabled, then all entities managed by the ``DoctrineORMAdminBundle`` will be audited.
+If the ``EntityAuditBundle`` is enabled, then by default all entities managed by the ``DoctrineORMAdminBundle``
+will be audited. You can change this behavior by setting the ``force`` option to ``false`` :
 
-It is possible to disable an entity to be audited with the attribute `audit="false"` in `services.xml`.
+.. code-block:: yaml
+
+    sonata_doctrine_orm_admin:
+        audit:
+            force: false
+
+It is also possible to configure an entity audit with the attribute `audit` in `services.xml`.
 For instance :
 
 .. code-block:: xml

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -17,6 +17,9 @@ Full configuration options
         # default value is null, so doctrine uses the value defined in the configuration
         entity_manager: ~
 
+        audit:
+            force: true
+
         templates:
             form:
                 - SonataDoctrineORMAdminBundle:Form:form_admin_fields.html.twig

--- a/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\DependencyInjection\Compiler;
+
+use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddAuditEntityCompilerPass;
+use Symfony\Component\DependencyInjection\Definition;
+
+class AddAuditEntityCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function processDataProvider()
+    {
+        return array(
+            array(true, array(
+                'admin1' => array('audit' => null,  'audited' => true),
+                'admin2' => array('audit' => true,  'audited' => true),
+                'admin3' => array('audit' => false, 'audited' => false),
+            )),
+            array(false, array(
+                'admin1' => array('audit' => null,  'audited' => false),
+                'admin2' => array('audit' => true,  'audited' => true),
+                'admin3' => array('audit' => false, 'audited' => false),
+            )),
+        );
+    }
+
+    /**
+     * @dataProvider processDataProvider
+     */
+    public function testProcess($force, array $services)
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $container
+            ->expects($this->any())
+            ->method('hasDefinition')
+            ->will($this->returnCallback(function ($id) {
+                if ('simplethings_entityaudit.config' === $id) {
+                    return true;
+                }
+            }))
+        ;
+
+        $container
+            ->expects($this->any())
+            ->method('getParameter')
+            ->will($this->returnCallback(function ($id) use ($force) {
+                if ('sonata_doctrine_orm_admin.audit.force' === $id) {
+                    return $force;
+                }
+
+                if ('simplethings.entityaudit.audited_entities' === $id) {
+                    return array();
+                }
+            }))
+        ;
+
+        $container
+            ->expects($this->any())
+            ->method('findTaggedServiceIds')
+            ->will($this->returnCallback(function ($id) use ($services) {
+                if ('sonata.admin' === $id) {
+                    $tags = array();
+
+                    foreach ($services as $id => $service) {
+                        $attributes = ['manager_type' => 'orm'];
+
+                        if (null !== $audit = $service['audit']) {
+                            $attributes['audit'] = $audit;
+                        }
+
+                        $tags[$id] = array(0 => $attributes);
+                    }
+
+                    return $tags;
+                }
+            }))
+        ;
+
+        $container
+            ->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnCallback(function ($id) {
+                return new Definition(null, array(null, $id));
+            }))
+        ;
+
+        $expectedAuditedEntities = array();
+
+        foreach ($services as $id => $service) {
+            if ($service['audited']) {
+                $expectedAuditedEntities[] = $id;
+            }
+        }
+
+        $container
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('simplethings.entityaudit.audited_entities', $expectedAuditedEntities)
+        ;
+
+        $compilerPass = new AddAuditEntityCompilerPass();
+        $compilerPass->process($container);
+    }
+}


### PR DESCRIPTION
This PR adds a `force` option to audit (`true` by default to keep BC).

```
    sonata_doctrine_orm_admin:
        audit:
            force: true
```

If `force` is `true`, all entities will be audited by default, unless `audit="false"` is set (previous default behavior).
If `force` is `false`, entites won't be audited by default, unless `audit="true"` is set.

I use a project where I want to audit only 1 entity, and that's much easier with this option.
