### PR TITLE
Check the entity identifier attribute is named id

### DIFF
--- a/Resources/views/Block/block_audit.html.twig
+++ b/Resources/views/Block/block_audit.html.twig
@@ -36,7 +36,11 @@ file that was distributed with this source code.
                                     {% for changedEntity in revision.entities %}
                                         <li>
                                             {{ changedEntity.entity }} / {{ changedEntity.revisionType }}
-                                            / {{ changedEntity.className }} - {{ changedEntity.id.id }}
+                                            / {{ changedEntity.className }} 
+                                            
+                                            {% if changedEntity.id.id is defined %}
+                                            - {{ changedEntity.id.id }}
+                                            {% endif %}
                                         </li>
                                     {% endfor %}
                                 </ul>


### PR DESCRIPTION
In some cases (legacy code) the id is not set, this fixes the error.

"Key "id" for array with keys "iid" does not exist in SonataDoctrineORMAdminBundle:Block:block_audit.html.twig at line 41"