### PR TITLE
change ProxyQuery::getFixedQueryBuilder to protected

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -85,7 +85,7 @@ class ProxyQuery implements ProxyQueryInterface
      *
      * @return QueryBuilder
      */
-    private function getFixedQueryBuilder(QueryBuilder $queryBuilder)
+    protected function getFixedQueryBuilder(QueryBuilder $queryBuilder)
     {
         $queryBuilderId = clone $queryBuilder;
 


### PR DESCRIPTION
I needed to extend ProxyQuery in order to add query hints in the execute() method.
Does it make sense to make the getFixedQueryBuilder method protected instead of private ?