### PR TITLE
Reset order by dql part

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -309,7 +309,7 @@ class ProxyQuery implements ProxyQueryInterface
             }
             $idxSelect .= ($idxSelect !== '' ? ', ' : '').$idSelect;
         }
-        $queryBuilderId->resetDQLPart('select');
+        $queryBuilderId->resetDQLParts(array('select', 'orderBy'));
         $queryBuilderId->add('select', 'DISTINCT '.$idxSelect);
 
         // for SELECT DISTINCT, ORDER BY expressions must appear in idxSelect list


### PR DESCRIPTION
I am targetting this branch, because I found bug in this version.

Fixes #210

## Changelog

```
### Fixed
- fixed query - resetting part orderBy
```

## Subject
Query getters number of records should not use an orderBy part. Therefore part about orderBy should be reset.
Thanks to this amendment, you can use orderBy in a createQuery method without error in postgresql.