### PR TITLE
Improved support for symfony3

### DIFF
--- a/Filter/AbstractDateFilter.php
+++ b/Filter/AbstractDateFilter.php
@@ -165,6 +165,17 @@ abstract class AbstractDateFilter extends Filter
             $name .= '_range';
         }
 
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $classnames = array(
+                'sonata_type_filter_date' => 'Sonata\AdminBundle\Form\Type\Filter\DateType',
+                'sonata_type_filter_date_range' => 'Sonata\AdminBundle\Form\Type\Filter\DateRangeType',
+                'sonata_type_filter_datetime' => 'Sonata\AdminBundle\Form\Type\Filter\DateTimeType',
+                'sonata_type_filter_datetime_range' => 'Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType',
+            );
+            $name = $classnames[$name];
+        }
+
         return array($name, array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),

--- a/Filter/BooleanFilter.php
+++ b/Filter/BooleanFilter.php
@@ -66,7 +66,12 @@ class BooleanFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('sonata_type_filter_default', array(
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
+            : 'sonata_type_filter_default';
+
+        return array($type, array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => 'hidden',

--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -45,7 +45,12 @@ class CallbackFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('sonata_type_filter_default', array(
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
+            : 'sonata_type_filter_default';
+
+        return array($type, array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/Filter/ChoiceFilter.php
+++ b/Filter/ChoiceFilter.php
@@ -76,7 +76,12 @@ class ChoiceFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('sonata_type_filter_default', array(
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
+            : 'sonata_type_filter_default';
+
+        return array($type, array(
             'operator_type' => 'sonata_type_equal',
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),

--- a/Filter/ClassFilter.php
+++ b/Filter/ClassFilter.php
@@ -76,7 +76,12 @@ class ClassFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('sonata_type_filter_default', array(
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
+            : 'sonata_type_filter_default';
+
+        return array($type, array(
             'operator_type' => 'sonata_type_equal',
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),

--- a/Filter/ModelAutocompleteFilter.php
+++ b/Filter/ModelAutocompleteFilter.php
@@ -57,7 +57,12 @@ class ModelAutocompleteFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('sonata_type_filter_default', array(
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
+            : 'sonata_type_filter_default';
+
+        return array($type, array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -59,7 +59,12 @@ class ModelFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('sonata_type_filter_default', array(
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
+            : 'sonata_type_filter_default';
+
+        return array($type, array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/Filter/NumberFilter.php
+++ b/Filter/NumberFilter.php
@@ -52,7 +52,12 @@ class NumberFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('sonata_type_filter_number', array(
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\NumberType'
+            : 'sonata_type_filter_number';
+
+        return array($type, array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -65,7 +65,12 @@ class StringFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('sonata_type_filter_choice', array(
+        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
+        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType'
+            : 'sonata_type_filter_choice';
+
+        return array($type, array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Use class names for filters when using symfony 2.8+
```
## Subject

This will reduce some deprecation warnings and supports the new class usage for forms.
