### PR TITLE
Fixed apparent typo (parameterUniqueId -> uniqueParameterId)

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -25,7 +25,7 @@ class ProxyQuery implements ProxyQueryInterface
 
     protected $sortOrder;
 
-    protected $parameterUniqueId;
+    protected $uniqueParameterId;
 
     protected $entityJoinAliases;
 


### PR DESCRIPTION
Property name was not the same as the one in the constructor, also old name of parameterUniqueId not found anywhere else in Sonata code.
