### PR TITLE
Changed lowercase 'edit' in isGranted to uppercase 'EDIT'

### DIFF
--- a/Resources/views/CRUD/show_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_many.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field%}
     <ul class="sonata-ba-show-many-to-many">
-    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('edit')%}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT')%}
         {% for element in value%}
             <li>
                 <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a>


### PR DESCRIPTION
The isGranted('edit') function returns false even when the user has the EDIT role, because the role naming conventions are to use uppercase. Changing the lowercase 'edit' in isGranted to uppercase 'EDIT' fixes the template.
