### PR TITLE
Fixed invalid escaping DQL parameters

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -103,14 +103,14 @@ class ProxyQuery implements ProxyQueryInterface
 
         $results    = $queryBuilderId->getQuery()->execute(array(), Query::HYDRATE_ARRAY);
         $idx        = array();
-        $connection = $queryBuilder->getEntityManager()->getConnection();
         foreach ($results as $id) {
-            $idx[] = $connection->quote($id[$idName]);
+            $idx[] = $id[$idName];
         }
 
         // step 4 : alter the query to match the targeted ids
         if (count($idx) > 0) {
-            $queryBuilder->andWhere(sprintf('%s IN (%s)', $select, implode(',', $idx)));
+            $queryBuilder->andWhere(sprintf('%s IN (:sonata_ids)', $select));
+            $queryBuilder->setParameter('sonata_ids', $idx);
             $queryBuilder->setMaxResults(null);
             $queryBuilder->setFirstResult(null);
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | sonata-project/SonataAdminBundle#2378, sonata-project/SonataAdminBundle#1977, sonata-project/SonataAdminBundle#1420 |
| License | MIT |

This escaping bug occures if the primary key was a string and not an integer.
