### PR TITLE
Fix deprecated "factory-*" service definition

### DIFF
--- a/Resources/config/doctrine_orm.xml
+++ b/Resources/config/doctrine_orm.xml
@@ -5,7 +5,8 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="sonata.admin.entity_manager" factory-service="doctrine" factory-method="getEntityManager" class="Doctrine\ORM\EntityManager" public="false">
+        <service id="sonata.admin.entity_manager" class="Doctrine\ORM\EntityManager" public="false">
+            <factory service="doctrine" method="getEntityManager"/>
             <argument>%sonata_doctrine_orm_admin.entity_manager%</argument>
         </service>
 


### PR DESCRIPTION
As of Symfony 2.7, "factory-method" and "factory-service" are deprecated in favor of "factory".