### PR TITLE
Fixed FormContractor for new ModelListType

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -104,6 +104,7 @@ class FormContractor implements FormContractorInterface
             'Sonata\AdminBundle\Form\Type\ModelType',
             'sonata_type_model_list',
             'Sonata\AdminBundle\Form\Type\ModelTypeList',
+            'Sonata\AdminBundle\Form\Type\ModelListType',
             'sonata_type_model_hidden',
             'Sonata\AdminBundle\Form\Type\ModelHiddenType',
             'sonata_type_model_autocomplete',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `FormContractor` supports the new `Sonata\AdminBundle\Form\Type\ModelListType`
```

## Subject

This is a fix, to support the new `ModelListType` type too.

Refs https://github.com/sonata-project/SonataAdminBundle/pull/3978

