### PR TITLE
Adds missing translation of 'Delete' in edit view

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -106,7 +106,7 @@ file that was distributed with this source code.
                                 </div>
 
                                 {% if nested_group_field['_delete'] is defined %}
-                                    {{ form_row(nested_group_field['_delete']) }}
+                                    {{ form_row(nested_group_field['_delete'],  { 'label': ('action_delete'|trans({}, 'SonataAdminBundle')) } ) }}
                                 {% endif %}
                             </div>
                         {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Adds missing translation of 'Delete' in edit view
```

## Subject

The `Delete` label wasn't translated.

