### PR TITLE
Update to remove double check of defaulting

### DIFF
--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -35,10 +35,6 @@ class StringFilter extends Filter
 
         $operator = $this->getOperator((int) $data['type']);
 
-        if (!$operator) {
-            $operator = 'LIKE';
-        }
-
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($queryBuilder);
         $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));


### PR DESCRIPTION
Remove the if($operator) if the $data[type] is always being set on line 34.
The if statement was always being skipped. It can also be corrected by removing the ternary statement.

The test already exists and still continues to pass.