### PR TITLE
Fix empty field param for CallbackFilter

### DIFF
--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -20,7 +20,7 @@ class CallbackFilter extends Filter
      */
     protected function association(ProxyQueryInterface $queryBuilder, $data)
     {
-        return array($this->getOption('alias', $queryBuilder->getRootAlias()), false);
+        return array($this->getOption('alias', $queryBuilder->getRootAlias()), $this->getFieldName());
     }
 
     /**

--- a/Tests/Filter/CallbackFilterTest.php
+++ b/Tests/Filter/CallbackFilterTest.php
@@ -76,11 +76,11 @@ class CallbackFilterTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyMethod()
     {
-        $builder = new ProxyQuery(new QueryBuilder);
+        $builder = new ProxyQuery(new QueryBuilder());
 
-        $filter = new CallbackFilter;
+        $filter = new CallbackFilter();
         $filter->initialize('field_name_test', array(
-            'callback' => function($builder, $alias, $field, $value) {
+            'callback' => function ($builder, $alias, $field, $value) {
                 $builder->andWhere(sprintf('CUSTOM QUERY %s.%s', $alias, $field));
                 $builder->setParameter('value', $value['value']);
 

--- a/Tests/Filter/CallbackFilterTest.php
+++ b/Tests/Filter/CallbackFilterTest.php
@@ -73,4 +73,26 @@ class CallbackFilterTest extends \PHPUnit_Framework_TestCase
 
         $filter->filter($builder, 'alias', 'field', 'myValue');
     }
+
+    public function testApplyMethod()
+    {
+        $builder = new ProxyQuery(new QueryBuilder);
+
+        $filter = new CallbackFilter;
+        $filter->initialize('field_name_test', array(
+            'callback' => function($builder, $alias, $field, $value) {
+                $builder->andWhere(sprintf('CUSTOM QUERY %s.%s', $alias, $field));
+                $builder->setParameter('value', $value['value']);
+
+                return true;
+            },
+            'field_name' => 'field_name_test',
+        ));
+
+        $filter->apply($builder, array('value' => 'myValue'));
+
+        $this->assertEquals(array('CUSTOM QUERY o.field_name_test'), $builder->query);
+        $this->assertEquals(array('value' => 'myValue'), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
+    }
 }


### PR DESCRIPTION
Hello,

I tried to use the `field` param from the CallbackFilter callback, but it was empty.

After some research, I found this issue: #472 

And here is the pull request to fix it :)

Thank you for your time,

Vincent