### PR TITLE
Fix js call order

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -59,10 +59,10 @@ This code manage the many-to-[one|many] association field popup
                 success: function(html) {
                     Admin.log('[{{ id }}|field_dialog_form_list_link] callback success, attach valid js event');
 
+                    Admin.shared_setup(field_dialog_{{ id }});
+
                     field_dialog_content_{{ id }}.html(html);
                     field_dialog_form_list_handle_action_{{ id }}();
-
-                    Admin.shared_setup(field_dialog_{{ id }});
                 }
             });
 


### PR DESCRIPTION
Call ``shared_setup`` before ``field_dialog_form_list_handle_action`` so that the form ``submit event`` (used for ajax handling) is registered after all others.

This fixes an issue with the ``clear filters`` feature (https://github.com/sonata-project/SonataAdminBundle/pull/2777) which also uses a ``submit event``.