### PR TITLE
Visual feedback when you click "Add new"

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_many.html.twig
@@ -81,7 +81,7 @@ file that was distributed with this source code.
                 <span id="field_actions_{{ id }}" >
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
-                        onclick="return start_field_retrieve_{{ id }}(this);"
+                        onclick="$(this).html('<i class=\'fa fa-spinner fa-spin\'></i>'); return start_field_retrieve_{{ id }}(this);"
                         class="btn btn-success btn-sm btn-outline sonata-ba-action"
                         title="{{ btn_add|trans({}, btn_catalogue) }}"
                         >

--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -118,7 +118,7 @@ file that was distributed with this source code.
                 <span id="field_actions_{{ id }}" >
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
-                        onclick="return start_field_retrieve_{{ id }}(this);"
+                        onclick="$(this).html('<i class=\'fa fa-spinner fa-spin\'></i>'); return start_field_retrieve_{{ id }}(this);"
                         class="btn btn-success btn-sm btn-outline sonata-ba-action"
                         title="{{ btn_add|trans({}, btn_catalogue) }}"
                         >


### PR DESCRIPTION
Replace link (button) text with a simple fontawesome spinner when it is clicked.

(This is replaced by the original "Add new" text when the new content is loaded)