### PR TITLE
Fix not working filters on model list popup

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -34,6 +34,10 @@ This code manage the many-to-[one|many] association field popup
         initialize_popup_{{ id }}();
 
         var target = jQuery(this);
+        
+        if (target.attr('href').length === 0 || target.attr('href') === '#') {
+            return;
+        }
 
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
### Changelog

```markdown
### Fixed
- Create form is shown instead of filters on `sonata_type_model_list` popup 
```

### Subject

When using `sonata_type_model_list`, dropdown filters are not working inside the list popup due to an AJAX call. This function is catching that website click, so we must assure that the click href contains something different than *empty* and *#* to make the AJAX request. `return` is needed so other JS files are able to catch that event. For example: Bootstrap dropdown (filters, as seen in previous lines).