### PR TITLE
Nested sortable table form items not persisted on save

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_table.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_table.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 <script type="text/javascript">
-    jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody').sortable({
+    jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody').first().sortable({
         axis: 'y',
         opacity: 0.6,
         items: '> tr',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting 3.x, because this is a bug fix, to match expected behaviour.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Nested sortable table form items not persisted on save
```

## To do

## Subject

<!-- Describe your Pull Request content here -->

With nested sortable forms, the child form's position elements are not updated.

The 'sortable' jQuery plugin finds _all_ child `tdbody.sonata-ba-tbody` elements, _including_ those _in child forms_, and only triggers the _parent form_'s handler.

This means when you re-order child elements, the parent form's hidden position fields are updated even though they haven't changed, and the child form's position fields are not updated.

By restricting to the first (outer most) match, the `.sortable(` attempting to bind to the child form is able to react to its own events.