### PR TITLE
Removed javascript code blocking select button

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -35,12 +35,6 @@ This code manage the many-to-[one|many] association field popup
 
         var target = jQuery(this);
 
-        // return if the link is an anchor inside the same page
-        if (this.nodeName == 'A' && (target.attr('href').length == 0 || target.attr('href')[0] == '#')) {
-            Admin.log('[{{ id }}|field_dialog_form_list_link] element is an anchor, skipping action', this);
-            return;
-        }
-
         event.preventDefault();
         event.stopPropagation();
 


### PR DESCRIPTION
The commit ce5bd40 broke the select button when using sonata_type_model_list.
I removed this condition since it's blocking the default select action and I can't see how it's usefull.

fixes #404