### PR TITLE
Fix deprecated factory definition

### DIFF
--- a/DependencyInjection/SonataDoctrineORMAdminExtension.php
+++ b/DependencyInjection/SonataDoctrineORMAdminExtension.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\DependencyInjection\AbstractSonataAdminExtension;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * SonataAdminBundleExtension
@@ -43,6 +44,15 @@ class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('doctrine_orm.xml');
         $loader->load('doctrine_orm_filter_types.xml');
+
+        // TODO: Go back on xml configuration when bumping requirements to SF 2.6+
+        $doctrineEMDefinition = $container->getDefinition('sonata.admin.entity_manager');
+        if (method_exists($doctrineEMDefinition, 'setFactory')) {
+            $doctrineEMDefinition->setFactory(array(new Reference('doctrine'), 'getEntityManager'));
+        } else {
+            $doctrineEMDefinition->setFactoryService('doctrine');
+            $doctrineEMDefinition->setFactoryMethod('getEntityManager');
+        }
 
         $bundles = $container->getParameter('kernel.bundles');
 

--- a/Resources/config/doctrine_orm.xml
+++ b/Resources/config/doctrine_orm.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="sonata.admin.entity_manager" factory-service="doctrine" factory-method="getEntityManager" class="Doctrine\ORM\EntityManager" public="false">
+        <service id="sonata.admin.entity_manager" class="Doctrine\ORM\EntityManager" public="false">
             <argument>%sonata_doctrine_orm_admin.entity_manager%</argument>
         </service>
 

--- a/Tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
+++ b/Tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Sonata\DoctrineORMAdminBundle\DependencyInjection\SonataDoctrineORMAdminExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class SonataDoctrineORMAdminExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    protected $configuration;
+
+    public function testEntityManagerSetFactory()
+    {
+        $this->configuration = new ContainerBuilder();
+        $this->configuration->setParameter('kernel.bundles', array());
+        $loader = new SonataDoctrineORMAdminExtension();
+        $loader->load(array(), $this->configuration);
+
+        $definition = $this->configuration->getDefinition('sonata.admin.entity_manager');
+        $doctrineServiceId = 'doctrine';
+        $doctrineFactoryMethod = 'getEntityManager';
+
+        if (method_exists($definition, 'getFactory')) {
+            $this->assertEquals(array(new Reference($doctrineServiceId), $doctrineFactoryMethod), $definition->getFactory());
+        } else {
+            $this->assertEquals($doctrineServiceId, $definition->getFactoryService());
+            $this->assertEquals($doctrineFactoryMethod, $definition->getFactoryMethod());
+        }
+    }
+
+    protected function tearDown()
+    {
+        unset($this->configuration);
+    }
+}


### PR DESCRIPTION
This PR replace `factory-service` and `factory-method` attributes by `factory` section, according to Symfony deprecate rules.

`factory` section was introduce on Symfony 2.6 (https://github.com/symfony/symfony/pull/9839) so this PR will break support of `symfony/dependency-injection` minor to 2.6.

If you are OK with not supporting symfony < 2.6 anymore, just merge this PR.

Otherwise, I will update it to look like this kind of PR: https://github.com/FriendsOfSymfony/FOSUserBundle/pull/1765/files

Regards