### PR TITLE
fix #565 A column has been specified more than once in the order by list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,3 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Added missing default sort by primary key(s).
 - Allow non integer/string types as identifier (ex. uuid).
-- A column has been specified more than once in the order by list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Added missing default sort by primary key(s).
 - Allow non integer/string types as identifier (ex. uuid).
+- A column has been specified more than once in the order by list

--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -116,8 +116,8 @@ class ProxyQuery implements ProxyQueryInterface
 
         $existingOrders = [];
         /** @var Query\Expr\OrderBy $order */
-        foreach ($queryBuilder->getDQLPart('orderBy') as $order){
-            foreach ($order->getParts() as $part){
+        foreach ($queryBuilder->getDQLPart('orderBy') as $order) {
+            foreach ($order->getParts() as $part) {
                 $existingOrders[] = trim(str_replace([Criteria::DESC, Criteria::ASC], '', $part));
             }
         }

--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -114,17 +114,17 @@ class ProxyQuery implements ProxyQueryInterface
             ->getMetadataFor(current($queryBuilder->getRootEntities()))
             ->getIdentifierFieldNames();
 
-        $existingOrders = [];
+        $existingOrders = array();
         /** @var Query\Expr\OrderBy $order */
         foreach ($queryBuilder->getDQLPart('orderBy') as $order) {
             foreach ($order->getParts() as $part) {
-                $existingOrders[] = trim(str_replace([Criteria::DESC, Criteria::ASC], '', $part));
+                $existingOrders[] = trim(str_replace(array(Criteria::DESC, Criteria::ASC), '', $part));
             }
         }
 
         foreach ($identifierFields as $identifierField) {
             $order = $rootAlias.'.'.$identifierField;
-            if(!in_array($order, $existingOrders)){
+            if (!in_array($order, $existingOrders)){
                 $queryBuilder->addOrderBy(
                     $order,
                     $this->getSortOrder() // reusing the sort order is the most natural way to go

--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Datagrid;
 
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
@@ -113,15 +114,17 @@ class ProxyQuery implements ProxyQueryInterface
             ->getMetadataFor(current($queryBuilder->getRootEntities()))
             ->getIdentifierFieldNames();
 
-        $existsOrder = [];
+        $existingOrders = [];
         /** @var Query\Expr\OrderBy $order */
         foreach ($queryBuilder->getDQLPart('orderBy') as $order){
-            $existsOrder = array_merge($existsOrder, $order->getParts());
+            foreach ($order->getParts() as $part){
+                $existingOrders[] = trim(str_replace([Criteria::DESC, Criteria::ASC], '', $part));
+            }
         }
 
         foreach ($identifierFields as $identifierField) {
             $order = $rootAlias.'.'.$identifierField;
-            if(!in_array(($order.' '.$this->getSortOrder()), $existsOrder)){
+            if(!in_array($order, $existingOrders)){
                 $queryBuilder->addOrderBy(
                     $order,
                     $this->getSortOrder() // reusing the sort order is the most natural way to go

--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -124,7 +124,7 @@ class ProxyQuery implements ProxyQueryInterface
 
         foreach ($identifierFields as $identifierField) {
             $order = $rootAlias.'.'.$identifierField;
-            if (!in_array($order, $existingOrders)){
+            if (!in_array($order, $existingOrders)) {
                 $queryBuilder->addOrderBy(
                     $order,
                     $this->getSortOrder() // reusing the sort order is the most natural way to go

--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -113,11 +113,20 @@ class ProxyQuery implements ProxyQueryInterface
             ->getMetadataFor(current($queryBuilder->getRootEntities()))
             ->getIdentifierFieldNames();
 
+        $existsOrder = [];
+        /** @var Query\Expr\OrderBy $order */
+        foreach ($queryBuilder->getDQLPart('orderBy') as $order){
+            $existsOrder = array_merge($existsOrder, $order->getParts());
+        }
+
         foreach ($identifierFields as $identifierField) {
-            $queryBuilder->addOrderBy(
-                $rootAlias.'.'.$identifierField,
-                $this->getSortOrder() // reusing the sort order is the most natural way to go
-            );
+            $order = $rootAlias.'.'.$identifierField;
+            if(!in_array(($order.' '.$this->getSortOrder()), $existsOrder)){
+                $queryBuilder->addOrderBy(
+                    $order,
+                    $this->getSortOrder() // reusing the sort order is the most natural way to go
+                );
+            }
         }
 
         return $this->getFixedQueryBuilder($queryBuilder)->getQuery()->execute($params, $hydrationMode);


### PR DESCRIPTION
Closes #565

### Changelog

```markdown
### Fixed
- Avoid duplicate field in ORDER clause
```
### Subject
Fix issue #565 "A column has been specified more than once in the order by list"
