### PR TITLE
Fix typo in exception message

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -133,7 +133,7 @@ class FormContractor implements FormContractorInterface
             }
 
             if (!in_array($fieldDescription->getMappingType(), array(ClassMetadataInfo::ONE_TO_ONE, ClassMetadataInfo::MANY_TO_ONE))) {
-                throw new \RuntimeException(sprintf('You are trying to add `sonata_type_admin` field `%s` which is not One-To-One or  Many-To-One. Maybe you want `sonata_model_list` instead?', $fieldDescription->getName()));
+                throw new \RuntimeException(sprintf('You are trying to add `sonata_type_admin` field `%s` which is not One-To-One or  Many-To-One. Maybe you want `sonata_type_collection` instead?', $fieldDescription->getName()));
             }
 
             // set sensitive default value to have a component working fine out of the box


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #327

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
    Fixed typo in exception message in Builder/FormContractor.php 
```

## Subject

<!-- Describe your Pull Request content here -->

Type `sonata_model_list` doesn't exist. `sonata_type_model_list` doesn't work for one-to-many relation, so the suggested form type should be `sonata_type_collection`.