### PR TITLE
Fix formcontractor typecheck for classes

### DIFF
--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -72,13 +72,27 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
         $collectionTypes = array('sonata_type_collection');
         // NEXT_MAJOR: Use only FQCNs when dropping support for Symfony <2.8
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            array_push(
-                $modelTypes,
+            $classTypes = array(
                 'Sonata\AdminBundle\Form\Type\ModelType',
                 'Sonata\AdminBundle\Form\Type\ModelTypeList',
                 'Sonata\AdminBundle\Form\Type\ModelHiddenType',
-                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType'
+                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
             );
+
+            foreach ($classTypes as $classType) {
+                array_push(
+                    $modelTypes,
+                    // add class type.
+                    $classType,
+                    // add instance of class type.
+                    get_class(
+                        $this->getMockBuilder($classType)
+                            ->disableOriginalConstructor()
+                            ->getMock()
+                    )
+                );
+            }
+
             $adminTypes[] = 'Sonata\AdminBundle\Form\Type\AdminType';
             $collectionTypes[] = 'Sonata\CoreBundle\Form\Type\CollectionType';
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because there are no BC breaks.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed how `FormContractor::getDefaultOptions` checks which type is used. Instead of checking for an array of available types, we improve this by checking for the class instance or parents. 
```

This fixes an issue, when you for example try to extend ModelAutocompleteType, you will receive a fatal error: `Catchable Fatal Error: Argument 1 passed to Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer::__construct() must implement interface Sonata\AdminBundle\Model\ModelManagerInterface, null given, called in /app/vendor/sonata-project/admin-bundle/Form/Type/ModelAutocompleteType.php on line 37 and defined.`

That was because it only checks for the ModelAutocompleteType, and not types extending it.

<!-- Describe your Pull Request content here -->