### PR TITLE
Always sort

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/console": "~2.3|~3.0",
         "symfony/doctrine-bridge": "~2.2|~3.0",
         "symfony/framework-bundle": "~2.2|~3.0",
+        "symfony/security-acl": "~2.2|~3.0@dev",
         "sonata-project/exporter": "~1.3,>=1.3.1",
         "sonata-project/admin-bundle": "~2.4@dev",
         "sonata-project/core-bundle": "~2.3,>=2.3.1"


### PR DESCRIPTION
If no ORDER BY query is specified, the order of elements cannot be
guaranteed between executions. See
http://stackoverflow.com/questions/1793147/sql-best-practice-to-deal-with-default-sort-order
This change finds out the identifier keys of the main entity at hand,
and adds a sort based on these keys.
Fixes #507 .