### PR TITLE
Embedded class support

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -78,8 +78,15 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
         foreach ($nameElements as $nameElement) {
             $metadata = $this->getMetadata($class);
-            $parentAssociationMappings[] = $metadata->associationMappings[$nameElement];
-            $class = $metadata->getAssociationTargetClass($nameElement);
+
+            if (isset($metadata->associationMappings[$nameElement])) {
+                $parentAssociationMappings[] = $metadata->associationMappings[$nameElement];
+                $class = $metadata->getAssociationTargetClass($nameElement);
+            } elseif (isset($metadata->embeddedClasses[$nameElement])) {
+                $parentAssociationMappings = array();
+                $lastPropertyName = $propertyFullName;
+                $class = $baseClass;
+            }
         }
 
         return array($this->getMetadata($class), $lastPropertyName, $parentAssociationMappings);

--- a/Tests/Fixtures/Entity/AssociatedEntity.php
+++ b/Tests/Fixtures/Entity/AssociatedEntity.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity;
+
+class AssociatedEntity
+{
+    /**
+     * @var string
+     */
+    protected $plainField;
+}

--- a/Tests/Fixtures/Entity/ContainerEntity.php
+++ b/Tests/Fixtures/Entity/ContainerEntity.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity;
+
+class ContainerEntity
+{
+    /**
+     * @var int
+     */
+    protected $plainField;
+
+    /**
+     * @var AssociatedEntity
+     */
+    protected $associatedEntity;
+
+    /**
+     * @var Embeddable\EmbeddedEntity
+     */
+    protected $embeddedEntity;
+
+    /**
+     * @param AssociatedEntity          $associatedEntity
+     * @param Embeddable\EmbeddedEntity $embeddedEntity
+     */
+    public function __construct(AssociatedEntity $associatedEntity, Embeddable\EmbeddedEntity $embeddedEntity)
+    {
+        $this->associatedEntity = $associatedEntity;
+        $this->embeddedEntity = $embeddedEntity;
+    }
+}

--- a/Tests/Fixtures/Entity/Embeddable/EmbeddedEntity.php
+++ b/Tests/Fixtures/Entity/Embeddable/EmbeddedEntity.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable;
+
+class EmbeddedEntity
+{
+    /**
+     * @var bool
+     */
+    protected $plainField;
+}


### PR DESCRIPTION
I tried to use an embeddable property with dot notation as a form item. Since dot notation items are all treated as associations (no check for embeddables) there was an "undefined index" exception.

~~After adding this patch my form items got rendered correctly~~ the form type guessers don't receive/deduce the correct field information / form widgets. The form just falls back to text-input defaults.

N.B.: uninitialized embedded objects (`null`) will also break somewhere at the `PropertyAccessor` level.