### PR TITLE
Update Example 6.1

### DIFF
--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -25,7 +25,7 @@ Example
         protected function configureFormFields(FormMapper $formMapper)
         {
             $formMapper
-                ->add('author', 'sonata_type_model', array(), array('edit' => 'list'))
+                ->add('author', 'sonata_type_model_list', array())
                 ->add('enabled')
                 ->add('title')
                 ->add('abstract', null, array('required' => false))


### PR DESCRIPTION
The type sonata_type_model_list replaces the fourth parameter in $formMapper->add()
