### PR TITLE
Replace deprecated 'form' type by FormType class

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -158,7 +158,9 @@ class DatagridBuilder implements DatagridBuilderInterface
             $defaultOptions['csrf_protection'] = false;
         }
 
-        $formBuilder = $this->formFactory->createNamedBuilder('filter', 'form', array(), $defaultOptions);
+        $formtype = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                                    'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+        $formBuilder = $this->formFactory->createNamedBuilder('filter', $formtype, array(), $defaultOptions);
 
         return new Datagrid($admin->createQuery(), $admin->getList(), $pager, $formBuilder, $values);
     }

--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -76,7 +76,10 @@ class FormContractor implements FormContractorInterface
      */
     public function getFormBuilder($name, array $options = array())
     {
-        return $this->getFormFactory()->createNamedBuilder($name, 'form', null, $options);
+        $formtype = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+                                    'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+
+        return $this->getFormFactory()->createNamedBuilder($name, $formtype, null, $options);
     }
 
     /**


### PR DESCRIPTION
Update FormContractor.php to remove use of deprecated 'form' type by using the fully qualified FormType class name.
Implemented in a way to keep it BC with Sf 2.3.

Documentation remains unchanged.

Test cases: none have existed so far on the mapping between form type and FormType class. Need to investigate. I wonder in how it makes sense to test a feature that is not being used anymore since this PR - any suggestions are welcome.
