### PR TITLE
Updated orm relations twig files to use hasAccess

### DIFF
--- a/Resources/views/CRUD/list_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_many.html.twig
@@ -13,10 +13,9 @@ file that was distributed with this source code.
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}
-    {% set route_role = route_name | upper %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) %}
         {% for element in value %}
-            {%- if field_description.associationadmin.isGranted(route_role, value) -%}
+            {%- if field_description.associationadmin.hasAccess(route_name, value) -%}
                 {{ block('relation_link') }}
             {%- else -%}
                 {{ block('relation_value') }}

--- a/Resources/views/CRUD/list_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_one.html.twig
@@ -14,8 +14,7 @@ file that was distributed with this source code.
 {% block field %}
     {% if value %}
         {% set route_name = field_description.options.route.name %}
-        {% set route_role = route_name | upper %}
-        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.isGranted(route_role, value) %}
+        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
                 {{ value|render_relation_element(field_description) }}
             </a>

--- a/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -13,10 +13,9 @@ file that was distributed with this source code.
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}
-    {% set route_role = route_name | upper %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) %}
         {% for element in value %}
-            {%- if field_description.associationadmin.isGranted(route_role, value) -%}
+            {%- if field_description.associationadmin.hasAccess(route_name, value) -%}
                 {{ block('relation_link') }}
             {%- else -%}
                 {{ block('relation_value') }}

--- a/Resources/views/CRUD/list_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_one.html.twig
@@ -13,8 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}
-    {% set route_role = route_name | upper %}
-    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.isGranted(route_role, value) and field_description.associationadmin.hasRoute(route_name) %}
+    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
         <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
     {% else %}
         {{ value|render_relation_element(field_description) }}

--- a/Resources/views/CRUD/show_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_many.html.twig
@@ -14,21 +14,16 @@ file that was distributed with this source code.
 {% block field%}
     <ul class="sonata-ba-show-many-to-many">
     {% set route_name = field_description.options.route.name %}
-    {% set route_role = route_name | upper %}
-    {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.isGranted(route_role)%}
         {% for element in value %}
             <li>
-                <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
+                {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value)%}
+                    <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
+                        {{ element|render_relation_element(field_description) }}
+                    </a>
+                {% else %}
                     {{ element|render_relation_element(field_description) }}
-                </a>
+                {% endif %}
             </li>
         {% endfor %}
-    {% else %}
-        {% for element in value %}
-            <li>
-                {{ element|render_relation_element(field_description) }}
-            </li>
-        {% endfor %}
-    {% endif %}
     </ul>
 {% endblock %}

--- a/Resources/views/CRUD/show_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_one.html.twig
@@ -14,8 +14,7 @@ file that was distributed with this source code.
 {% block field %}
     {% if value %}
         {% set route_name = field_description.options.route.name %}
-        {% set route_role = route_name | upper %}
-        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.isGranted(route_role) %}
+        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
                 {{ value|render_relation_element(field_description) }}
             </a>

--- a/Resources/views/CRUD/show_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_one_to_many.html.twig
@@ -14,15 +14,12 @@ file that was distributed with this source code.
 {% block field%}
     <ul class="sonata-ba-show-one-to-many">
     {% set route_name = field_description.options.route.name %}
-    {% set route_role = route_name | upper %}
-    {% if field_description.hasassociationadmin and field_description.associationadmin.isGranted(route_role) and field_description.associationadmin.hasRoute(route_name) %}
-        {% for element in value%}
+    {% for element in value%}
+        {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
             <li><a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a></li>
-        {% endfor %}
-    {% else %}
-        {% for element in value%}
+        {% else %}
             <li>{{ element|render_relation_element(field_description) }}</li>
-        {% endfor %}
-    {% endif %}
+        {% endif %}
+    {% endfor %}
     </ul>
 {% endblock %}

--- a/Resources/views/CRUD/show_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_one_to_one.html.twig
@@ -13,8 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}
-    {% set route_role = route_name | upper %}
-    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.isGranted(route_role) and field_description.associationadmin.hasRoute(route_name) %}
+    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
         <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
             {{ value|render_relation_element(field_description) }}
         </a>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #529

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- ORM any-to-any list and show templates now use `hasAccess`
```


## Subject

The ORM ANY-to-ANY list and show templates use uppercased version of route name as role, this causes problem in some routes (eg.: `show` route -> `VIEW` role, `history` route -> `EDIT` role). With the update they use the new `hasAccess` function from `AbstractAdmin` introduced in sonata-project/SonataAdminBundle#3749 to check the role.