### PR TITLE
Fix wrong property name on FormContractor

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -20,9 +20,16 @@ use Symfony\Component\Form\FormFactoryInterface;
 class FormContractor implements FormContractorInterface
 {
     /**
+     * @deprecated since version 3.x, to be removed in 4.0
+     *
      * @var FormFactoryInterface
      */
     protected $fieldFactory;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
 
     /**
      * @param FormFactoryInterface $formFactory


### PR DESCRIPTION
### Changelog

```markdown
### Fixed
- Fix wrong property name on FormContractor
```

### Subject

The other is never used. As a protected one, I keep it for BC.

Because of the deprecation, this should be delivered as a new minor.
