### PR TITLE
reset orderBy DQL part in datagrid query

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -309,7 +309,7 @@ class ProxyQuery implements ProxyQueryInterface
             }
             $idxSelect .= ($idxSelect !== '' ? ', ' : '').$idSelect;
         }
-        $queryBuilderId->resetDQLPart('select');
+        $queryBuilderId->resetDQLParts(array('select', 'orderBy'));
         $queryBuilderId->add('select', 'DISTINCT '.$idxSelect);
 
         // for SELECT DISTINCT, ORDER BY expressions must appear in idxSelect list


### PR DESCRIPTION
I am targetting this branch, because I found bug in this version.

Fixes #458, #210

## Changelog

```markdown
### Changed
- added `orderBy` part to resetDQLparts
```

## Subject

To retrieve the different subjects ids, is not need set orderBy for sorting.
Without this fix database returns an error:
```
SQLSTATE[42P10]: Invalid column reference: 7 ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 1
```
Full db query:
```
SELECT DISTINCT p0_.id AS id_0, p0_.id AS id_1 FROM product_part_code p0_ LEFT JOIN product_part p1_ ON p0_.part_id = p1_.id ORDER BY p1_.name ASC, p0_.is_active DESC, p0_.id DESC, p0_.id DESC LIMIT 32 OFFSET 0
```

The problem occurs in two cases:
- in `configureFormFields`, when use field `sonata_type_model_autocomplete` and set 'callback'. like this:
```
'callback' => function ($admin, $property, $value) {
    $datagrid = $admin->getDatagrid();
    $queryBuilder = $datagrid->getQuery();
    $queryBuilder
      ->addSelect('p')
      ->join($queryBuilder->getRootAlias() . '.part', 'p')
      ->where('lower(' . $queryBuilder->getRootAlias() . '.name) LIKE :name or lower(p.name) LIKE :name')
      ->orderBy('p.name', 'asc')
      ->setParameter('name', '%' . mb_strtolower($value) . '%')
    ;
},
```
- When I want to manually determine the sorting (`orderBy`). 
```
public function createQuery($context = 'list')
{
    $query = parent::createQuery($context);
    $query
      ->orderBy('p.name')
      ->addOrderBy('pc.name')
    ;
    return $query;
}
```

