### PR TITLE
Replaced form type names with classnames

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -126,7 +126,8 @@ class DatagridBuilder implements DatagridBuilderInterface
 
         $fieldDescription->mergeOption('field_options', array('required' => false));
 
-        if ($type === 'doctrine_orm_model_autocomplete') {
+        // NEXT_MAJOR: Remove first check (when requirement of Symfony is >= 2.8)
+        if ($type === 'doctrine_orm_model_autocomplete' || $type === 'Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter') {
             $fieldDescription->mergeOption('field_options', array(
                 'class' => $fieldDescription->getTargetEntity(),
                 'model_manager' => $fieldDescription->getAdmin()->getModelManager(),

--- a/Filter/BooleanFilter.php
+++ b/Filter/BooleanFilter.php
@@ -57,7 +57,9 @@ class BooleanFilter extends Filter
     public function getDefaultOptions()
     {
         return array(
-            'field_type' => 'sonata_type_boolean',
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\BooleanType'
+                : 'sonata_type_boolean', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
         );
     }
 
@@ -74,7 +76,9 @@ class BooleanFilter extends Filter
         return array($type, array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
-            'operator_type' => 'hidden',
+            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'operator_options' => array(),
             'label' => $this->getLabel(),
         ));

--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -34,8 +34,12 @@ class CallbackFilter extends Filter
     {
         return array(
             'callback' => null,
-            'field_type' => 'text',
-            'operator_type' => 'hidden',
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'operator_options' => array(),
         );
     }

--- a/Filter/ChoiceFilter.php
+++ b/Filter/ChoiceFilter.php
@@ -82,7 +82,9 @@ class ChoiceFilter extends Filter
             : 'sonata_type_filter_default';
 
         return array($type, array(
-            'operator_type' => 'sonata_type_equal',
+            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\EqualType'
+                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/Filter/ClassFilter.php
+++ b/Filter/ClassFilter.php
@@ -54,7 +54,11 @@ class ClassFilter extends Filter
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'choice');
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            : 'choice'
+        );
     }
 
     /**
@@ -82,7 +86,9 @@ class ClassFilter extends Filter
             : 'sonata_type_filter_default';
 
         return array($type, array(
-            'operator_type' => 'sonata_type_equal',
+            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\EqualType'
+                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/Filter/DateFilter.php
+++ b/Filter/DateFilter.php
@@ -32,6 +32,10 @@ class DateFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'date');
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
+            : 'date'
+        );
     }
 }

--- a/Filter/DateRangeFilter.php
+++ b/Filter/DateRangeFilter.php
@@ -32,6 +32,10 @@ class DateRangeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'sonata_type_date_range');
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\CoreBundle\Form\Type\DateRangeType'
+            : 'sonata_type_date_range'
+        );
     }
 }

--- a/Filter/DateTimeFilter.php
+++ b/Filter/DateTimeFilter.php
@@ -32,6 +32,10 @@ class DateTimeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'datetime');
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
+            : 'datetime'
+        );
     }
 }

--- a/Filter/DateTimeRangeFilter.php
+++ b/Filter/DateTimeRangeFilter.php
@@ -32,6 +32,10 @@ class DateTimeRangeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'sonata_type_datetime_range');
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\CoreBundle\Form\Type\DateTimeRangeType'
+            : 'sonata_type_datetime_range'
+        );
     }
 }

--- a/Filter/ModelAutocompleteFilter.php
+++ b/Filter/ModelAutocompleteFilter.php
@@ -45,9 +45,13 @@ class ModelAutocompleteFilter extends Filter
     {
         return array(
             'field_name' => false,
-            'field_type' => 'sonata_type_model_autocomplete',
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\AdminBundle\Form\Type\ModelAutocompleteType'
+                : 'sonata_type_model_autocomplete', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'field_options' => array(),
-            'operator_type' => 'sonata_type_equal',
+            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\EqualType'
+                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'operator_options' => array(),
         );
     }

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -47,9 +47,13 @@ class ModelFilter extends Filter
         return array(
             'mapping_type' => false,
             'field_name' => false,
-            'field_type' => 'entity',
+            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Bridge\Doctrine\Form\Type\EntityType'
+                : 'entity', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'field_options' => array(),
-            'operator_type' => 'sonata_type_equal',
+            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Sonata\CoreBundle\Form\Type\EqualType'
+                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
             'operator_options' => array(),
         );
     }

--- a/Filter/TimeFilter.php
+++ b/Filter/TimeFilter.php
@@ -32,6 +32,10 @@ class TimeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        return $this->getOption('field_type', 'time');
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\TimeType'
+            : 'time'
+        );
     }
 }

--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -45,11 +45,16 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                 case ClassMetadataInfo::ONE_TO_MANY:
                 case ClassMetadataInfo::MANY_TO_ONE:
                 case ClassMetadataInfo::MANY_TO_MANY:
-
-                    $options['operator_type'] = 'sonata_type_equal';
+                    // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+                    $options['operator_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                        ? 'Sonata\CoreBundle\Form\Type\EqualType'
+                        : 'sonata_type_equal';
                     $options['operator_options'] = array();
 
-                    $options['field_type'] = 'entity';
+                    // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+                    $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                        ? 'Symfony\Bridge\Doctrine\Form\Type\EntityType'
+                        : 'entity';
                     $options['field_options'] = array(
                         'class' => $mapping['targetEntity'],
                     );
@@ -65,7 +70,10 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
         switch ($metadata->getTypeOfField($propertyName)) {
             case 'boolean':
-                $options['field_type'] = 'sonata_type_boolean';
+                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Sonata\CoreBundle\Form\Type\BooleanType'
+                    : 'sonata_type_boolean';
                 $options['field_options'] = array();
 
                 return new TypeGuess('doctrine_orm_boolean', $options, Guess::HIGH_CONFIDENCE);
@@ -77,18 +85,21 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                 return new TypeGuess('doctrine_orm_date', $options, Guess::HIGH_CONFIDENCE);
             case 'decimal':
             case 'float':
-                $options['field_type'] = 'number';
-
-                return new TypeGuess('doctrine_orm_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'integer':
             case 'bigint':
             case 'smallint':
-                $options['field_type'] = 'number';
+                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\NumberType'
+                    : 'number';
 
                 return new TypeGuess('doctrine_orm_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'string':
             case 'text':
-                $options['field_type'] = 'text';
+                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                    ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                    : 'text';
 
                 return new TypeGuess('doctrine_orm_string', $options, Guess::MEDIUM_CONFIDENCE);
             case 'time':


### PR DESCRIPTION
I am targetting this branch, because it's about avoiding deprecation warnings when using Sf >= 2.8, while keeping the old behavior.

## Changelog
```markdown
## Fixed
- Use class name when referencing `Form Type` to be compatible with Symfony 2.8+
```
Closes #613

## Subject

Remove deprecation warnings when using Sf >= 2.8