### PR TITLE
Fixed deprecated BaseBlockService usage (#641)

### DIFF
--- a/Block/AuditBlockService.php
+++ b/Block/AuditBlockService.php
@@ -13,8 +13,8 @@ namespace Sonata\DoctrineORMAdminBundle\Block;
 
 use SimpleThings\EntityAudit\AuditReader;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AuditBlockService extends BaseBlockService
+class AuditBlockService extends AbstractBlockService
 {
     /**
      * @var AuditReader


### PR DESCRIPTION
I am targetting this branch, because this was BC in the first place.

Refs #641 
## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecated usage of Sonata\BlockBundle\Block\BaseBlockService
```
## Subject

This is a backport from a PR that should have been merged in 3.x instead of master.

