### PR TITLE
LabelFix

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -27,7 +27,9 @@ file that was distributed with this source code.
                                             <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                                         {% else %}
                                             <th {{ nested_field.vars['required']  ? 'class="required"' : '' }}{% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %} style="display:none;"{% endif %}>
-                                                {{ nested_field.vars['sonata_admin'].admin.trans(nested_field.vars.label) }}
+                                                {% if nested_field.vars.label %}
+                                                    {{ nested_field.vars['sonata_admin'].admin.trans(nested_field.vars.label) }}
+                                                {% endif %}
                                             </th>
                                         {% endif %}
                                     {% endfor %}


### PR DESCRIPTION
The problem that the media-type's label isn't passed to the template which results in an error when invoking the translator/calling the trans method in the template. 