### PR TITLE
do not test dependencies

### DIFF
--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -63,7 +63,6 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $filter->getOption('foo', 'bar'));
 
         $this->assertEquals('field_name', $filter->getName());
-        $this->assertEquals('text', $filter->getFieldType());
         $this->assertEquals(array('class' => 'FooBar'), $filter->getFieldOptions());
     }
 


### PR DESCRIPTION
A unit test should not test methods defined outside the class under
test, even if it is a parent class, and especially if this class is
defined in another package.