### PR TITLE
Ability to use the date range filter with an open end on either side

### DIFF
--- a/Filter/AbstractDateFilter.php
+++ b/Filter/AbstractDateFilter.php
@@ -47,7 +47,7 @@ abstract class AbstractDateFilter extends Filter
                 return;
             }
 
-            if (!$data['value']['start'] || !$data['value']['end']) {
+            if (!$data['value']['start'] && !$data['value']['end']) {
                 return;
             }
 
@@ -76,12 +76,22 @@ abstract class AbstractDateFilter extends Filter
             if ($data['type'] == DateRangeType::TYPE_NOT_BETWEEN) {
                 $this->applyWhere($queryBuilder, sprintf('%s.%s < :%s OR %s.%s > :%s', $alias, $field, $startDateParameterName, $alias, $field, $endDateParameterName));
             } else {
-                $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, '>=', $startDateParameterName));
-                $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, '<=', $endDateParameterName));
+                if ($data['value']['start']) {
+                    $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, '>=', $startDateParameterName));
+                }
+
+                if ($data['value']['end']) {
+                    $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, '<=', $endDateParameterName));
+                }
             }
 
-            $queryBuilder->setParameter($startDateParameterName, $data['value']['start']);
-            $queryBuilder->setParameter($endDateParameterName, $data['value']['end']);
+            if ($data['value']['start']) {
+                $queryBuilder->setParameter($startDateParameterName, $data['value']['start']);
+            }
+
+            if ($data['value']['end']) {
+                $queryBuilder->setParameter($endDateParameterName, $data['value']['end']);
+            }
         } else {
             if (!$data['value']) {
                 return;

--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -90,6 +90,19 @@ This form type requires ``property`` option. See documentation of ``sonata_type_
         ;
     }
 
+doctrine_orm_date_range
+-----------------------
+The ``doctrine_orm_date_range`` filter renders two fields to filter all records between two dates.
+If only one date is set it will filter for all records until or since the given date.
+
+.. code-block:: php
+
+    // ArticleAdmin
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper->add('created', 'doctrine_orm_date_range');
+    }
+
 Timestamps
 ----------
 

--- a/Tests/Filter/DateRangeFilterTest.php
+++ b/Tests/Filter/DateRangeFilterTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
+
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Filter\DateRangeFilter;
+
+/**
+ * @author Patrick Landolt <patrick.landolt@artack.ch>
+ */
+class DateRangeFilterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFilterEmpty()
+    {
+        $filter = new DateRangeFilter();
+        $filter->initialize('field_name', array('field_options' => array('class' => 'FooBar')));
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $filter->filter($builder, 'alias', 'field', null);
+        $filter->filter($builder, 'alias', 'field', '');
+        $filter->filter($builder, 'alias', 'field', 'test');
+        $filter->filter($builder, 'alias', 'field', false);
+
+        $filter->filter($builder, 'alias', 'field', array());
+        $filter->filter($builder, 'alias', 'field', array(null, 'test'));
+        $filter->filter($builder, 'alias', 'field', array('type' => null, 'value' => array()));
+        $filter->filter($builder, 'alias', 'field', array(
+            'type' => null,
+            'value' => array('start' => null, 'end' => null),
+        ));
+        $filter->filter($builder, 'alias', 'field', array(
+            'type' => null,
+            'value' => array('start' => '', 'end' => ''),
+        ));
+
+        $this->assertSame(array(), $builder->query);
+        $this->assertFalse($filter->isActive());
+    }
+
+    public function testFilterStartDateAndEndDate()
+    {
+        $filter = new DateRangeFilter();
+        $filter->initialize('field_name', array('field_options' => array('class' => 'FooBar')));
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $startDateTime = new \DateTime('2016-08-01');
+        $endDateTime = new \DateTime('2016-08-31');
+
+        $filter->filter($builder, 'alias', 'field', array(
+            'type' => null,
+            'value' => array(
+                'start' => $startDateTime,
+                'end' => $endDateTime,
+            ),
+        ));
+
+        $this->assertSame(array('alias.field >= :field_name_0', 'alias.field <= :field_name_1'), $builder->query);
+        $this->assertSame(array(
+            'field_name_0' => $startDateTime,
+            'field_name_1' => $endDateTime,
+        ), $builder->parameters);
+        $this->assertTrue($filter->isActive());
+    }
+
+    public function testFilterStartDate()
+    {
+        $filter = new DateRangeFilter();
+        $filter->initialize('field_name', array('field_options' => array('class' => 'FooBar')));
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $startDateTime = new \DateTime('2016-08-01');
+
+        $filter->filter($builder, 'alias', 'field', array(
+            'type' => null,
+            'value' => array(
+                'start' => $startDateTime,
+                'end' => '',
+            ),
+        ));
+
+        $this->assertSame(array('alias.field >= :field_name_0'), $builder->query);
+        $this->assertSame(array('field_name_0' => $startDateTime), $builder->parameters);
+        $this->assertTrue($filter->isActive());
+    }
+
+    public function testFilterEndDate()
+    {
+        $filter = new DateRangeFilter();
+        $filter->initialize('field_name', array('field_options' => array('class' => 'FooBar')));
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $endDateTime = new \DateTime('2016-08-31');
+
+        $filter->filter($builder, 'alias', 'field', array(
+            'type' => null,
+            'value' => array(
+                'start' => '',
+                'end' => $endDateTime,
+            ),
+        ));
+
+        $this->assertSame(array('alias.field <= :field_name_1'), $builder->query);
+        $this->assertSame(array('field_name_1' => $endDateTime), $builder->parameters);
+        $this->assertTrue($filter->isActive());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch

    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #408

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Date range filter can now be used with only one side defined
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

It is now possible to only set one date for a range. With this it will filter to all records until or from the given date.
