### PR TITLE
Updated edit one to many tab design

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -66,38 +66,40 @@ file that was distributed with this source code.
 
                     <div>
                         {% for nested_group_field in form.children %}
-                            <ul class="nav nav-tabs">
-                                {% for name, form_group in associationAdmin.formgroups %}
-                                    <li class="{% if loop.first %}active{% endif %}">
-                                        <a href="#{{ associationAdmin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}" data-toggle="tab">
-                                            <i class="icon-exclamation-sign has-errors hide"></i>
-                                            {{ associationAdmin.trans(name, {}, form_group.translation_domain) }}
-                                        </a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
+                            <div class="nav-tabs-custom">
+                                <ul class="nav nav-tabs">
+                                    {% for name, form_group in associationAdmin.formgroups %}
+                                        <li class="{% if loop.first %}active{% endif %}">
+                                            <a href="#{{ associationAdmin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}" data-toggle="tab">
+                                                <i class="icon-exclamation-sign has-errors hide"></i>
+                                                {{ associationAdmin.trans(name, {}, form_group.translation_domain) }}
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
 
-                            <div class="tab-content">
-                                {% for name, form_group in associationAdmin.formgroups %}
-                                    <div class="tab-pane {% if loop.first %}active{% endif %}" id="{{ associationAdmin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}">
-                                        <fieldset>
-                                            <div class="sonata-ba-collapsed-fields">
-                                                {% for field_name in form_group.fields %}
-                                                    {% set nested_field = nested_group_field.children[field_name] %}
-                                                    {% if associationAdmin.formfielddescriptions[field_name] is defined %}
-                                                        {{ form_row(nested_field, {
-                                                            'inline': 'natural',
-                                                            'edit'  : 'inline'
-                                                        }) }}
-                                                        {% set dummy = nested_group_field.setrendered %}
-                                                    {% else %}
-                                                        {{ form_row(nested_field) }}
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </div>
-                                        </fieldset>
-                                    </div>
-                                {% endfor %}
+                                <div class="tab-content">
+                                    {% for name, form_group in associationAdmin.formgroups %}
+                                        <div class="tab-pane {% if loop.first %}active{% endif %}" id="{{ associationAdmin.uniqid }}_{{ loop.parent.loop.index }}_{{ loop.index }}">
+                                            <fieldset>
+                                                <div class="sonata-ba-collapsed-fields">
+                                                    {% for field_name in form_group.fields %}
+                                                        {% set nested_field = nested_group_field.children[field_name] %}
+                                                        {% if associationAdmin.formfielddescriptions[field_name] is defined %}
+                                                            {{ form_row(nested_field, {
+                                                                'inline': 'natural',
+                                                                'edit'  : 'inline'
+                                                            }) }}
+                                                            {% set dummy = nested_group_field.setrendered %}
+                                                        {% else %}
+                                                            {{ form_row(nested_field) }}
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                </div>
+                                            </fieldset>
+                                        </div>
+                                    {% endfor %}
+                                </div>
                             </div>
 
                             {% if nested_group_field['_delete'] is defined %}


### PR DESCRIPTION
Updates the design of the one2many tab view in the edit/create form.

Before
![bildschirmfoto 2015-09-30 um 20 36 43](https://cloud.githubusercontent.com/assets/3440437/10202817/fe8beb2e-67b2-11e5-850c-9c566a0500f5.PNG)

After
![bildschirmfoto 2015-09-30 um 20 25 59](https://cloud.githubusercontent.com/assets/3440437/10202818/feaaee98-67b2-11e5-8e38-a93a92fd386a.PNG)