### PR TITLE
Update StringFilter.php to support both individual and combined keyword ...

### DIFF
--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -38,15 +38,24 @@ class StringFilter extends Filter
         if (!$operator) {
             $operator = 'LIKE';
         }
-
+        
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($queryBuilder);
-        $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
 
-        if ($data['type'] == ChoiceType::TYPE_EQUAL) {
-            $queryBuilder->setParameter($parameterName, $data['value']);
-        } else {
-            $queryBuilder->setParameter($parameterName, sprintf($this->getOption('format'), $data['value']));
+        // explode option specifies whether to split the string into individual words for comparison
+        // as opposed to comparing the string as a whole
+        $explode = (bool)$this->getOption('explode',false);
+        $values = $explode ? explode(" ", $data['value']) : array($data['value']);
+        
+        foreach( $values as $value )
+        {
+            $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
+    
+            if ($data['type'] == ChoiceType::TYPE_EQUAL) {
+                $queryBuilder->setParameter($parameterName, $value);
+            } else {
+                $queryBuilder->setParameter($parameterName, sprintf($this->getOption('format'), $value));
+            }
         }
     }
 

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -47,8 +47,7 @@ class StringFilter extends Filter
         $explode = (bool)$this->getOption('explode',false);
         $values = $explode ? explode(" ", $data['value']) : array($data['value']);
         
-        foreach( $values as $value )
-        {
+        foreach( $values as $value ) {
             $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
     
             if ($data['type'] == ChoiceType::TYPE_EQUAL) {


### PR DESCRIPTION
...comparison

Problem: I have come across a real world scenario where users of the Sonata admin system are using a string filter to search through entities, but not retrieving the expected results from the search, because the search filter only supports the comparison of a complete string and not a comparison against individual words contained within the specified filter string.

For example, a user of Sonata admin may search against a name of a product entity and want to retrieve all Pro model bikes made by the company Inspired. If the entity product names were for example:

Inspired Silver Pro
Inspired Black Pro

and then the admin user entered the text 'Inspired Pro' within the product name search filter, it would be likely that they would be hoping to retrieve the two results listed above. However, as there is another word separating the words 'Inspired' and 'Pro', the search against the name field would return no results.

Solution: I have made the above changes to the StringFilter.php file, such that by default, the functionality of the filter function remains completely unchanged. However, if an 'explode' option is set when adding the filter to the $datagridMapper object as follows: (I had considered calling this split, but explode ties in with the PHP function name)

$datagridMapper->add('name', 'doctrine_orm_string', array('explode' => true));

then an individual comparison is carried out on each individual word within the string, rather than just comparing the string as a whole.

I think the ability to easily turn this functionality on and off with the explode parameter will enhance the usefulness of this function when used within real world scenarios. By default explode is set to false so that the function behaves as normal and won't create any unexpected results for those using it already with the default behaviour.