### PR TITLE
Support embedded object for mapping

### DIFF
--- a/Admin/FieldDescription.php
+++ b/Admin/FieldDescription.php
@@ -98,6 +98,13 @@ class FieldDescription extends BaseFieldDescription
             $object = $this->getFieldValue($object, $parentAssociationMapping['fieldName']);
         }
 
+        $fieldMapping = $this->getFieldMapping();
+        // Support embedded object for mapping
+        // Ref: http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/tutorials/embeddables.html
+        if (isset($fieldMapping['declaredField'])) {
+            $object = $this->getFieldValue($object, $fieldMapping['declaredField']);
+        }
+
         return $this->getFieldValue($object, $this->fieldName);
     }
 }

--- a/Resources/doc/reference/list_field_definition.rst
+++ b/Resources/doc/reference/list_field_definition.rst
@@ -131,7 +131,7 @@ Advance Usage
 Displaying sub entity properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you need to display only one field from a sub entity in a dedicated column, you can simply use the dot-separated notation:
+If you need to display only one field from a sub entity or embedded object in a dedicated column, you can simply use the dot-separated notation:
 
 .. note::
     This only makes sense when the prefix path is made of entities, not collections.

--- a/Resources/doc/tutorial/creating_your_first_admin_class/defining_admin_class.rst
+++ b/Resources/doc/tutorial/creating_your_first_admin_class/defining_admin_class.rst
@@ -44,6 +44,7 @@ First, you need to create an `Admin/PostAdmin.php` file:
             $showMapper
                 ->add('enabled')
                 ->add('title')
+                ->add('author.name')
                 ->add('abstract')
                 ->add('content')
                 ->add('tags')
@@ -85,6 +86,7 @@ First, you need to create an `Admin/PostAdmin.php` file:
         {
             $listMapper
                 ->addIdentifier('title')
+                ->add('author.name')
                 ->add('enabled')
                 ->add('abstract')
                 ->add('content')

--- a/Resources/doc/tutorial/creating_your_first_admin_class/defining_entities.rst
+++ b/Resources/doc/tutorial/creating_your_first_admin_class/defining_entities.rst
@@ -16,6 +16,38 @@ Model definition
 
 Now we need to create the entities that will be used in the blog:
 
+Author
+~~~~~~
+
+.. code-block:: php
+
+    <?php
+    // src/Tutorial/BlogBundle/Entity/Author.php
+    namespace Tutorial\BlogBundle\Entity;
+
+    use Doctrine\ORM\Mapping as ORM;
+
+    /**
+     * @ORM\Embeddable
+     */
+    class Author
+    {
+        /**
+         * @ORM\Column(type = "string")
+         */
+        protected $name;
+
+        public function __construct($name)
+        {
+            $this->name = $name;
+        }
+
+        public function getName()
+        {
+            return $this->name;
+        }
+    }
+
 Post
 ~~~~
 
@@ -81,16 +113,27 @@ Post
          */
         protected $tags;
 
+        /**
+         * @ORM\Embedded(class="Author")
+         */
+        protected $author;
+
         public function __construct()
         {
             $this->tags     = new \Doctrine\Common\Collections\ArrayCollection();
             $this->comments = new \Doctrine\Common\Collections\ArrayCollection();
             $this->created_at = new \DateTime("now");
+            $this->author = new Author('admin');
         }
 
         public function __toString()
         {
             return $this->getTitle();
+        }
+
+        public function getAuthor()
+        {
+            return $this->author;
         }
     }
 

--- a/Tests/Admin/FieldDescriptionTest.php
+++ b/Tests/Admin/FieldDescriptionTest.php
@@ -330,4 +330,26 @@ class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($fieldMapping, $field->getFieldMapping());
     }
+
+    public function testGetValueForEmbeddedObject()
+    {
+        $mockedEmbeddedObject = $this->getMock('MockedTestObject', array('myMethod'));
+        $mockedEmbeddedObject->expects($this->once())
+                    ->method('myMethod')
+                    ->will($this->returnValue('myMethodValue'));
+
+        $mockedObject = $this->getMock('MockedTestObject', array('getMyEmbeddedObject'));
+        $mockedObject->expects($this->once())
+            ->method('getMyEmbeddedObject')
+            ->will($this->returnValue($mockedEmbeddedObject));
+
+        $field = new FieldDescription();
+        $field->setFieldMapping(array(
+            'declaredField' => 'myEmbeddedObject', 'type' => 'string', 'fieldName' => 'myEmbeddedObject.myMethod',
+        ));
+        $field->setFieldName('myMethod');
+        $field->setOption('code', 'myMethod');
+
+        $this->assertEquals('myMethodValue', $field->getValue($mockedObject));
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Support embedded object for mapping
```

### Subject
This PR allow to use embedded object in the show mapper. 
```php
class Foo {
    public function getValue()
    {
        return 'myValue';
    }
}

class Bar {
    public function getFoo()
    {
        return $this->foo;
    }
}
```
``` php
protected function configureShowFields(ShowMapper $showMapper)
{
    $showMapper
        ->add('foo.value');
}
```
The FieldDescription method getValue ignore the embedded object and do 
``` php
$bar = new Bar();
$bar->getValue()
```
With my PR the getter call is on the embedded object and not on the parent object.
``` php
$bar->getFoo()->getValue()
```
