### PR TITLE
Use translation_domain on collection labels

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -27,7 +27,7 @@ file that was distributed with this source code.
                                             <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                                         {% else %}
                                             <th {{ nested_field.vars['required']  ? 'class="required"' : '' }}{% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %} style="display:none;"{% endif %}>
-                                                {{ nested_field.vars['sonata_admin'].admin.trans(nested_field.vars.label) }}
+                                                {{ nested_field.vars['sonata_admin'].admin.trans(nested_field.vars.label, {}, nested_field.vars.translation_domain) }}
                                             </th>
                                         {% endif %}
                                     {% endfor %}


### PR DESCRIPTION
When using `sonata_type_collection` with inline/table, custom `translation_domain` is ignored :
```php
->add('commission', 'percent', ['translation_domain' => 'CustomDomain'])
```
**Before**
![translation_domain](https://cloud.githubusercontent.com/assets/663607/10795333/8b93f16e-7d99-11e5-8736-9f9c92bbca4a.JPG)

**After**
![translation_domain](https://cloud.githubusercontent.com/assets/663607/10795411/f83a5682-7d99-11e5-87ad-4df8e1d381bd.JPG)

