### PR TITLE
Get database value of identifier to support other identifier type classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Added missing default sort by primary key(s).
+- Allow non integer/string types as identifier (ex. uuid)

--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Datagrid;
 
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -316,10 +317,17 @@ class ProxyQuery implements ProxyQueryInterface
         }
 
         $results = $queryBuilderId->getQuery()->execute(array(), Query::HYDRATE_ARRAY);
+        $platform = $queryBuilderId->getEntityManager()->getConnection()->getDatabasePlatform();
         $idxMatrix = array();
         foreach ($results as $id) {
             foreach ($idNames as $idName) {
-                $idxMatrix[$idName][] = $id[$idName];
+                $phpValue = $id[$idName];
+                // Convert ids to database value in case of custom type
+                $fieldType = $metadata->getTypeOfField($idName);
+                $type = Type::getType($fieldType);
+                $dbValue = $type->convertToDatabaseValue($phpValue, $platform);
+
+                $idxMatrix[$idName][] = $dbValue;
             }
         }
 

--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -14,6 +14,7 @@ namespace Sonata\DoctrineORMAdminBundle\Model;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
@@ -338,19 +339,28 @@ class ModelManager implements ModelManagerInterface, LockInterface
         //    throw new \RuntimeException('Entities passed to the choice field must be managed');
         //}
 
-        $class = $this->getMetadata(ClassUtils::getClass($entity));
+        $class = ClassUtils::getClass($entity);
+        $metadata = $this->getMetadata($class);
+        $platform = $this->getEntityManager($class)->getConnection()->getDatabasePlatform();
 
         $identifiers = array();
 
-        foreach ($class->getIdentifierValues($entity) as $value) {
+        foreach ($metadata->getIdentifierValues($entity) as $name => $value) {
             if (!is_object($value)) {
                 $identifiers[] = $value;
                 continue;
             }
 
-            $class = $this->getMetadata(ClassUtils::getClass($value));
+            $fieldType = $metadata->getTypeOfField($name);
+            $type = Type::getType($fieldType);
+            if ($type) {
+                $identifiers[] = $type->convertToDatabaseValue($value, $platform);
+                continue;
+            }
 
-            foreach ($class->getIdentifierValues($value) as $value) {
+            $metadata = $this->getMetadata(ClassUtils::getClass($value));
+
+            foreach ($metadata->getIdentifierValues($value) as $value) {
                 $identifiers[] = $value;
             }
         }
@@ -376,7 +386,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
         }
 
         // the entities is not managed
-        if (!$entity /*|| !$this->getEntityManager($entity)->getUnitOfWork()->isInIdentityMap($entity) // commented for perfomance concern */) {
+        if (!$entity || !$this->getEntityManager($entity)->getUnitOfWork()->isInIdentityMap($entity)) {
             return;
         }
 

--- a/Resources/doc/reference/list_field_definition.rst
+++ b/Resources/doc/reference/list_field_definition.rst
@@ -67,6 +67,30 @@ The most important option for each field is the ``type``. The available `types` 
 
     For the `many_to_one` type, a link will be added to the related `Edit` action.
 
+.. note::
+
+    Entities with a class as identifier value (ex. `uuid <https://github.com/ramsey/uuid>`_) will resolve to the correct supported type.
+
+    .. code-block:: php
+
+        <?php
+        use Ramsey\Uuid\Uuid;
+
+        class Example
+        {
+            /**
+             * @var \Ramsey\Uuid\Uuid
+             *
+             * @ORM\Column(type="uuid")
+             * @ORM\Id
+             */
+            private $id;
+
+            public function __construct()
+            {
+                $this->id = Uuid::uuid4();
+            }
+        }
 
 If no type is set, the ``Admin`` class will use the type defined in the Doctrine mapping definition.
 

--- a/Tests/Datagrid/ProxyQueryTest.php
+++ b/Tests/Datagrid/ProxyQueryTest.php
@@ -11,15 +11,26 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Datagrid;
 
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Query\Expr\From;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
 
 class ProxyQueryTest extends \PHPUnit_Framework_TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (!Type::hasType('uuid')) {
+            Type::addType('uuid', 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType');
+        }
+    }
+
     public function dataGetFixedQueryBuilder()
     {
         return array(
-            array('aaa', 'bbb', 'id', 'id_idx', 33),
-            array('aaa', 'bbb', 'id.value', 'id_value_idx', 33),
+            array('aaa', 'bbb', 'id', 'id_idx', 33, Type::INTEGER),
+            array('aaa', 'bbb', 'id.value', 'id_value_idx', 33, Type::INTEGER),
+            array('aaa', 'bbb', 'id.uuid', 'id_uuid_idx', new NonIntegerIdentifierTestClass('80fb6f91-bba1-4d35-b3d4-e06b24494e85'), UuidType::NAME),
         );
     }
 
@@ -30,7 +41,7 @@ class ProxyQueryTest extends \PHPUnit_Framework_TestCase
      * @param $alias
      * @param $id
      */
-    public function testGetFixedQueryBuilder($class, $alias, $id, $expectedId, $value)
+    public function testGetFixedQueryBuilder($class, $alias, $id, $expectedId, $value, $identifierType)
     {
         $meta = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataInfo')
             ->disableOriginalConstructor()
@@ -38,6 +49,9 @@ class ProxyQueryTest extends \PHPUnit_Framework_TestCase
         $meta->expects($this->any())
             ->method('getIdentifierFieldNames')
             ->willReturn(array($id));
+        $meta->expects($this->any())
+            ->method('getTypeOfField')
+            ->willReturn($identifierType);
 
         $mf = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataFactory')
             ->disableOriginalConstructor()
@@ -47,12 +61,26 @@ class ProxyQueryTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($class))
             ->willReturn($meta);
 
+        $platform = $this->getMockBuilder('Doctrine\DBAL\Platforms\PostgreSqlPlatform')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $conn->expects($this->any())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
         $em->expects($this->any())
             ->method('getMetadataFactory')
             ->willReturn($mf);
+        $em->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($conn);
 
         $q = $this->getMock('PDOStatement');
         $q->expects($this->any())

--- a/Tests/Fixtures/DoctrineType/UuidType.php
+++ b/Tests/Fixtures/DoctrineType/UuidType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\StringType;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
+
+/**
+ * Mock for a custom doctrine type used in the ModelManagerTest suite
+ *
+ * @author Jeroen Thora <jeroen.thora@gmail.com>
+ */
+class UuidType extends StringType
+{
+    const NAME = 'uuid';
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return !empty($value) ? new NonIntegerIdentifierTestClass($value) : null;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return $value->toString();
+    }
+}

--- a/Tests/Fixtures/Entity/UuidEntity.php
+++ b/Tests/Fixtures/Entity/UuidEntity.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity;
+
+class UuidEntity
+{
+    private $uuid;
+
+    public function __construct($uuid)
+    {
+        $this->uuid = $uuid;
+    }
+
+    public function getId()
+    {
+        return $this->uuid;
+    }
+}

--- a/Tests/Fixtures/Util/NonIntegerIdentifierTestClass.php
+++ b/Tests/Fixtures/Util/NonIntegerIdentifierTestClass.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util;
+
+/**
+ * This class is used in the ModelManagerTest suite to test non integer/string identifiers
+ *
+ * @author Jeroen Thora <jeroen.thora@gmail.com>
+ */
+class NonIntegerIdentifierTestClass
+{
+    /**
+     * @var string
+     */
+    private $uuid;
+
+    /**
+     * @param string $uuid
+     */
+    public function __construct($uuid)
+    {
+        $this->uuid = $uuid;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toString();
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->uuid;
+    }
+}


### PR DESCRIPTION
_Resubmitted PR #523 to the correct branch after switching release strategy_

Description from #523:

> 
> I came across this issue/case when using an entity with uuid identifier and prefilled (uuid generated in the entity) identifier
> 
> Example:
> ```php
> use Ramsey\Uuid\Uuid;
> 
> class Example
> {
>     /**
>      * @var \Ramsey\Uuid\Uuid
>      *
>      * @ORM\Column(type="uuid")
>      * @ORM\Id
>      */
>     private $id;
> 
>     public function __construct()
>     {
>         $this->id = Uuid::uuid4();
>     }
> }
> ```
> 
> Problems:
> - Create page could not be opened (as the identifier class could not be resolved)
> - prefilled identifier caused the code to think it was editing an existing item
> 
> Fixes:
> - Use the database value of each type to display the entity
> - Check with the unit of work if an entity is managed or not (to check if it is create or edit)
> - I had to use the old uuid lib from Rhumsaa instead of Ramsey's to keep the tests compatible with php 5.3
> 
> I've also added tests to check this behavior. Based this pr on changes in #481.

Done:
- [x] Imported fixes from #481

Todo:
- [x] Rework tests so they don't rely on rhumsaa/uuid
- [x] Add changelog

Can someone help me a bit to get started on the mock of the uuid class and uuid doctirne type for the unittests?
