### PR TITLE
Fix typo on RuntimeException usage

### DIFF
--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -141,7 +141,7 @@ class ModelFilter extends Filter
         );
 
         if (!in_array($this->getOption('mapping_type'), $types)) {
-            throw new \RunTimeException('Invalid mapping type');
+            throw new \RuntimeException('Invalid mapping type');
         }
 
         $associationMappings = $this->getParentAssociationMappings();

--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -117,7 +117,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     public function getNewFieldDescriptionInstance($class, $name, array $options = array())
     {
         if (!is_string($name)) {
-            throw new \RunTimeException('The name argument must be a string');
+            throw new \RuntimeException('The name argument must be a string');
         }
 
         if (!isset($options['route']['name'])) {
@@ -383,7 +383,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     public function getNormalizedIdentifier($entity)
     {
         if (is_scalar($entity)) {
-            throw new \RunTimeException('Invalid argument, object or null required');
+            throw new \RuntimeException('Invalid argument, object or null required');
         }
 
         if (!$entity) {


### PR DESCRIPTION
I am targetting this branch, because this is a bugfix.

## Changelog

```markdown
### Fixed
- Typo on `RuntimeException` usages
```
