### PR TITLE
Fix doctrine_orm_choice crash on negative value

### DIFF
--- a/Filter/ChoiceFilter.php
+++ b/Filter/ChoiceFilter.php
@@ -18,6 +18,8 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 class ChoiceFilter extends Filter
 {
     /**
+     * @param ProxyQueryInterface|QueryBuilder $queryBuilder
+     *
      * {@inheritdoc}
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
@@ -35,11 +37,15 @@ class ChoiceFilter extends Filter
                 return;
             }
 
+            // Have to pass IN array value as parameter. See: http://www.doctrine-project.org/jira/browse/DDC-3759
+            $completeField = sprintf('%s.%s', $alias, $field);
+            $parameterName = $this->getNewParameterName($queryBuilder);
             if ($data['type'] == ChoiceType::TYPE_NOT_CONTAINS) {
-                $this->applyWhere($queryBuilder, $queryBuilder->expr()->notIn(sprintf('%s.%s', $alias, $field ), $data['value']));
+                $this->applyWhere($queryBuilder, $queryBuilder->expr()->notIn($completeField, ':'.$parameterName));
             } else {
-                $this->applyWhere($queryBuilder, $queryBuilder->expr()->in(sprintf('%s.%s', $alias, $field ), $data['value']));
+                $this->applyWhere($queryBuilder, $queryBuilder->expr()->in($completeField, ':'.$parameterName));
             }
+            $queryBuilder->setParameter($parameterName, $data['value']);
 
         } else {
 

--- a/Tests/Filter/ChoiceFilterTest.php
+++ b/Tests/Filter/ChoiceFilterTest.php
@@ -41,7 +41,8 @@ class ChoiceFilterTest extends \PHPUnit_Framework_TestCase
 
         $filter->filter($builder, 'alias', 'field', array('type' => ChoiceType::TYPE_CONTAINS, 'value' => array('1', '2')));
 
-        $this->assertEquals(array('in_alias.field', 'alias.field IN ("1,2")'), $builder->query);
+        $this->assertEquals(array('in_alias.field', 'in_alias.field IN :field_name_0'), $builder->query);
+        $this->assertEquals(array('field_name_0' => array('1', '2')), $builder->parameters);
         $this->assertEquals(true, $filter->isActive());
     }
 


### PR DESCRIPTION
This (finally) fix https://github.com/sonata-project/SonataAdminBundle/issues/1061.

Also add an extra `@param` line on PHPDoc block to make it more IDE friendly.