### PR TITLE
fix for FilterTypeGuesser for ManyToOne relations, it conflicts with …

### DIFF
--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -50,8 +50,8 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                     $options['operator_options'] = array();
 
                     $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            			'Symfony\Bridge\Doctrine\Form\Type\EntityType' :
-            			'entity';
+                        'Symfony\Bridge\Doctrine\Form\Type\EntityType' :
+                        'entity';
                     $options['field_options'] = array(
                         'class' => $mapping['targetEntity'],
                     );

--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -49,7 +49,9 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                     $options['operator_type'] = 'sonata_type_equal';
                     $options['operator_options'] = array();
 
-                    $options['field_type'] = 'entity';
+                    $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            			'Symfony\Bridge\Doctrine\Form\Type\EntityType' :
+            			'entity';
                     $options['field_options'] = array(
                         'class' => $mapping['targetEntity'],
                     );


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it causes conflicts with current versions of symfony.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes https://github.com/sonata-project/SonataAdminBundle/issues/4052

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- The way `FilterTypeGuesser` resolves ManyToOne relations, so it supports the new way symfony defines form types (FQCN)
```

## Subject

<!-- Describe your Pull Request content here -->

It changes  the form FilterTypeGuesser.php resolves ManyToOne relations, so it supports the new way symfony defines types (FQCN). 