### PR TITLE
Replace deprecated 'form' type by FormType class

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -158,7 +158,9 @@ class DatagridBuilder implements DatagridBuilderInterface
             $defaultOptions['csrf_protection'] = false;
         }
 
-        $formBuilder = $this->formFactory->createNamedBuilder('filter', 'form', array(), $defaultOptions);
+        $formtype = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                                    'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+        $formBuilder = $this->formFactory->createNamedBuilder('filter', $type, array(), $defaultOptions);
 
         return new Datagrid($admin->createQuery(), $admin->getList(), $pager, $formBuilder, $values);
     }

--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -76,7 +76,9 @@ class FormContractor implements FormContractorInterface
      */
     public function getFormBuilder($name, array $options = array())
     {
-        return $this->getFormFactory()->createNamedBuilder($name, 'form', null, $options);
+        $formtype = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                                    'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+        return $this->getFormFactory()->createNamedBuilder($name, $formtype, null, $options);
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.1](https://github.com/sonata-project/SonataAdminBundle/compare/3.0.0...3.0.1) - 2016-05-22
+## [Unreleased]
+### Added
+
 ### Fixed
+
 - Added missing default sort by primary key(s).
-- Allow non integer/string types as identifier (ex. uuid).
+- Replaced deprecated 'form' type by FormType class


### PR DESCRIPTION
Update FormContractor.php to remove use of deprecated 'form' type by using the fully qualified FormType class name.
The documentation remains unchanged.