### PR TITLE
Fix buttons render for sonata_type_model_list_widget

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -93,9 +93,7 @@ file that was distributed with this source code.
                         {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
-            </span>
 
-            <span class="btn-group">
                 {% if sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') and btn_delete %}
                     <a  href=""
                         onclick="return remove_selected_element_{{ id }}(this);"


### PR DESCRIPTION
Hi,

When i only display the button delete on a sonata_type_model_list, the button is displayed on the far right of the screen instead of being close to the field.
![sonata_model_list_widget screen1](https://cloud.githubusercontent.com/assets/520893/4506591/3f3ac9d2-4b04-11e4-9145-6d432ae44582.png)

 I fixed this, here are some screenshots of the admin with my fix:

![sonata_model_list_widget screen2](https://cloud.githubusercontent.com/assets/520893/4506611/71f775aa-4b04-11e4-9950-570f3f12a67e.png)
![sonata_model_list_widget screen3](https://cloud.githubusercontent.com/assets/520893/4506612/7404b7f4-4b04-11e4-94b3-9f1923a28572.png)
![sonata_model_list_widget screen4](https://cloud.githubusercontent.com/assets/520893/4506613/763aa2e0-4b04-11e4-9db0-1f107c94db18.png)
