### PR TITLE
Fix array notation for php < 5.4

### DIFF
--- a/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
@@ -71,7 +71,7 @@ class AddAuditEntityCompilerPassTest extends \PHPUnit_Framework_TestCase
                     $tags = array();
 
                     foreach ($services as $id => $service) {
-                        $attributes = ['manager_type' => 'orm'];
+                        $attributes = array('manager_type' => 'orm');
 
                         if (null !== $audit = $service['audit']) {
                             $attributes['audit'] = $audit;


### PR DESCRIPTION
This PR replaces a php 5.4 array notation in tests introduced in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/commit/bb778193a8e38e58124efb73e36ac3c2fc14fcf0.
