### PR TITLE
TYPE_NOT_CONTAINS doesn't consider NULL values

### DIFF
--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -50,7 +50,7 @@ class StringFilter extends Filter
             $or->add($queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $field)));
         }
 
-        $this->applyWhere($queryBuilder, $or);        
+        $this->applyWhere($queryBuilder, $or);
 
         if ($data['type'] == ChoiceType::TYPE_EQUAL) {
             $queryBuilder->setParameter($parameterName, $data['value']);

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -41,17 +41,17 @@ class StringFilter extends Filter
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($queryBuilder);
-        
+
         $or = $queryBuilder->expr()->orX();
-        
+
         $or->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
-        
+
         if ($data['type'] == ChoiceType::TYPE_NOT_CONTAINS) {
             $or->add($queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $field)));
         }
-        
+
         $this->applyWhere($queryBuilder, $or);        
-        
+
         if ($data['type'] == ChoiceType::TYPE_EQUAL) {
             $queryBuilder->setParameter($parameterName, $data['value']);
         } else {

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -41,8 +41,15 @@ class StringFilter extends Filter
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($queryBuilder);
-        $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
 
+        $whereCondition = sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName);
+
+        if ($data['type'] == ChoiceType::TYPE_NOT_CONTAINS) {
+            $whereCondition .= sprintf(' OR %s.%s IS NULL', $alias, $field);
+        }
+        
+        $this->applyWhere($queryBuilder, $whereCondition);
+        
         if ($data['type'] == ChoiceType::TYPE_EQUAL) {
             $queryBuilder->setParameter($parameterName, $data['value']);
         } else {

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -46,8 +46,7 @@ class StringFilter extends Filter
         
         $or->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
         
-        if ($data['type'] == ChoiceType::TYPE_NOT_CONTAINS)
-        {
+        if ($data['type'] == ChoiceType::TYPE_NOT_CONTAINS) {
             $or->add($queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $field)));
         }
         

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -41,14 +41,17 @@ class StringFilter extends Filter
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($queryBuilder);
-
-        $whereCondition = sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName);
-
-        if ($data['type'] == ChoiceType::TYPE_NOT_CONTAINS) {
-            $whereCondition .= sprintf(' OR %s.%s IS NULL', $alias, $field);
+        
+        $or = $queryBuilder->expr()->orX();
+        
+        $or->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
+        
+        if ($data['type'] == ChoiceType::TYPE_NOT_CONTAINS)
+        {
+            $or->add($queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $field)));
         }
         
-        $this->applyWhere($queryBuilder, $whereCondition);
+        $this->applyWhere($queryBuilder, $or);        
         
         if ($data['type'] == ChoiceType::TYPE_EQUAL) {
             $queryBuilder->setParameter($parameterName, $data['value']);

--- a/Tests/Filter/QueryBuilder.php
+++ b/Tests/Filter/QueryBuilder.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
+use Doctrine\ORM\Query\Expr\Orx;
+
 class QueryBuilder
 {
     public $parameters = array();
@@ -79,5 +81,53 @@ class QueryBuilder
     public function leftJoin($parameter, $alias)
     {
         $this->query[] = $parameter;
+    }
+
+    /**
+     * @return Orx
+     */
+    public function orX($x = null)
+    {
+        return new Orx(func_get_args());
+    }
+
+    /**
+     * @param string $alias
+     * @param string $parameter
+     *
+     * @return string
+     */
+    public function neq($alias, $parameter)
+    {
+        return sprintf('%s <> %s', $alias, $parameter);
+    }
+
+    /**
+     * @param string $queryPart
+     *
+     * @return string
+     */
+    public function isNull($queryPart)
+    {
+        return $queryPart.' IS NULL';
+    }
+
+    /**
+     * @param string $alias
+     * @param string $parameter
+     *
+     * @return string
+     */
+    public function notIn($alias, $parameter)
+    {
+        return sprintf('%s NOT IN %s', $alias, $parameter);
+    }
+
+    /**
+     * @return array
+     */
+    public function getAllAliases()
+    {
+        return array($this->getRootAlias());
     }
 }

--- a/Tests/Filter/StringFilterTest.php
+++ b/Tests/Filter/StringFilterTest.php
@@ -61,7 +61,7 @@ class StringFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $builder->query);
 
         $filter->filter($builder, 'alias', 'field', array('value' => 'asd', 'type' => ChoiceType::TYPE_NOT_CONTAINS));
-        $this->assertEquals(array('alias.field NOT LIKE :field_name_0'), $builder->query);
+        $this->assertEquals(array('alias.field NOT LIKE :field_name_0', 'alias.field IS NULL'), $builder->query[0]->getParts());
         $this->assertEquals(array('field_name_0' => 'asd'), $builder->parameters);
         $this->assertEquals(true, $filter->isActive());
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch because it's a bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Consider NULL values when using 'does not contain' advanced string filter
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->

TYPE_NOT_CONTAINS advanced filter should consider also the NULL values. Instead of

$alias.$field NOT LIKE :$parameterName

you should have

$alias.$field NOT LIKE :$parameterName OR $alias.$field IS NULL

If you have the following values for a field 

['Susoo', NULL, 'Bibee']

If you filter by << does not contain 'Susoo' >>, it should return [NULL, 'Bibee'], not only ['Bibee'] as it is implemented right now.