### PR TITLE
adds support for FQCN form type referencing to FormContractor

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -98,20 +98,32 @@ class FormContractor implements FormContractorInterface
         $options = array();
         $options['sonata_field_description'] = $fieldDescription;
 
-        if (in_array($type, array('sonata_type_model', 'sonata_type_model_list', 'sonata_type_model_hidden', 'sonata_type_model_autocomplete'))) {
-            if ($fieldDescription->getOption('edit') == 'list') {
+        // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony <2.8
+        if (in_array($type, array(
+            'sonata_type_model',
+            'Sonata\AdminBundle\Form\Type\ModelType',
+            'sonata_type_model_list',
+            'Sonata\AdminBundle\Form\Type\ModelTypeList',
+            'sonata_type_model_hidden',
+            'Sonata\AdminBundle\Form\Type\ModelHiddenType',
+            'sonata_type_model_autocomplete',
+            'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
+        ), true)) {
+            if ($fieldDescription->getOption('edit') === 'list') {
                 throw new \LogicException('The ``sonata_type_model`` type does not accept an ``edit`` option anymore, please review the UPGRADE-2.1.md file from the SonataAdminBundle');
             }
 
             $options['class'] = $fieldDescription->getTargetEntity();
             $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
 
-            if ($type == 'sonata_type_model_autocomplete') {
+            if ($type === 'sonata_type_model_autocomplete'
+                || $type === 'Sonata\AdminBundle\Form\Type\ModelAutocompleteType'
+            ) {
                 if (!$fieldDescription->getAssociationAdmin()) {
                     throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity: `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
                 }
             }
-        } elseif ($type == 'sonata_type_admin') {
+        } elseif ($type === 'sonata_type_admin' || $type === 'Sonata\AdminBundle\Form\Type\AdminType') {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
             }
@@ -126,7 +138,7 @@ class FormContractor implements FormContractorInterface
 
             $options['data_class'] = $fieldDescription->getAssociationAdmin()->getClass();
             $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
-        } elseif ($type == 'sonata_type_collection') {
+        } elseif ($type === 'sonata_type_collection' || $type === 'Sonata\CoreBundle\Form\Type\CollectionType') {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
             }

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
 
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\DoctrineORMAdminBundle\Builder\FormContractor;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -31,7 +32,7 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $this->formFactory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
 
         $this->formContractor = new FormContractor($this->formFactory);
     }
@@ -45,5 +46,70 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
             'Symfony\Component\Form\FormBuilderInterface',
             $this->formContractor->getFormBuilder('test', array('foo' => 'bar'))
         );
+    }
+
+    public function testDefaultOptionsForSonataFormTypes()
+    {
+        $admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminInterface')->getMock();
+        $modelManager = $this->getMockBuilder('Sonata\AdminBundle\Model\ModelManagerInterface')->getMock();
+        $modelClass = 'FooEntity';
+
+        $admin->method('getModelManager')->willReturn($modelManager);
+        $admin->method('getClass')->willReturn($modelClass);
+
+        $fieldDescription = $this->getMockBuilder('Sonata\AdminBundle\Admin\FieldDescriptionInterface')->getMock();
+        $fieldDescription->method('getAdmin')->willReturn($admin);
+        $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
+        $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
+
+        $modelTypes = array(
+            'sonata_type_model',
+            'sonata_type_model_list',
+            'sonata_type_model_hidden',
+            'sonata_type_model_autocomplete',
+        );
+        $adminTypes = array('sonata_type_admin');
+        $collectionTypes = array('sonata_type_collection');
+        // NEXT_MAJOR: Use only FQCNs when dropping support for Symfony <2.8
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            array_push(
+                $modelTypes,
+                'Sonata\AdminBundle\Form\Type\ModelType',
+                'Sonata\AdminBundle\Form\Type\ModelTypeList',
+                'Sonata\AdminBundle\Form\Type\ModelHiddenType',
+                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType'
+            );
+            $adminTypes[] = 'Sonata\AdminBundle\Form\Type\AdminType';
+            $collectionTypes[] = 'Sonata\CoreBundle\Form\Type\CollectionType';
+        }
+
+        // model types
+        foreach ($modelTypes as $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
+            $this->assertSame($fieldDescription, $options['sonata_field_description']);
+            $this->assertSame($modelClass, $options['class']);
+            $this->assertSame($modelManager, $options['model_manager']);
+        }
+
+        // admin type
+        $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::ONE_TO_ONE);
+        foreach ($adminTypes as $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
+            $this->assertSame($fieldDescription, $options['sonata_field_description']);
+            $this->assertSame($modelClass, $options['data_class']);
+            $this->assertSame(false, $options['btn_add']);
+            $this->assertSame(false, $options['delete']);
+        }
+
+        // collection type
+        $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::ONE_TO_MANY);
+        foreach ($collectionTypes as $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
+            $this->assertSame($fieldDescription, $options['sonata_field_description']);
+            $this->assertSame('sonata_type_admin', $options['type']);
+            $this->assertSame(true, $options['modifiable']);
+            $this->assertSame($fieldDescription, $options['type_options']['sonata_field_description']);
+            $this->assertSame($modelClass, $options['type_options']['data_class']);
+        }
     }
 }


### PR DESCRIPTION
I am targetting this branch, because this is a BC bugfix

Will close https://github.com/sonata-project/SonataAdminBundle/issues/3976 when [doctrine-mongodb-admin-bundle PR](https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/178) is also merged.

## Changelog

```markdown
### Fixed
- Fix `FormContractor::getDefaultOptions` not checking against form types FQCNs
```

## Subject

`FormContractor::getDefaultOptions` didn't check against form types FQCNs, causing the default options not to be set when using the Symfony 3 way:
```php
$formMapper->add('foo', ModelType::class);
```
See related admin-bundle issue at https://github.com/sonata-project/SonataAdminBundle/issues/3976