### PR TITLE
support order asc nulls first for postgresql database

### DIFF
--- a/Admin/FieldDescription.php
+++ b/Admin/FieldDescription.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sonata package.
  *
- * (c) 2010-2011 Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -117,7 +117,7 @@ class DatagridBuilder implements DatagridBuilderInterface
         $fieldDescription->mergeOption('field_options', array('required' => false));
         $filter = $this->filterFactory->create($fieldDescription->getName(), $type, $fieldDescription->getOptions());
 
-        if (!$filter->getLabel()) {
+        if (false !== $filter->getLabel() && !$filter->getLabel()) {
             $filter->setLabel($admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'filter', 'label'));
         }
 

--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -89,7 +89,7 @@ class DatagridBuilder implements DatagridBuilderInterface
      *
      * @return void
      */
-    public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
+    public function addFilter(DatagridInterface $datagrid, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
     {
         if ($type == null) {
             $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());

--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -89,7 +89,7 @@ class DatagridBuilder implements DatagridBuilderInterface
      *
      * @return void
      */
-    public function addFilter(DatagridInterface $datagrid, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
+    public function addFilter(DatagridInterface $datagrid, $type = null, FieldDescriptionInterface $fieldDescription, AdminInterface $admin)
     {
         if ($type == null) {
             $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());

--- a/Builder/ListBuilder.php
+++ b/Builder/ListBuilder.php
@@ -127,37 +127,33 @@ class ListBuilder implements ListBuilderInterface
 
             $fieldDescription->setTemplate($this->getTemplate($fieldDescription->getType()));
 
-            if ($fieldDescription->getMappingType() == ClassMetadataInfo::MANY_TO_ONE) {
-                $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:list_orm_many_to_one.html.twig');
-            }
+            if (!$fieldDescription->getTemplate()) {
 
-            if ($fieldDescription->getMappingType() == ClassMetadataInfo::ONE_TO_ONE) {
-                $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:list_orm_one_to_one.html.twig');
-            }
+                switch($fieldDescription->getMappingType()) {
+                    case ClassMetadataInfo::MANY_TO_ONE:
+                        $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:list_orm_many_to_one.html.twig');
+                        break;
+                    case ClassMetadataInfo::ONE_TO_ONE:
+                        $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:list_orm_one_to_one.html.twig');
+                        break;
+                    case ClassMetadataInfo::ONE_TO_MANY:
+                        $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:list_orm_one_to_many.html.twig');
+                        break;
+                    case ClassMetadataInfo::MANY_TO_MANY:
+                        $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:list_orm_many_to_many.html.twig');
+                        break;
+                }
 
-            if ($fieldDescription->getMappingType() == ClassMetadataInfo::ONE_TO_MANY) {
-                $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:list_orm_one_to_many.html.twig');
-            }
-
-            if ($fieldDescription->getMappingType() == ClassMetadataInfo::MANY_TO_MANY) {
-                $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:list_orm_many_to_many.html.twig');
             }
         }
 
-        if ($fieldDescription->getMappingType() == ClassMetadataInfo::MANY_TO_ONE) {
-            $admin->attachAdminClass($fieldDescription);
-        }
-
-        if ($fieldDescription->getMappingType() == ClassMetadataInfo::ONE_TO_ONE) {
-            $admin->attachAdminClass($fieldDescription);
-        }
-
-        if ($fieldDescription->getMappingType() == ClassMetadataInfo::ONE_TO_MANY) {
-            $admin->attachAdminClass($fieldDescription);
-        }
-
-        if ($fieldDescription->getMappingType() == ClassMetadataInfo::MANY_TO_MANY) {
-            $admin->attachAdminClass($fieldDescription);
+        switch($fieldDescription->getMappingType()) {
+            case ClassMetadataInfo::MANY_TO_ONE:
+            case ClassMetadataInfo::ONE_TO_ONE:
+            case ClassMetadataInfo::ONE_TO_MANY:
+            case ClassMetadataInfo::MANY_TO_MANY:
+                $admin->attachAdminClass($fieldDescription);
+                break;
         }
     }
 

--- a/Builder/ShowBuilder.php
+++ b/Builder/ShowBuilder.php
@@ -119,9 +119,9 @@ class ShowBuilder implements ShowBuilderInterface
         if (!$fieldDescription->getTemplate()) {
 
             $fieldDescription->setTemplate($this->getTemplate($fieldDescription->getType()));
-            
+
             if (!$fieldDescription->getTemplate()) {
-                
+
                 switch($fieldDescription->getMappingType()) {
                     case ClassMetadataInfo::MANY_TO_ONE:
                         $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:show_orm_many_to_one.html.twig');
@@ -136,7 +136,7 @@ class ShowBuilder implements ShowBuilderInterface
                         $fieldDescription->setTemplate('SonataDoctrineORMAdminBundle:CRUD:show_orm_many_to_many.html.twig');
                         break;
                 }
-                
+
             }
         }
 

--- a/Filter/AbstractDateFilter.php
+++ b/Filter/AbstractDateFilter.php
@@ -62,7 +62,6 @@ abstract class AbstractDateFilter extends Filter
             $queryBuilder->setParameter($startDateParameterName,  $data['value']['start']);
             $queryBuilder->setParameter($endDateParameterName,  $data['value']['end']);
         } else {
-
             if (!$data['value']) {
                 return;
             }
@@ -120,7 +119,7 @@ abstract class AbstractDateFilter extends Filter
     public function getDefaultOptions()
     {
         return array(
-            'input_type' => 'datetime'
+            'input_type' => 'datetime',
         );
     }
 
@@ -144,13 +143,5 @@ abstract class AbstractDateFilter extends Filter
             'field_options' => $this->getFieldOptions(),
             'label'         => $this->getLabel(),
         ));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFieldType()
-    {
-        return $this->getOption('field_type', 'sonata_type_datetime_range');
     }
 }

--- a/Filter/DateFilter.php
+++ b/Filter/DateFilter.php
@@ -26,4 +26,12 @@ class DateFilter extends AbstractDateFilter
      * @var boolean
      */
     protected $time = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldType()
+    {
+        return $this->getOption('field_type', 'date');
+    }
 }

--- a/Filter/DateRangeFilter.php
+++ b/Filter/DateRangeFilter.php
@@ -24,4 +24,12 @@ class DateRangeFilter extends AbstractDateFilter
      * @var boolean
      */
     protected $time = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldType()
+    {
+        return $this->getOption('field_type', 'sonata_type_date_range');
+    }
 }

--- a/Filter/DateTimeFilter.php
+++ b/Filter/DateTimeFilter.php
@@ -26,4 +26,12 @@ class DateTimeFilter extends AbstractDateFilter
      * @var boolean
      */
     protected $range = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldType()
+    {
+        return $this->getOption('field_type', 'datetime');
+    }
 }

--- a/Filter/DateTimeRangeFilter.php
+++ b/Filter/DateTimeRangeFilter.php
@@ -26,4 +26,12 @@ class DateTimeRangeFilter extends AbstractDateFilter
      * @var boolean
      */
     protected $range = true;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldType()
+    {
+        return $this->getOption('field_type', 'sonata_type_datetime_range');
+    }
 }

--- a/Filter/TimeFilter.php
+++ b/Filter/TimeFilter.php
@@ -26,4 +26,12 @@ class TimeFilter extends AbstractDateFilter
      * @var boolean
      */
     protected $time = true;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldType()
+    {
+        return $this->getOption('field_type', 'time');
+    }
 }

--- a/Resources/meta/LICENSE
+++ b/Resources/meta/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010-2013 thomas.rabaix@sonata-project.org
+Copyright (c) 2010-2015 thomas.rabaix@sonata-project.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -35,12 +35,6 @@ This code manage the many-to-[one|many] association field popup
 
         var target = jQuery(this);
 
-        // return if the link is an anchor inside the same page
-        if (this.nodeName == 'A' && (target.attr('href').length == 0 || target.attr('href')[0] == '#')) {
-            Admin.log('[{{ id }}|field_dialog_form_list_link] element is an anchor, skipping action', this);
-            return;
-        }
-
         event.preventDefault();
         event.stopPropagation();
 

--- a/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('EDIT') %}
+    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') %}
         {% for element in value%}
             {%- if field_description.associationadmin.isGranted('edit', value) -%}
                 {{ block('relation_link') }}

--- a/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -14,7 +14,7 @@ file that was distributed with this source code.
 {% block field %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') %}
         {% for element in value%}
-            {%- if field_description.associationadmin.isGranted('edit', value) -%}
+            {%- if field_description.associationadmin.isGranted('EDIT', value) -%}
                 {{ block('relation_link') }}
             {%- else -%}
                 {{ block('relation_value') }}


### PR DESCRIPTION
Hello

SonataDoctrineORMAdminBundle

 support order asc nulls first for postgresql database

in Sonata\ClassificationBundle\Entity\CategoryManager


protected function loadCategories(ContextInterface $context)
    {
        if (array_key_exists($context->getId(), $this->categories)) {
            return;
        }
        $class = $this->getClass();
        $categories = $this->getObjectManager()->createQuery(sprintf('SELECT c FROM %s c WHERE c.context = :context ORDER BY c.parent ASC NULLS FIRST', $class))
            ->setParameter('context', $context->getId())
            ->execute();

Thanks

Joseph