### PR TITLE
[ProxyQuery] Convert identifiers values to database value

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -14,6 +14,7 @@ namespace Sonata\DoctrineORMAdminBundle\Model;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
@@ -339,20 +340,27 @@ class ModelManager implements ModelManagerInterface, LockInterface
         //    throw new \RuntimeException('Entities passed to the choice field must be managed');
         //}
 
-
-        $class = $this->getMetadata(ClassUtils::getClass($entity));
+        $class = ClassUtils::getClass($entity);
+        $metadata = $this->getMetadata($class);
+        $platform = $this->getEntityManager($class)->getConnection()->getDatabasePlatform();
 
         $identifiers = array();
 
-        foreach ($class->getIdentifierValues($entity) as $value) {
+        foreach ($metadata->getIdentifierValues($entity) as $name => $value) {
             if (!is_object($value)) {
                 $identifiers[] = $value;
                 continue;
             }
+            $fieldType = $metadata->getTypeOfField($name);
+            $type = Type::getType($fieldType);
+            if ($type) {
+                $identifiers[] = $type->convertToDatabaseValue($value, $platform);
+                continue;
+            }
 
-            $class = $this->getMetadata(ClassUtils::getClass($value));
+            $metadata = $this->getMetadata(ClassUtils::getClass($value));
 
-            foreach ($class->getIdentifierValues($value) as $value) {
+            foreach ($metadata->getIdentifierValues($value) as $name => $value) {
                 $identifiers[] = $value;
             }
         }


### PR DESCRIPTION
This allows using custom DBAL types as identifiers.

For example when using the [UuidBinaryType](https://github.com/ramsey/uuid-doctrine/blob/master/src/UuidBinaryType.php) from the `ramsey/uuid-doctrine` package:
```php
use Ramsey\Uuid\Uuid;

class Example
{
    /**
     * @var \Ramsey\Uuid\Uuid
     *
     * @ORM\Column(type="uuid_binary")
     * @ORM\Id
     */
    private $id;

    public function __construct()
    {
        $this->id = Uuid::uuid4();
    }
}
```

the identifier cannot simply be cast to string, since the database requires it's binary representation.
So we must make sure we convert the identifiers to their database value.