### PR TITLE
Fixed deprecated `BaseBlockService` usage

### DIFF
--- a/Block/AuditBlockService.php
+++ b/Block/AuditBlockService.php
@@ -13,7 +13,7 @@ namespace Sonata\DoctrineORMAdminBundle\Block;
 
 use SimpleThings\EntityAudit\AuditReader;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AuditBlockService extends BaseBlockService
+class AuditBlockService extends AbstractBlockService
 {
     /**
      * @var AuditReader


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because of the depraction of  Sonata\BlockBundle\Block\BaseBlockService on branch 3.x of the block bundle

## Changelog
```markdown
### Changed
class Sonata\DoctrineORMAdminBundle\Block\AuditBlockService now extends Sonata\BlockBundle\Block\Service\AbstractBlockService

## Subject
The 3.x branch of the sonata-project/block-bundle deprecates the class BaseBlockService