### PR TITLE
[DO NOT MERGE]Avoid two last versions of phpunit mock objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 	git diff --exit-code
 
 test:
-	phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
+	vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
 
 docs:
 	cd Resources/doc && sphinx-build -W -b html -d _build/doctrees . _build/html

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,8 @@
     },
     "require-dev": {
         "knplabs/knp-menu-bundle": "^2.1.1",
+        "phpunit/phpunit": "^4.7 || ^5.5",
+        "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
         "simplethings/entity-audit-bundle": "0.1 - 0.9",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"


### PR DESCRIPTION
I am targetting this branch, because this is a patch


They are buggy. This implies using phpunit from the vendors.
See
https://github.com/sebastianbergmann/phpunit-mock-objects/pull/324/files
and
https://github.com/sebastianbergmann/phpunit-mock-objects/issues/322

This is a POC, do not merge, it is just to show how the build can be fixed, but should not be merged because some files are supposed to come from dev-kit.