### PR TITLE
Change required to false in sonata_type_model_list to avoid error "An invalid form control with name='' is not focusable"

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -110,7 +110,8 @@ file that was distributed with this source code.
         </span>
 
         <span style="display: none" >
-            {{ form_widget(form) }}
+            {# Hidden text input cannot be required, because browser will throw error "An invalid form control with name='' is not focusable"  #}
+            {{ form_widget(form, {'required':false}) }}
         </span>
 
         <div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | sonata-project/SonataAdminBundle#1994, #257 |
| License | MIT |

My previous PR sonata-project/SonataAdminBundle#2455 didn't fix the issue properly (it introduced a problem with label). So I have [reverted the change](https://github.com/sonata-project/SonataAdminBundle/commit/45dc49f2f554871c643f84174ae509ec8e994341) and prepared this new PR to fix the issue.
