### PR TITLE
Replace deprecated 'form' type by FormType class

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -22,7 +22,7 @@ use Sonata\AdminBundle\Datagrid\SimplePager;
 use Sonata\AdminBundle\Filter\FilterFactoryInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
-use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormFactoryInterface;
 
 class DatagridBuilder implements DatagridBuilderInterface
 {
@@ -32,7 +32,7 @@ class DatagridBuilder implements DatagridBuilderInterface
     protected $filterFactory;
 
     /**
-     * @var FormFactory
+     * @var FormFactoryInterface
      */
     protected $formFactory;
 
@@ -47,12 +47,12 @@ class DatagridBuilder implements DatagridBuilderInterface
     protected $csrfTokenEnabled;
 
     /**
-     * @param FormFactory            $formFactory
+     * @param FormFactoryInterface   $formFactory
      * @param FilterFactoryInterface $filterFactory
      * @param TypeGuesserInterface   $guesser
      * @param bool                   $csrfTokenEnabled
      */
-    public function __construct(FormFactory $formFactory, FilterFactoryInterface $filterFactory, TypeGuesserInterface $guesser, $csrfTokenEnabled = true)
+    public function __construct(FormFactoryInterface $formFactory, FilterFactoryInterface $filterFactory, TypeGuesserInterface $guesser, $csrfTokenEnabled = true)
     {
         $this->formFactory = $formFactory;
         $this->filterFactory = $filterFactory;

--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -158,7 +158,10 @@ class DatagridBuilder implements DatagridBuilderInterface
             $defaultOptions['csrf_protection'] = false;
         }
 
-        $formBuilder = $this->formFactory->createNamedBuilder('filter', 'form', array(), $defaultOptions);
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $formType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+        $formBuilder = $this->formFactory->createNamedBuilder('filter', $formType, array(), $defaultOptions);
 
         return new Datagrid($admin->createQuery(), $admin->getList(), $pager, $formBuilder, $values);
     }

--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -76,7 +76,11 @@ class FormContractor implements FormContractorInterface
      */
     public function getFormBuilder($name, array $options = array())
     {
-        return $this->getFormFactory()->createNamedBuilder($name, 'form', null, $options);
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $formType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+
+        return $this->getFormFactory()->createNamedBuilder($name, $formType, null, $options);
     }
 
     /**

--- a/Tests/Builder/DatagridBuilderTest.php
+++ b/Tests/Builder/DatagridBuilderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
+
+use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Filter\FilterFactoryInterface;
+use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\DoctrineORMAdminBundle\Builder\DatagridBuilder;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class DatagridBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TypeGuesserInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $typeGuesser;
+
+    /**
+     * @var DatagridBuilder
+     */
+    protected $datagridBuilder;
+    /**
+     * @var FormFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $formFactory;
+
+    /**
+     * @var FilterFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $filterFactory;
+
+    protected function setUp()
+    {
+        $this->formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $this->filterFactory = $this->getMock('Sonata\AdminBundle\Filter\FilterFactoryInterface');
+        $this->typeGuesser = $this->getMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+
+        $this->datagridBuilder = new DatagridBuilder($this->formFactory, $this->filterFactory, $this->typeGuesser);
+    }
+
+    public function testGetBaseDatagrid()
+    {
+        $admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AbstractAdmin')
+            ->disableOriginalConstructor()->getMock();
+        $admin->expects($this->once())->method('getPagerType')->willReturn(Pager::TYPE_SIMPLE);
+        $admin->expects($this->once())->method('getClass')->willReturn('Foo\Bar');
+        $admin->expects($this->once())->method('createQuery')
+            ->willReturn($this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+        $admin->expects($this->once())->method('getList')
+            ->willReturn($this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection'));
+
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager->expects($this->once())->method('getIdentifierFieldNames')->willReturn(array('id'));
+        $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
+
+        $this->formFactory->expects($this->once())->method('createNamedBuilder')
+            ->willReturn($this->getMock('Symfony\Component\Form\FormBuilderInterface'));
+
+        $this->assertInstanceOf('Sonata\AdminBundle\Datagrid\Datagrid', $this->datagridBuilder->getBaseDatagrid($admin));
+    }
+}

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
+
+use Sonata\DoctrineORMAdminBundle\Builder\FormContractor;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class FormContractorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FormFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $formFactory;
+
+    /**
+     * @var FormContractor
+     */
+    private $formContractor;
+
+    protected function setUp()
+    {
+        $this->formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+
+        $this->formContractor = new FormContractor($this->formFactory);
+    }
+
+    public function testGetFormBuilder()
+    {
+        $this->formFactory->expects($this->once())->method('createNamedBuilder')
+            ->willReturn($this->getMock('Symfony\Component\Form\FormBuilderInterface'));
+
+        $this->assertInstanceOf(
+            'Symfony\Component\Form\FormBuilderInterface',
+            $this->formContractor->getFormBuilder('test', array('foo' => 'bar'))
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/framework-bundle": "^2.2 || ^3.0",
         "symfony/security-acl": "^2.2 || ^3.0",
         "sonata-project/exporter": "^1.3.1",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Replaces #587 

### Changelog
```markdown
### Fixed
- Deprecated usage of `form` type name
```
