### PR TITLE
fix broken build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/console": "~2.3|~3.0",
         "symfony/doctrine-bridge": "~2.2|~3.0",
         "symfony/framework-bundle": "~2.2|~3.0",
+        "symfony/security-acl": "~2.2|~3.0@dev",
         "sonata-project/exporter": "~1.3,>=1.3.1",
         "sonata-project/admin-bundle": "~2.4@dev",
         "sonata-project/core-bundle": "~2.3,>=2.3.1"


### PR DESCRIPTION
Fixes #509 .
ACLs have been moved out of Symfony since version 2.8. See
https://github.com/symfony/symfony/issues/14718