### PR TITLE
Ensure DoctrineType is available before using it

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -333,13 +333,11 @@ class ProxyQuery implements ProxyQueryInterface
         $idxMatrix = array();
         foreach ($results as $id) {
             foreach ($idNames as $idName) {
-                $phpValue = $id[$idName];
-                // Convert ids to database value in case of custom type
+                // Convert ids to database value in case of custom type, if provided.
                 $fieldType = $metadata->getTypeOfField($idName);
-                $type = Type::getType($fieldType);
-                $dbValue = $type->convertToDatabaseValue($phpValue, $platform);
-
-                $idxMatrix[$idName][] = $dbValue;
+                $idxMatrix[$idName][] = $fieldType && Type::hasType($fieldType)
+                    ? Type::getType($fieldType)->convertToDatabaseValue($id[$idName], $platform)
+                    : $id[$idName];
             }
         }
 

--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -352,7 +352,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
             }
 
             $fieldType = $metadata->getTypeOfField($name);
-            $type = Type::getType($fieldType);
+            $type = $fieldType && Type::hasType($fieldType) ? Type::getType($fieldType) : null;
             if ($type) {
                 $identifiers[] = $type->convertToDatabaseValue($value, $platform);
                 continue;

--- a/Tests/Datagrid/ProxyQueryTest.php
+++ b/Tests/Datagrid/ProxyQueryTest.php
@@ -30,6 +30,7 @@ class ProxyQueryTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('aaa', 'bbb', 'id', 'id_idx', 33, Type::INTEGER),
+            array('aaa', 'bbb', 'associatedId', 'associatedId_idx', 33, null),
             array('aaa', 'bbb', 'id.value', 'id_value_idx', 33, Type::INTEGER),
             array('aaa', 'bbb', 'id.uuid', 'id_uuid_idx', new NonIntegerIdentifierTestClass('80fb6f91-bba1-4d35-b3d4-e06b24494e85'), UuidType::NAME),
         );

--- a/Tests/Fixtures/Entity/AssociatedEntity.php
+++ b/Tests/Fixtures/Entity/AssociatedEntity.php
@@ -5,7 +5,25 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity;
 class AssociatedEntity
 {
     /**
-     * @var string
+     * @var int
      */
     protected $plainField;
+
+    /**
+     * AssociatedEntity constructor.
+     *
+     * @param int $plainField
+     */
+    public function __construct($plainField = null)
+    {
+        $this->plainField = $plainField;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPlainField()
+    {
+        return $this->plainField;
+    }
 }

--- a/Tests/Fixtures/Entity/ContainerEntity.php
+++ b/Tests/Fixtures/Entity/ContainerEntity.php
@@ -28,4 +28,12 @@ class ContainerEntity
         $this->associatedEntity = $associatedEntity;
         $this->embeddedEntity = $embeddedEntity;
     }
+
+    /**
+     * @return AssociatedEntity
+     */
+    public function getAssociatedEntity()
+    {
+        return $this->associatedEntity;
+    }
 }

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -348,6 +348,61 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($entity->getId()->toString(), $result[0]);
     }
 
+    public function testAssociationIdentifierType()
+    {
+        $entity = new ContainerEntity(new AssociatedEntity(42), new EmbeddedEntity());
+
+        $meta = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataInfo')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $meta->expects($this->any())
+            ->method('getIdentifierValues')
+            ->willReturn(array($entity->getAssociatedEntity()->getPlainField()));
+        $meta->expects($this->any())
+            ->method('getTypeOfField')
+            ->willReturn(null);
+
+        $mf = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mf->expects($this->any())
+            ->method('getMetadataFor')
+            ->willReturn($meta);
+
+        $platform = $this->getMockBuilder('Doctrine\DBAL\Platforms\PostgreSqlPlatform')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $conn->expects($this->any())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $em->expects($this->any())
+            ->method('getMetadataFactory')
+            ->willReturn($mf);
+        $em->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($conn);
+
+        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $registry->expects($this->any())
+            ->method('getManagerForClass')
+            ->willReturn($em);
+
+        $manager = new ModelManager($registry);
+        $result = $manager->getIdentifierValues($entity);
+
+        $this->assertSame(42, $result[0]);
+    }
+
     private function getMetadata($class, $isVersioned)
     {
         $metadata = new ClassMetadata($class);


### PR DESCRIPTION
Closes #585

### Changelog

```markdown
### Fixed
- Failing identifier management for relations as id
```

### Subject

PR #547 brought other identifier types support.

This uses `Type::getType` method with `ClassMetada::getTypeOfField` returned value.

`ClassMetada::getTypeOfField` can return null and then `Type::getType` throw an exception.

This can be reproduced with an entity having a relation as an identifier.

Plus, the given type field may be not mapper under Type map.

Checking `ClassMetada::getTypeOfField` return value and use `Type::hasType` before solve the issue.