### PR TITLE
Fixing dependencies problem since 3.x-dev update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/security-acl": "^2.2 || ^3.0",
         "sonata-project/exporter": "^1.3.1",
         "sonata-project/admin-bundle": "3.x-dev@dev",
-        "sonata-project/core-bundle": "^2.3.1"
+        "sonata-project/core-bundle": "3.x-dev@dev"
     },
     "require-dev": {
         "simplethings/entity-audit-bundle": "~0.1",


### PR DESCRIPTION
Since you made change on the core bundle this week end, there is a conflict between the blockbundle and the doctrine orm bundle.

They should require the 3.x-dev branch and not the 2.x anymore.

Fixes #537 