### PR TITLE
Fix ProxyQuery error on relational identifiers

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -76,16 +76,30 @@ class ProxyQuery implements ProxyQueryInterface
         // step 1 : retrieve the targeted class
         $from  = $queryBuilderId->getDQLPart('from');
         $class = $from[0]->getFrom();
+        $metadata = $queryBuilderId->getEntityManager()->getMetadataFactory()->getMetadataFor($class);
 
-        // step 2 : retrieve the column id
-        $idName = current($queryBuilderId->getEntityManager()->getMetadataFactory()->getMetadataFor($class)->getIdentifierFieldNames());
+        // step 2 : retrieve identifier columns
+        $idNames = $metadata->getIdentifierFieldNames();
 
-        // step 3 : retrieve the different subjects id
-        $select = sprintf('%s.%s', $queryBuilderId->getRootAlias(), $idName);
+        // step 3 : retrieve the different subjects ids
+        $selects = array();
+        $idxSelect = '';
+        foreach ($idNames as $idName) {
+            $select = sprintf('%s.%s', $queryBuilderId->getRootAlias(), $idName);
+            // Put the ID select on this array to use it on results QB
+            $selects[$idName] = $select;
+            // Use IDENTITY if id is a relation too. See: http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
+            // Should work only with doctrine/orm: ~2.2
+            $idSelect = $select;
+            if ($metadata->hasAssociation($idName)) {
+                $idSelect = sprintf('IDENTITY(%s) as %s', $idSelect, $idName);
+            }
+            $idxSelect .= ($idxSelect !== '' ? ', ' : '') . $idSelect;
+        }
         $queryBuilderId->resetDQLPart('select');
-        $queryBuilderId->add('select', 'DISTINCT '.$select);
+        $queryBuilderId->add('select', 'DISTINCT '.$idxSelect);
 
-        // for SELECT DISTINCT, ORDER BY expressions must appear in select list
+        // for SELECT DISTINCT, ORDER BY expressions must appear in idxSelect list
         /* Consider
             SELECT DISTINCT x FROM tab ORDER BY y;
         For any particular x-value in the table there might be many different y
@@ -102,17 +116,22 @@ class ProxyQuery implements ProxyQueryInterface
         }
 
         $results    = $queryBuilderId->getQuery()->execute(array(), Query::HYDRATE_ARRAY);
-        $idx        = array();
+        $idxMatrix  = array();
         foreach ($results as $id) {
-            $idx[] = $id[$idName];
+            foreach ($idNames as $idName) {
+                $idxMatrix[$idName][] = $id[$idName];
+            }
         }
 
         // step 4 : alter the query to match the targeted ids
-        if (count($idx) > 0) {
-            $queryBuilder->andWhere(sprintf('%s IN (:sonata_ids)', $select));
-            $queryBuilder->setParameter('sonata_ids', $idx);
-            $queryBuilder->setMaxResults(null);
-            $queryBuilder->setFirstResult(null);
+        foreach ($idxMatrix as $idName => $idx) {
+            if (count($idx) > 0) {
+                $idxParamName = sprintf('%s_idx', $idName);
+                $queryBuilder->andWhere(sprintf('%s IN (:%s)', $selects[$idName], $idxParamName));
+                $queryBuilder->setParameter($idxParamName, $idx);
+                $queryBuilder->setMaxResults(null);
+                $queryBuilder->setFirstResult(null);
+            }
         }
 
         return $queryBuilder;


### PR DESCRIPTION
Actually, the ProxyQuery can't handle identifier with relational link properly. This PR patch this.

It's a corrected version of #226 and concern issus #225, https://github.com/sonata-project/SonataAdminBundle/issues/1392 and https://github.com/sonata-project/SonataAdminBundle/issues/1000 as far I know.

I think it's quite critical, please have a look! :+1: 

Thanks.

I give you some steps to reproduce the error with the current master version.

If we have an entity with relational identifiers like this:

```php
/**
 * UserBrowser
 *
 * @ORM\Table(name="user_browser")
 * @ORM\Entity
 */
class UserBrowser
{
    /**
     * @var User
     *
     * @ORM\Id
     * @ORM\ManyToOne(targetEntity="Nexy\UserBundle\Entity\User", inversedBy="browsers")
     * @ORM\JoinColumn(name="user_id", referencedColumnName="id")
     */
    private $user;

    /**
     * @var User
     *
     * @ORM\Id
     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\Browser")
     * @ORM\JoinColumn(name="browser_id", referencedColumnName="id")
     */
    private $browser;

    // [...]
```

And a configured admin like this:

```php
/**
 * Class UserBrowserAdmin
 */
class UserBrowserAdmin extends Admin
{
    protected $baseRouteName = 'admin_user_browser';
    protected $baseRoutePattern = 'user/browser';
    protected $datagridValues = array(
        '_sort_by'      => 'lastUsedAt',
        '_sort_order'   => 'DESC',
    );

    protected function configureListFields(ListMapper $list)
    {
        $list
            ->addIdentifier('user')
            ->addIdentifier('browser')
            ->add('lastUsedAt')
            ->add('_action', 'actions', array(
                'actions'   => array(
                    'show'      => array(),
                )
            ))
        ;
    }

    protected function configureShowFields(ShowMapper $filter)
    {
        $filter
            ->add('user')
            ->add('browser.id')
            ->add('lastUsedAt')
            ->add('browser.details')
        ;
    }
}
```

We got this error:

```
An exception has been thrown during the rendering of a template ("[Semantical Error] line 0, col 18 near 'user FROM AppBundle\Entity\UserBrowser': Error: Invalid PathExpression. Must be a StateFieldPathExpression.") in SonataAdminBundle:CRUD:base_list.html.twig at line 33.
```