### PR TITLE
Improve detection of entity persistence:

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\UnitOfWork;
 use Exporter\Source\DoctrineORMQuerySourceIterator;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
@@ -385,8 +386,12 @@ class ModelManager implements ModelManagerInterface, LockInterface
             throw new \RunTimeException('Invalid argument, object or null required');
         }
 
-        // the entities is not managed
-        if (!$entity || !$this->getEntityManager($entity)->getUnitOfWork()->isInIdentityMap($entity)) {
+        if (!$entity) {
+            return;
+        }
+
+        $entityState = $this->getEntityManager($entity)->getUnitOfWork()->getEntityState($entity);
+        if (UnitOfWork::STATE_NEW == $entityState || UnitOfWork::STATE_REMOVED == $entityState) {
             return;
         }
 


### PR DESCRIPTION
I am targetting this branch, because…
the changes in this PR make the existing code more robust and address possible bugs caused by the UnitOfWork not carrying already-persisted entities in some scenarios

See discussion:
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/547#r80505888


## Changelog

```markdown
### Changed
- Changed how persisted entities are detected, now using UnitOfWork::getEntityState() instead of isInIdentityMap()
```

## Subject
Instead of looking at the UnitOfWork identity map (which may detach objects after a flush), this revision uses the reported entity state which should be a more robust indicator of whether or not a given entity has been persisted
