### PR TITLE
Allow not mapped field to use `admin_code` option

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -71,21 +71,6 @@ class FormContractor implements FormContractorInterface
     }
 
     /**
-     * @param FieldDescriptionInterface $fieldDescription
-     *
-     * @return bool
-     */
-    private function hasAssociation(FieldDescriptionInterface $fieldDescription)
-    {
-        return in_array($fieldDescription->getMappingType(), [
-            ClassMetadataInfo::ONE_TO_MANY,
-            ClassMetadataInfo::MANY_TO_MANY,
-            ClassMetadataInfo::MANY_TO_ONE,
-            ClassMetadataInfo::ONE_TO_ONE
-        ]);
-    }
-
-    /**
      * @return FormFactoryInterface
      */
     public function getFormFactory()
@@ -174,5 +159,20 @@ class FormContractor implements FormContractorInterface
         }
 
         return $options;
+    }
+
+    /**
+     * @param FieldDescriptionInterface $fieldDescription
+     *
+     * @return bool
+     */
+    private function hasAssociation(FieldDescriptionInterface $fieldDescription)
+    {
+        return in_array($fieldDescription->getMappingType(), array(
+            ClassMetadataInfo::ONE_TO_MANY,
+            ClassMetadataInfo::MANY_TO_MANY,
+            ClassMetadataInfo::MANY_TO_ONE,
+            ClassMetadataInfo::ONE_TO_ONE,
+        ));
     }
 }

--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -65,9 +65,24 @@ class FormContractor implements FormContractorInterface
         $fieldDescription->setAdmin($admin);
         $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'standard'));
 
-        if (in_array($fieldDescription->getMappingType(), array(ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY, ClassMetadataInfo::MANY_TO_ONE, ClassMetadataInfo::ONE_TO_ONE))) {
+        if ($this->hasAssociation($fieldDescription) || $fieldDescription->getOption('admin_code')) {
             $admin->attachAdminClass($fieldDescription);
         }
+    }
+
+    /**
+     * @param FieldDescriptionInterface $fieldDescription
+     *
+     * @return bool
+     */
+    private function hasAssociation(FieldDescriptionInterface $fieldDescription)
+    {
+        return in_array($fieldDescription->getMappingType(), [
+            ClassMetadataInfo::ONE_TO_MANY,
+            ClassMetadataInfo::MANY_TO_MANY,
+            ClassMetadataInfo::MANY_TO_ONE,
+            ClassMetadataInfo::ONE_TO_ONE
+        ]);
     }
 
     /**

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -142,5 +142,4 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
         // When
         $this->formContractor->fixFieldDescription($admin, $fieldDescription);
     }
-
 }

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -112,4 +112,35 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
             $this->assertSame($modelClass, $options['type_options']['data_class']);
         }
     }
+
+    public function testAdminClassAttachForNotMappedField()
+    {
+        // Given
+        $modelManager = $this->getMockBuilder('Sonata\DoctrineORMAdminBundle\Model\ModelManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $modelManager->method('hasMetadata')->willReturn(false);
+
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->method('getModelManager')->willReturn($modelManager);
+
+        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription->method('getMappingType')->willReturn('simple');
+        $fieldDescription->method('getType')->willReturn('sonata_type_model_list');
+        $fieldDescription->method('getOption')->with($this->logicalOr(
+            $this->equalTo('edit'),
+            $this->equalTo('admin_code')
+        ))->willReturn('sonata.admin.code');
+
+        // Then
+        $admin
+            ->expects($this->once())
+            ->method('attachAdminClass')
+            ->with($fieldDescription)
+        ;
+
+        // When
+        $this->formContractor->fixFieldDescription($admin, $fieldDescription);
+    }
+
 }


### PR DESCRIPTION
I am targetting this branch, because it is a bug fix.

## Changelog

### Fixed

- fixed: allow not mapped field to use `admin_code` option for `sonata_type_model_list`

## Subject

When you have field with option `mapped => false`, example:

```php
                   ->add('company', 'sonata_type_model_list', [
                        'btn_add' => false,
                        'btn_delete' => false,
                        'mapped' => false,
                        'class' => Company::class,
                    ], [
                        'admin_code' => 'sonata.admin.company',
                    ])
```



This error occurs:
```
Impossible to invoke a method ("id") on a null variable in SonataDoctrineORMAdminBundle:Form:form_admin_fields.html.twig at line 59
```

This patch fixes error and allow not mapped filed work with `sonata_type_model_list`.