### PR TITLE
Do not add left join to already joined entities with custom query

### DIFF
--- a/Tests/Filter/QueryBuilder.php
+++ b/Tests/Filter/QueryBuilder.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
-use Sonata\DoctrineORMAdminBundle\Filter\Filter;
 
 class QueryBuilder
 {
@@ -58,6 +57,11 @@ class QueryBuilder
         }
 
         return sprintf('%s IN %s', 'in_'.$name, $value);
+    }
+
+    public function getDQLPart($queryPart)
+    {
+        return array();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | sonata-project/SonataAdminBundle#2884
| License       | MIT

If developer overload `createQuery` method in admin class, we should not `leftJoin` entities that are already joined. Too many same `leftJoin`s breaks the query performance and may cause unexpected results.