### PR TITLE
[Translation] Add delete checkbox translation in collection

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_many.html.twig
@@ -63,7 +63,11 @@ file that was distributed with this source code.
                                     }) }}
                                     {% set dummy = nested_group_field.setrendered %}
                                 {% else %}
-                                    {{ form_row(nested_field) }}
+                                    {% if nested_field.vars.name == '_delete' %}
+                                        {{ form_row(nested_field, { 'label': ('action_delete'|trans({}, 'SonataAdminBundle')) }) }}
+                                    {% else %}
+                                        {{ form_row(nested_field) }}
+                                    {% endif %}
                                 {% endif %}
                             {% endfor %}
                         {% endfor %}


### PR DESCRIPTION
On default behavior (inline, not table), the `action_delete` translation was not included.
Tested on local machine, everything seems working fine.