### PR TITLE
Fix lowest dependencies issue with knp-menu-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^5.3 || ^7.0",
         "doctrine/orm": "^2.3",
+        "knplabs/knp-menu-bundle": "^2.1.1",
         "symfony/form": "^2.3 || ^3.0",
         "symfony/security": "^2.3 || ^3.0",
         "symfony/console": "^2.3 || ^3.0",


### PR DESCRIPTION
The added knplabs/knp-menu-bundle requirement have to removed when issue linked below will be resolved.

https://github.com/composer/composer/issues/5355