### PR TITLE
Get database value of identifier to support other identifier type classes

### DIFF
--- a/Tests/Fixtures/Entity/UuidEntity.php
+++ b/Tests/Fixtures/Entity/UuidEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity;
+
+use rhumsaa\Uuid\Uuid;
+
+class UuidEntity
+{
+    private $uuid;
+
+    public function __construct()
+    {
+        $this->uuid = Uuid::uuid4();
+    }
+
+    public function getId()
+    {
+        return $this->uuid;
+    }
+}

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -11,18 +11,28 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Model;
 
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Version;
+use Rhumsaa\Uuid\Doctrine\UuidType;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\AssociatedEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ContainerEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\VersionedEntity;
 
 class ModelManagerTest extends \PHPUnit_Framework_TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType('uuid')) {
+            Type::addType('uuid', 'Rhumsaa\Uuid\Doctrine\UuidType');
+        }
+    }
+
     public function testSortParameters()
     {
         $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
@@ -294,5 +304,60 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
         $metadata->inlineEmbeddable('embeddedEntity', $this->getMetadataForEmbeddedEntity());
 
         return $metadata;
+    }
+
+    public function testNonIntegerIdentifierType()
+    {
+        $entity = new UuidEntity();
+
+        $meta = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataInfo')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $meta->expects($this->any())
+            ->method('getIdentifierValues')
+            ->willReturn(array($entity->getId()));
+        $meta->expects($this->any())
+            ->method('getTypeOfField')
+            ->willReturn(UuidType::NAME);
+
+        $mf = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mf->expects($this->any())
+            ->method('getMetadataFor')
+            ->willReturn($meta);
+
+        $platform = $this->getMockBuilder('Doctrine\DBAL\Platforms\PostgreSqlPlatform')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $conn->expects($this->any())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $em->expects($this->any())
+            ->method('getMetadataFactory')
+            ->willReturn($mf);
+        $em->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($conn);
+
+        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $registry->expects($this->any())
+            ->method('getManagerForClass')
+            ->willReturn($em);
+
+        $manager  = new ModelManager($registry);
+        $result = $manager->getIdentifierValues($entity);
+
+        $this->assertEquals($entity->getId()->toString(), $result[0]);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "sonata-project/core-bundle": "3.x-dev@dev"
     },
     "require-dev": {
+        "rhumsaa/uuid": "^2.8",
         "simplethings/entity-audit-bundle": "~0.1",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },


### PR DESCRIPTION
I came across this issue/case when using an entity with uuid identifier and prefilled (uuid generated in the entity) identifier

Example:
```php
use Ramsey\Uuid\Uuid;

class Example
{
    /**
     * @var \Ramsey\Uuid\Uuid
     *
     * @ORM\Column(type="uuid")
     * @ORM\Id
     */
    private $id;

    public function __construct()
    {
        $this->id = Uuid::uuid4();
    }
}
```

Problems:
- Create page could not be opened (as the identifier class could not be resolved)
- prefilled identifier caused the code to think it was editing an existing item

Fixes:
- Use the database value of each type to display the entity
- Check with the unit of work if an entity is managed or not (to check if it is create or edit)
- I had to use the old uuid lib from Rhumsaa instead of Ramsey's to keep the tests compatible with php 5.3

I've also added tests to check this behavior. Based this pr on changes in #481.