### PR TITLE
Avoid 'No entity manager defined for class' in hasMetadata

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -107,7 +107,22 @@ class ModelManager implements ModelManagerInterface, LockInterface
      */
     public function hasMetadata($class)
     {
-        return $this->getEntityManager($class)->getMetadataFactory()->hasMetadataFor($class);
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
+        if (isset($this->cache[$class])) {
+            $em = $this->cache[$class];
+        } else {
+            $em = $this->registry->getManagerForClass($class);
+        }
+
+        if ($em === null) {
+            return false;
+        }
+        $this->cache[$class] = $em;
+
+        return $em->getMetadataFactory()->hasMetadataFor($class);
     }
 
     /**

--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -359,7 +359,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $identifiers = array();
 
         foreach ($class->getIdentifierValues($entity) as $value) {
-            if (!is_object($value)) {
+            if (!is_object($value) || !$this->hasMetadata($value)) {
                 $identifiers[] = $value;
                 continue;
             }

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -234,6 +234,46 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($metadata->fieldMappings[$lastPropertyName]['type'], 'boolean');
     }
 
+    public function testHasMetadata()
+    {
+        $metaDataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+        $metaDataFactory
+            ->expects($this->any())
+            ->method('hasMetadataFor')
+            ->willReturnMap(array(
+                array('myEntity', true),
+                array('mySecondEntity', true),
+                array('objectWithNoMetadata', false),
+            ))
+        ;
+
+        $entityManager = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $entityManager
+            ->expects($this->any())
+            ->method('getMetadataFactory')
+            ->willReturn($metaDataFactory);
+
+        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry->expects($this->any())
+            ->method('getManagerForClass')
+            ->willReturnMap(array(
+                array('stdClass', null),
+                array('myEntity', $entityManager),
+                array('mySecondEntity', $entityManager),
+                array('objectWithNoMetadata', $entityManager),
+            ))
+        ;
+
+        $manager = new ModelManager($registry);
+
+        $this->assertFalse($manager->hasMetadata('stdClass'));
+        $this->assertTrue($manager->hasMetadata('myEntity'));
+        $this->assertTrue($manager->hasMetadata('mySecondEntity'));
+        $this->assertFalse($manager->hasMetadata('objectWithNoMetadata'));
+    }
+
     public function getMetadataForEmbeddedEntity()
     {
         $metadata = new ClassMetadata('Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity');


### PR DESCRIPTION
I kept getting "No entity manager defined for class Rhumsaa\Uuid\Uuid" in my templates.
This happens because ModelManager::getEntityManager will throw a exception when the class has no entity manager. 

This PR fixes this.
