### PR TITLE
Fixed deprecated BaseBlockService usage

### DIFF
--- a/Block/AuditBlockService.php
+++ b/Block/AuditBlockService.php
@@ -13,8 +13,8 @@ namespace Sonata\DoctrineORMAdminBundle\Block;
 
 use SimpleThings\EntityAudit\AuditReader;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;

--- a/Block/AuditBlockService.php
+++ b/Block/AuditBlockService.php
@@ -13,7 +13,7 @@ namespace Sonata\DoctrineORMAdminBundle\Block;
 
 use SimpleThings\EntityAudit\AuditReader;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;

--- a/Block/AuditBlockService.php
+++ b/Block/AuditBlockService.php
@@ -13,7 +13,7 @@ namespace Sonata\DoctrineORMAdminBundle\Block;
 
 use SimpleThings\EntityAudit\AuditReader;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AuditBlockService extends BaseBlockService
+class AuditBlockService extends AbstractBlockService
 {
     /**
      * @var AuditReader


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
sonata-project/block-bundle, on 3.x branch, BaseBlockService @deprecated since 3.2, to be removed with 4.0

## Subject

<!-- Describe your Pull Request content here -->

Fixed deprecated `BaseBlockService` usage, in the 3.x branch of sonata-project/block-bundle