### PR TITLE
When checking if to show links to associated admins, check permissions a...

### DIFF
--- a/Resources/views/CRUD/list_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_many.html.twig
@@ -12,9 +12,9 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') %}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(field_description.options.route.name) %}
         {% for element in value%}
-            {%- if field_description.associationadmin.isGranted('EDIT', value) -%}
+            {%- if field_description.associationadmin.isGranted(field_description.options.route.name|upper, value) -%}
                 {{ block('relation_link') }}
             {%- else -%}
                 {{ block('relation_value') }}

--- a/Resources/views/CRUD/list_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_one.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     {% if value %}
-        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT', value) %}
+        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute(field_description.options.route.name) and field_description.associationadmin.isGranted(field_description.options.route.name|upper, value) %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
         {% else %}
             {{ value|render_relation_element(field_description) }}

--- a/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -12,9 +12,9 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('EDIT') %}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(field_description.options.route.name|upper) %}
         {% for element in value%}
-            {%- if field_description.associationadmin.isGranted('edit', value) -%}
+            {%- if field_description.associationadmin.isGranted(field_description.options.route.name, value) -%}
                 {{ block('relation_link') }}
             {%- else -%}
                 {{ block('relation_value') }}

--- a/Resources/views/CRUD/list_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_one.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.isGranted('EDIT', value) and field_description.associationadmin.hasRoute('edit') %}
+    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.isGranted(field_description.options.route.name|upper, value) and field_description.associationadmin.hasRoute(field_description.options.route.name) %}
         <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
     {% else %}
         {{ value|render_relation_element(field_description) }}

--- a/Resources/views/CRUD/show_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_many.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field%}
     <ul class="sonata-ba-show-many-to-many">
-    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT')%}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(field_description.options.route.name) and field_description.associationadmin.isGranted(field_description.options.route.name|upper)%}
         {% for element in value%}
             <li>
                 <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a>

--- a/Resources/views/CRUD/show_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_one.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     {% if value %}
-        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('EDIT') %}
+        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute(field_description.options.route.name) and field_description.associationadmin.isGranted(field_description.options.route.name|upper) %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
         {% else %}
             {{ value|render_relation_element(field_description) }}

--- a/Resources/views/CRUD/show_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_one_to_many.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field%}
     <ul class="sonata-ba-show-one-to-many">
-    {% if field_description.hasassociationadmin and field_description.associationadmin.isGranted('EDIT') and field_description.associationadmin.hasRoute('edit') %}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.isGranted(field_description.options.route.name|upper) and field_description.associationadmin.hasRoute(field_description.options.route.name) %}
         {% for element in value%}
             <li><a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a></li>
         {% endfor %}

--- a/Resources/views/CRUD/show_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_one_to_one.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
 {% block field %}
-    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.isGranted('EDIT') and field_description.associationadmin.hasRoute('edit') %}
+    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.isGranted(field_description.options.route.name|upper) and field_description.associationadmin.hasRoute(field_description.options.route.name) %}
         <a href="{{ field_description.associationadmin.generateObjectUrl(field_description.options.route.name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
     {% else %}
         {{ value|render_relation_element(field_description) }}


### PR DESCRIPTION
...gainst the configured admin instead of blindly checking the edit admin.

The admins will not link to related entities if the EDIT Page is not available or the user does not have permission to it, even when the link is not to the edit page but configured to be for another admin page such as SHOW. This should check against the correct admin each time.
