### PR TITLE
Drop old versions

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -126,8 +126,7 @@ class DatagridBuilder implements DatagridBuilderInterface
 
         $fieldDescription->mergeOption('field_options', array('required' => false));
 
-        // NEXT_MAJOR: Remove first check (when requirement of Symfony is >= 2.8)
-        if ($type === 'doctrine_orm_model_autocomplete' || $type === 'Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter') {
+        if ($type === 'Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter') {
             $fieldDescription->mergeOption('field_options', array(
                 'class' => $fieldDescription->getTargetEntity(),
                 'model_manager' => $fieldDescription->getAdmin()->getModelManager(),
@@ -159,10 +158,12 @@ class DatagridBuilder implements DatagridBuilderInterface
             $defaultOptions['csrf_protection'] = false;
         }
 
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $formType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
-        $formBuilder = $this->formFactory->createNamedBuilder('filter', $formType, array(), $defaultOptions);
+        $formBuilder = $this->formFactory->createNamedBuilder(
+            'filter',
+            'Symfony\Component\Form\Extension\Core\Type\FormType',
+            array(),
+            $defaultOptions
+        );
 
         return new Datagrid($admin->createQuery(), $admin->getList(), $pager, $formBuilder, $values);
     }

--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -85,11 +85,12 @@ class FormContractor implements FormContractorInterface
      */
     public function getFormBuilder($name, array $options = array())
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $formType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
-
-        return $this->getFormFactory()->createNamedBuilder($name, $formType, null, $options);
+        return $this->getFormFactory()->createNamedBuilder(
+            $name,
+            'Symfony\Component\Form\Extension\Core\Type\FormType',
+            null,
+            $options
+        );
     }
 
     /**
@@ -100,19 +101,13 @@ class FormContractor implements FormContractorInterface
         $options = array();
         $options['sonata_field_description'] = $fieldDescription;
 
-        // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony <2.8
-        if ($this->checkFormType($type, array(
-                'sonata_type_model',
-                'sonata_type_model_list',
-                'sonata_type_model_hidden',
-                'sonata_type_model_autocomplete',
-            )) || $this->checkFormClass($type, array(
-                'Sonata\AdminBundle\Form\Type\ModelType',
-                'Sonata\AdminBundle\Form\Type\ModelTypeList',
-                'Sonata\AdminBundle\Form\Type\ModelListType',
-                'Sonata\AdminBundle\Form\Type\ModelHiddenType',
-                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
-            ))) {
+        if ($this->checkFormClass($type, array(
+            'Sonata\AdminBundle\Form\Type\ModelType',
+            'Sonata\AdminBundle\Form\Type\ModelTypeList',
+            'Sonata\AdminBundle\Form\Type\ModelListType',
+            'Sonata\AdminBundle\Form\Type\ModelHiddenType',
+            'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
+        ))) {
             if ($fieldDescription->getOption('edit') === 'list') {
                 throw new \LogicException('The ``sonata_type_model`` type does not accept an ``edit`` option anymore, please review the UPGRADE-2.1.md file from the SonataAdminBundle');
             }
@@ -120,14 +115,12 @@ class FormContractor implements FormContractorInterface
             $options['class'] = $fieldDescription->getTargetEntity();
             $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
 
-            // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony <2.8
-            if ($this->checkFormType($type, array('sonata_type_model_autocomplete')) || $this->checkFormClass($type, array('Sonata\AdminBundle\Form\Type\ModelAutocompleteType'))) {
+            if ($this->checkFormClass($type, array('Sonata\AdminBundle\Form\Type\ModelAutocompleteType'))) {
                 if (!$fieldDescription->getAssociationAdmin()) {
                     throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity: `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
                 }
             }
-            // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony <2.8
-        } elseif ($this->checkFormType($type, array('sonata_type_admin')) || $this->checkFormClass($type, array('Sonata\AdminBundle\Form\Type\AdminType'))) {
+        } elseif ($this->checkFormClass($type, array('Sonata\AdminBundle\Form\Type\AdminType'))) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
             }
@@ -142,8 +135,7 @@ class FormContractor implements FormContractorInterface
 
             $options['data_class'] = $fieldDescription->getAssociationAdmin()->getClass();
             $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
-            // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony <2.8
-        } elseif ($this->checkFormType($type, array('sonata_type_collection')) || $this->checkFormClass($type, array('Sonata\CoreBundle\Form\Type\CollectionType'))) {
+        } elseif ($this->checkFormClass($type, array('Sonata\CoreBundle\Form\Type\CollectionType'))) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
             }
@@ -172,19 +164,6 @@ class FormContractor implements FormContractorInterface
             ClassMetadataInfo::MANY_TO_ONE,
             ClassMetadataInfo::ONE_TO_ONE,
         ));
-    }
-
-    /**
-     * NEXT_MAJOR: See next major comments above, this method should be removed when dropping support for Symfony <2.8.
-     *
-     * @param string $type
-     * @param array  $types
-     *
-     * @return bool
-     */
-    private function checkFormType($type, $types)
-    {
-        return in_array($type, $types, true);
     }
 
     /**

--- a/Filter/AbstractDateFilter.php
+++ b/Filter/AbstractDateFilter.php
@@ -155,26 +155,17 @@ abstract class AbstractDateFilter extends Filter
      */
     public function getRenderSettings()
     {
-        $name = 'sonata_type_filter_date';
+        $name = 'Sonata\AdminBundle\Form\Type\Filter\Date';
 
         if ($this->time) {
-            $name .= 'time';
+            $name .= 'Time';
         }
 
         if ($this->range) {
-            $name .= '_range';
+            $name .= 'Range';
         }
 
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $classnames = array(
-                'sonata_type_filter_date' => 'Sonata\AdminBundle\Form\Type\Filter\DateType',
-                'sonata_type_filter_date_range' => 'Sonata\AdminBundle\Form\Type\Filter\DateRangeType',
-                'sonata_type_filter_datetime' => 'Sonata\AdminBundle\Form\Type\Filter\DateTimeType',
-                'sonata_type_filter_datetime_range' => 'Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType',
-            );
-            $name = $classnames[$name];
-        }
+        $name .= 'Type';
 
         return array($name, array(
             'field_type' => $this->getFieldType(),

--- a/Filter/BooleanFilter.php
+++ b/Filter/BooleanFilter.php
@@ -56,11 +56,7 @@ class BooleanFilter extends Filter
      */
     public function getDefaultOptions()
     {
-        return array(
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\BooleanType'
-                : 'sonata_type_boolean', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        );
+        return array('field_type' => 'Sonata\CoreBundle\Form\Type\BooleanType');
     }
 
     /**
@@ -68,17 +64,10 @@ class BooleanFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return array($type, array(
+        return array('Sonata\AdminBundle\Form\Type\Filter\DefaultType', array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => 'Symfony\Component\Form\Extension\Core\Type\HiddenType',
             'operator_options' => array(),
             'label' => $this->getLabel(),
         ));

--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -34,12 +34,8 @@ class CallbackFilter extends Filter
     {
         return array(
             'callback' => null,
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'operator_type' => 'Symfony\Component\Form\Extension\Core\Type\HiddenType',
             'operator_options' => array(),
         );
     }
@@ -49,12 +45,7 @@ class CallbackFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return array($type, array(
+        return array('Sonata\AdminBundle\Form\Type\Filter\DefaultType', array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/Filter/ChoiceFilter.php
+++ b/Filter/ChoiceFilter.php
@@ -76,15 +76,8 @@ class ChoiceFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return array($type, array(
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return array('Sonata\AdminBundle\Form\Type\Filter\DefaultType', array(
+            'operator_type' => 'Sonata\CoreBundle\Form\Type\EqualType',
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/Filter/ClassFilter.php
+++ b/Filter/ClassFilter.php
@@ -54,11 +54,7 @@ class ClassFilter extends Filter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice'
-        );
+        return $this->getOption('field_type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType');
     }
 
     /**
@@ -80,15 +76,8 @@ class ClassFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return array($type, array(
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return array('Sonata\AdminBundle\Form\Type\Filter\DefaultType', array(
+            'operator_type' => 'Sonata\CoreBundle\Form\Type\EqualType',
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/Filter/DateFilter.php
+++ b/Filter/DateFilter.php
@@ -32,10 +32,6 @@ class DateFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
-            : 'date'
-        );
+        return $this->getOption('field_type', 'Symfony\Component\Form\Extension\Core\Type\DateType');
     }
 }

--- a/Filter/DateRangeFilter.php
+++ b/Filter/DateRangeFilter.php
@@ -32,10 +32,6 @@ class DateRangeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\CoreBundle\Form\Type\DateRangeType'
-            : 'sonata_type_date_range'
-        );
+        return $this->getOption('field_type', 'Sonata\CoreBundle\Form\Type\DateRangeType');
     }
 }

--- a/Filter/DateTimeFilter.php
+++ b/Filter/DateTimeFilter.php
@@ -32,10 +32,6 @@ class DateTimeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
-            : 'datetime'
-        );
+        return $this->getOption('field_type', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType');
     }
 }

--- a/Filter/DateTimeRangeFilter.php
+++ b/Filter/DateTimeRangeFilter.php
@@ -32,10 +32,6 @@ class DateTimeRangeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\CoreBundle\Form\Type\DateTimeRangeType'
-            : 'sonata_type_datetime_range'
-        );
+        return $this->getOption('field_type', 'Sonata\CoreBundle\Form\Type\DateTimeRangeType');
     }
 }

--- a/Filter/ModelAutocompleteFilter.php
+++ b/Filter/ModelAutocompleteFilter.php
@@ -45,13 +45,9 @@ class ModelAutocompleteFilter extends Filter
     {
         return array(
             'field_name' => false,
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\AdminBundle\Form\Type\ModelAutocompleteType'
-                : 'sonata_type_model_autocomplete', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => 'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
             'field_options' => array(),
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => 'Sonata\CoreBundle\Form\Type\EqualType',
             'operator_options' => array(),
         );
     }
@@ -61,12 +57,7 @@ class ModelAutocompleteFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return array($type, array(
+        return array('Sonata\AdminBundle\Form\Type\Filter\DefaultType', array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -47,13 +47,9 @@ class ModelFilter extends Filter
         return array(
             'mapping_type' => false,
             'field_name' => false,
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Bridge\Doctrine\Form\Type\EntityType'
-                : 'entity', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => 'Symfony\Bridge\Doctrine\Form\Type\EntityType',
             'field_options' => array(),
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => 'Sonata\CoreBundle\Form\Type\EqualType',
             'operator_options' => array(),
         );
     }
@@ -63,12 +59,7 @@ class ModelFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return array($type, array(
+        return array('Sonata\AdminBundle\Form\Type\Filter\DefaultType', array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/Filter/NumberFilter.php
+++ b/Filter/NumberFilter.php
@@ -52,12 +52,7 @@ class NumberFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\NumberType'
-            : 'sonata_type_filter_number';
-
-        return array($type, array(
+        return array('Sonata\AdminBundle\Form\Type\Filter\NumberType', array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -65,12 +65,7 @@ class StringFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType'
-            : 'sonata_type_filter_choice';
-
-        return array($type, array(
+        return array('Sonata\AdminBundle\Form\Type\Filter\ChoiceType', array(
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/Filter/TimeFilter.php
+++ b/Filter/TimeFilter.php
@@ -32,10 +32,6 @@ class TimeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TimeType'
-            : 'time'
-        );
+        return $this->getOption('field_type', 'Symfony\Component\Form\Extension\Core\Type\TimeType');
     }
 }

--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -45,16 +45,10 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                 case ClassMetadataInfo::ONE_TO_MANY:
                 case ClassMetadataInfo::MANY_TO_ONE:
                 case ClassMetadataInfo::MANY_TO_MANY:
-                    // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                    $options['operator_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                        ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                        : 'sonata_type_equal';
+                    $options['operator_type'] = 'Sonata\CoreBundle\Form\Type\EqualType';
                     $options['operator_options'] = array();
 
-                    // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                    $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                        ? 'Symfony\Bridge\Doctrine\Form\Type\EntityType'
-                        : 'entity';
+                    $options['field_type'] = 'Symfony\Bridge\Doctrine\Form\Type\EntityType';
                     $options['field_options'] = array(
                         'class' => $mapping['targetEntity'],
                     );
@@ -70,10 +64,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
         switch ($metadata->getTypeOfField($propertyName)) {
             case 'boolean':
-                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Sonata\CoreBundle\Form\Type\BooleanType'
-                    : 'sonata_type_boolean';
+                $options['field_type'] = 'Sonata\CoreBundle\Form\Type\BooleanType';
                 $options['field_options'] = array();
 
                 return new TypeGuess('doctrine_orm_boolean', $options, Guess::HIGH_CONFIDENCE);
@@ -88,18 +79,12 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             case 'integer':
             case 'bigint':
             case 'smallint':
-                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\NumberType'
-                    : 'number';
+                $options['field_type'] = 'Symfony\Component\Form\Extension\Core\Type\NumberType';
 
                 return new TypeGuess('doctrine_orm_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'string':
             case 'text':
-                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                    : 'text';
+                $options['field_type'] = 'Symfony\Component\Form\Extension\Core\Type\TextType';
 
                 return new TypeGuess('doctrine_orm_string', $options, Guess::MEDIUM_CONFIDENCE);
             case 'time':

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -62,39 +62,26 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
         $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
 
-        $modelTypes = array(
-            'sonata_type_model',
-            'sonata_type_model_list',
-            'sonata_type_model_hidden',
-            'sonata_type_model_autocomplete',
+        $modelTypes = array();
+        $classTypes = array(
+            'Sonata\AdminBundle\Form\Type\ModelType',
+            'Sonata\AdminBundle\Form\Type\ModelTypeList',
+            'Sonata\AdminBundle\Form\Type\ModelHiddenType',
+            'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
         );
-        $adminTypes = array('sonata_type_admin');
-        $collectionTypes = array('sonata_type_collection');
-        // NEXT_MAJOR: Use only FQCNs when dropping support for Symfony <2.8
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $classTypes = array(
-                'Sonata\AdminBundle\Form\Type\ModelType',
-                'Sonata\AdminBundle\Form\Type\ModelTypeList',
-                'Sonata\AdminBundle\Form\Type\ModelHiddenType',
-                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
+
+        foreach ($classTypes as $classType) {
+            array_push(
+                $modelTypes,
+                // add class type.
+                $classType,
+                // add instance of class type.
+                get_class(
+                    $this->getMockBuilder($classType)
+                        ->disableOriginalConstructor()
+                        ->getMock()
+                )
             );
-
-            foreach ($classTypes as $classType) {
-                array_push(
-                    $modelTypes,
-                    // add class type.
-                    $classType,
-                    // add instance of class type.
-                    get_class(
-                        $this->getMockBuilder($classType)
-                            ->disableOriginalConstructor()
-                            ->getMock()
-                    )
-                );
-            }
-
-            $adminTypes[] = 'Sonata\AdminBundle\Form\Type\AdminType';
-            $collectionTypes[] = 'Sonata\CoreBundle\Form\Type\CollectionType';
         }
 
         // model types
@@ -107,24 +94,26 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
 
         // admin type
         $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::ONE_TO_ONE);
-        foreach ($adminTypes as $formType) {
-            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
-            $this->assertSame($fieldDescription, $options['sonata_field_description']);
-            $this->assertSame($modelClass, $options['data_class']);
-            $this->assertSame(false, $options['btn_add']);
-            $this->assertSame(false, $options['delete']);
-        }
+        $options = $this->formContractor->getDefaultOptions(
+            'Sonata\AdminBundle\Form\Type\AdminType',
+            $fieldDescription
+        );
+        $this->assertSame($fieldDescription, $options['sonata_field_description']);
+        $this->assertSame($modelClass, $options['data_class']);
+        $this->assertSame(false, $options['btn_add']);
+        $this->assertSame(false, $options['delete']);
 
         // collection type
         $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::ONE_TO_MANY);
-        foreach ($collectionTypes as $formType) {
-            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
-            $this->assertSame($fieldDescription, $options['sonata_field_description']);
-            $this->assertSame('sonata_type_admin', $options['type']);
-            $this->assertSame(true, $options['modifiable']);
-            $this->assertSame($fieldDescription, $options['type_options']['sonata_field_description']);
-            $this->assertSame($modelClass, $options['type_options']['data_class']);
-        }
+        $options = $this->formContractor->getDefaultOptions(
+            'Sonata\CoreBundle\Form\Type\CollectionType',
+            $fieldDescription
+        );
+        $this->assertSame($fieldDescription, $options['sonata_field_description']);
+        $this->assertSame('sonata_type_admin', $options['type']);
+        $this->assertSame(true, $options['modifiable']);
+        $this->assertSame($fieldDescription, $options['type_options']['sonata_field_description']);
+        $this->assertSame($modelClass, $options['type_options']['data_class']);
     }
 
     public function testAdminClassAttachForNotMappedField()

--- a/composer.json
+++ b/composer.json
@@ -22,18 +22,18 @@
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/exporter": "^1.3.1",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/doctrine-bridge": "^2.2 || ^3.0",
-        "symfony/form": "^2.3 || ^3.0",
-        "symfony/framework-bundle": "^2.2 || ^3.0",
-        "symfony/security": "^2.3 || ^3.0",
-        "symfony/security-acl": "^2.2 || ^3.0"
+        "symfony/console": "^2.8 || ^3.0",
+        "symfony/doctrine-bridge": "^2.8 || ^3.0",
+        "symfony/form": "^2.8 || ^3.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0",
+        "symfony/security": "^2.8 || ^3.0",
+        "symfony/security-acl": "^2.8 || ^3.0"
     },
     "require-dev": {
         "knplabs/knp-menu-bundle": "^2.1.1",
         "simplethings/entity-audit-bundle": "0.1 - 0.9",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "suggest": {
         "simplethings/entity-audit-bundle": "If you want to support for versioning of entities and their associations."

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "doctrine/orm": "^2.3",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.0",


### PR DESCRIPTION
I am targetting this branch, because bumping versions of php / sf is considered major.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for PHP 5.3 through 5.5 was dropped
- Support for Symfony 2.2 through 2.7 was dropped
```

## Subject

This prepares the next major release
