### PR TITLE
TYPE_IS_NOT_EQUAL doesn't consider NULL values

### DIFF
--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -98,8 +98,8 @@ class ModelFilter extends Filter
         if (isset($data['type']) && $data['type'] == EqualType::TYPE_IS_NOT_EQUAL) {
             $or = $queryBuilder->expr()->orX();
 
-            $or->add($queryBuilder->expr()->notIn($alias, ':' . $parameterName));
-            
+            $or->add($queryBuilder->expr()->notIn($alias, ':'.$parameterName));
+
             $allAliases = $queryBuilder->getAllAliases();
             $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $allAliases[0], $this->getFieldName())));
 
@@ -129,8 +129,8 @@ class ModelFilter extends Filter
         if (isset($data['type']) && $data['type'] == EqualType::TYPE_IS_NOT_EQUAL) {
             $or = $queryBuilder->expr()->orX();
 
-            $or->add($queryBuilder->expr()->neq($alias, ':' . $parameterName));
-            
+            $or->add($queryBuilder->expr()->neq($alias, ':'.$parameterName));
+
             $allAliases = $queryBuilder->getAllAliases();
             $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $allAliases[0], $this->getFieldName())));
 

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -99,7 +99,9 @@ class ModelFilter extends Filter
             $or = $queryBuilder->expr()->orX();
 
             $or->add($queryBuilder->expr()->notIn($alias, ':' . $parameterName));
-            $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $queryBuilder->getAllAliases()[0], $this->getFieldName())));
+            
+            $allAliases = $queryBuilder->getAllAliases();
+            $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $allAliases[0], $this->getFieldName())));
 
             $this->applyWhere($queryBuilder, $or);
         } else {
@@ -128,7 +130,9 @@ class ModelFilter extends Filter
             $or = $queryBuilder->expr()->orX();
 
             $or->add($queryBuilder->expr()->neq($alias, ':' . $parameterName));
-            $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $queryBuilder->getAllAliases()[0], $this->getFieldName())));
+            
+            $allAliases = $queryBuilder->getAllAliases();
+            $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $allAliases[0], $this->getFieldName())));
 
             $this->applyWhere($queryBuilder, $or);
         } else {

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -132,8 +132,9 @@ class ModelFilter extends Filter
 
             $or->add($queryBuilder->expr()->neq($alias, ':'.$parameterName));
 
-            $allAliases = $queryBuilder->getAllAliases();
-            $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $allAliases[0], $this->getFieldName())));
+            $or->add($queryBuilder->expr()->isNull(
+                sprintf('IDENTITY(%s.%s)', $queryBuilder->getRootAlias(), $this->getFieldName())
+            ));
 
             $this->applyWhere($queryBuilder, $or);
         } else {

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -96,7 +96,12 @@ class ModelFilter extends Filter
         $parameterName = $this->getNewParameterName($queryBuilder);
 
         if (isset($data['type']) && $data['type'] == EqualType::TYPE_IS_NOT_EQUAL) {
-            $this->applyWhere($queryBuilder, $queryBuilder->expr()->notIn($alias, ':'.$parameterName));
+            $or = $queryBuilder->expr()->orX();
+
+            $or->add($queryBuilder->expr()->notIn($alias, ':' . $parameterName));
+            $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $queryBuilder->getAllAliases()[0], $this->getFieldName())));
+
+            $this->applyWhere($queryBuilder, $or);
         } else {
             $this->applyWhere($queryBuilder, $queryBuilder->expr()->in($alias, ':'.$parameterName));
         }
@@ -120,7 +125,12 @@ class ModelFilter extends Filter
         $parameterName = $this->getNewParameterName($queryBuilder);
 
         if (isset($data['type']) && $data['type'] == EqualType::TYPE_IS_NOT_EQUAL) {
-            $this->applyWhere($queryBuilder, sprintf('%s != :%s', $alias, $parameterName));
+            $or = $queryBuilder->expr()->orX();
+
+            $or->add($queryBuilder->expr()->neq($alias, ':' . $parameterName));
+            $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $queryBuilder->getAllAliases()[0], $this->getFieldName())));
+
+            $this->applyWhere($queryBuilder, $or);
         } else {
             $this->applyWhere($queryBuilder, sprintf('%s = :%s', $alias, $parameterName));
         }

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -33,7 +33,7 @@ class ModelFilter extends Filter
         }
 
         if (!is_array($data['value'])) {
-            $data['value'] = (array)$data['value'];
+            $data['value'] = (array) $data['value'];
         }
 
         $this->handleMultiple($queryBuilder, $alias, $data);

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -100,8 +100,9 @@ class ModelFilter extends Filter
 
             $or->add($queryBuilder->expr()->notIn($alias, ':'.$parameterName));
 
-            $allAliases = $queryBuilder->getAllAliases();
-            $or->add($queryBuilder->expr()->isNull(sprintf('IDENTITY(%s.%s)', $allAliases[0], $this->getFieldName())));
+            $or->add($queryBuilder->expr()->isNull(
+                sprintf('IDENTITY(%s.%s)', $queryBuilder->getRootAlias(), $this->getFieldName())
+            ));
 
             $this->applyWhere($queryBuilder, $or);
         } else {

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -101,7 +101,7 @@ class ModelFilter extends Filter
             $or->add($queryBuilder->expr()->notIn($alias, ':'.$parameterName));
 
             $or->add($queryBuilder->expr()->isNull(
-                sprintf('IDENTITY(%s.%s)', $queryBuilder->getRootAlias(), $this->getFieldName())
+                sprintf('IDENTITY(%s.%s)', current(($queryBuilder->getRootAliases())), $this->getFieldName())
             ));
 
             $this->applyWhere($queryBuilder, $or);

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -24,7 +24,7 @@ class ModelFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
+        if (!$data || !is_array($data) || !array_key_exists('value', $data) || empty($data['value'])) {
             return;
         }
 
@@ -32,11 +32,11 @@ class ModelFilter extends Filter
             $data['value'] = $data['value']->toArray();
         }
 
-        if (is_array($data['value'])) {
-            $this->handleMultiple($queryBuilder, $alias, $data);
-        } else {
-            $this->handleModel($queryBuilder, $alias, $data);
+        if (!is_array($data['value'])) {
+            $data['value'] = (array)$data['value'];
         }
+
+        $this->handleMultiple($queryBuilder, $alias, $data);
     }
 
     /**
@@ -107,38 +107,6 @@ class ModelFilter extends Filter
             $this->applyWhere($queryBuilder, $or);
         } else {
             $this->applyWhere($queryBuilder, $queryBuilder->expr()->in($alias, ':'.$parameterName));
-        }
-
-        $queryBuilder->setParameter($parameterName, $data['value']);
-    }
-
-    /**
-     * @param ProxyQueryInterface|QueryBuilder $queryBuilder
-     * @param string                           $alias
-     * @param mixed                            $data
-     *
-     * @return mixed
-     */
-    protected function handleModel(ProxyQueryInterface $queryBuilder, $alias, $data)
-    {
-        if (empty($data['value'])) {
-            return;
-        }
-
-        $parameterName = $this->getNewParameterName($queryBuilder);
-
-        if (isset($data['type']) && $data['type'] == EqualType::TYPE_IS_NOT_EQUAL) {
-            $or = $queryBuilder->expr()->orX();
-
-            $or->add($queryBuilder->expr()->neq($alias, ':'.$parameterName));
-
-            $or->add($queryBuilder->expr()->isNull(
-                sprintf('IDENTITY(%s.%s)', $queryBuilder->getRootAlias(), $this->getFieldName())
-            ));
-
-            $this->applyWhere($queryBuilder, $or);
-        } else {
-            $this->applyWhere($queryBuilder, sprintf('%s = :%s', $alias, $parameterName));
         }
 
         $queryBuilder->setParameter($parameterName, $data['value']);

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -60,6 +60,25 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         // the alias is now computer by the entityJoin method
         $this->assertEquals(array('in_alias', 'in_alias IN :field_name_0'), $builder->query);
+        $this->assertEquals(array('field_name_0' => array('1', '2')), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
+    }
+
+    public function testFilterArrayTypeIsNotEqual()
+    {
+        $filter = new ModelFilter();
+        $filter->initialize('field_name', array('field_options' => array('class' => 'FooBar'), 'field_name' => 'field_name'));
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $filter->filter($builder, 'alias', 'field', array(
+            'type' => EqualType::TYPE_IS_NOT_EQUAL,
+            'value' => array('1', '2'),
+        ));
+        
+        // the alias is now computer by the entityJoin method
+        $this->assertEquals(array('alias NOT IN :field_name_0', 'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'), $builder->query[0]->getParts());
+        $this->assertEquals(array('field_name_0' => array('1', '2')), $builder->parameters);
         $this->assertEquals(true, $filter->isActive());
     }
 
@@ -73,6 +92,20 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('type' => EqualType::TYPE_IS_EQUAL, 'value' => 2));
 
         $this->assertEquals(array('alias = :field_name_0'), $builder->query);
+        $this->assertEquals(array('field_name_0' => 2), $builder->parameters);
+        $this->assertEquals(true, $filter->isActive());
+    }
+
+    public function testFilterScalarTypeIsNotEqual()
+    {
+        $filter = new ModelFilter();
+        $filter->initialize('field_name', array('field_options' => array('class' => 'FooBar'), 'field_name' => 'field_name'));
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $filter->filter($builder, 'alias', 'field', array('type' => EqualType::TYPE_IS_NOT_EQUAL, 'value' => 2));
+
+        $this->assertEquals(array('alias <> :field_name_0', 'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'), $builder->query[0]->getParts());
         $this->assertEquals(array('field_name_0' => 2), $builder->parameters);
         $this->assertEquals(true, $filter->isActive());
     }

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -43,7 +43,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array());
 
         $this->assertEquals(array(), $builder->query);
-        $this->assertEquals(false, $filter->isActive());
+        $this->assertTrue($filter->isActive());
     }
 
     public function testFilterArray()
@@ -61,7 +61,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         // the alias is now computer by the entityJoin method
         $this->assertEquals(array('in_alias', 'in_alias IN :field_name_0'), $builder->query);
         $this->assertEquals(array('field_name_0' => array('1', '2')), $builder->parameters);
-        $this->assertEquals(true, $filter->isActive());
+        $this->assertTrue($filter->isActive());
     }
 
     public function testFilterArrayTypeIsNotEqual()
@@ -77,9 +77,12 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         ));
 
         // the alias is now computer by the entityJoin method
-        $this->assertEquals(array('alias NOT IN :field_name_0', 'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'), $builder->query[0]->getParts());
+        $this->assertEquals(array(
+            'alias NOT IN :field_name_0', 
+            'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'
+        ), $builder->query[0]->getParts());
         $this->assertEquals(array('field_name_0' => array('1', '2')), $builder->parameters);
-        $this->assertEquals(true, $filter->isActive());
+        $this->assertTrue($filter->isActive());
     }
 
     public function testFilterScalar()
@@ -93,7 +96,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('alias = :field_name_0'), $builder->query);
         $this->assertEquals(array('field_name_0' => 2), $builder->parameters);
-        $this->assertEquals(true, $filter->isActive());
+        $this->assertTrue($filter->isActive());
     }
 
     public function testFilterScalarTypeIsNotEqual()
@@ -105,9 +108,12 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         $filter->filter($builder, 'alias', 'field', array('type' => EqualType::TYPE_IS_NOT_EQUAL, 'value' => 2));
 
-        $this->assertEquals(array('alias <> :field_name_0', 'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'), $builder->query[0]->getParts());
+        $this->assertEquals(array(
+            'alias <> :field_name_0', 
+            'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'
+        ), $builder->query[0]->getParts());
         $this->assertEquals(array('field_name_0' => 2), $builder->parameters);
-        $this->assertEquals(true, $filter->isActive());
+        $this->assertTrue($filter->isActive());
     }
 
     /**
@@ -134,7 +140,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $builder = new ProxyQuery(new QueryBuilder());
 
         $filter->apply($builder, array('value' => 'asd'));
-        $this->assertEquals(true, $filter->isActive());
+        $this->assertTrue($filter->isActive());
     }
 
     public function testAssociationWithValidMapping()
@@ -152,8 +158,11 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         $filter->apply($builder, array('type' => EqualType::TYPE_IS_EQUAL, 'value' => 'asd'));
 
-        $this->assertEquals(array('o.association_mapping', 's_association_mapping = :field_name_0'), $builder->query);
-        $this->assertEquals(true, $filter->isActive());
+        $this->assertEquals(array(
+            'o.association_mapping', 
+            's_association_mapping = :field_name_0'
+        ), $builder->query);
+        $this->assertTrue($filter->isActive());
     }
 
     public function testAssociationWithValidParentAssociationMappings()
@@ -185,6 +194,6 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
             's_association_mapping_sub_association_mapping.sub_sub_association_mapping',
             's_association_mapping_sub_association_mapping_sub_sub_association_mapping = :field_name_0',
         ), $builder->query);
-        $this->assertEquals(true, $filter->isActive());
+        $this->assertTrue($filter->isActive());
     }
 }

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -79,7 +79,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         // the alias is now computer by the entityJoin method
         $this->assertEquals(array(
             'alias NOT IN :field_name_0',
-            'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL',
+            'IDENTITY('.current(($builder->getRootAliases())).'.field_name) IS NULL',
         ), $builder->query[0]->getParts());
         $this->assertEquals(array('field_name_0' => array('1', '2')), $builder->parameters);
         $this->assertTrue($filter->isActive());
@@ -110,7 +110,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array(
             'alias NOT IN :field_name_0',
-            'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL',
+            'IDENTITY('.current(($builder->getRootAliases())).'.field_name) IS NULL',
         ), $builder->query[0]->getParts());
 
         $this->assertEquals(array('field_name_0' => array(2)), $builder->parameters);

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -43,7 +43,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array());
 
         $this->assertEquals(array(), $builder->query);
-        $this->assertTrue($filter->isActive());
+        $this->assertFalse($filter->isActive());
     }
 
     public function testFilterArray()

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -94,8 +94,8 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         $filter->filter($builder, 'alias', 'field', array('type' => EqualType::TYPE_IS_EQUAL, 'value' => 2));
 
-        $this->assertEquals(array('alias = :field_name_0'), $builder->query);
-        $this->assertEquals(array('field_name_0' => 2), $builder->parameters);
+        $this->assertEquals(array('in_alias', 'in_alias IN :field_name_0'), $builder->query);
+        $this->assertEquals(array('field_name_0' => array(2)), $builder->parameters);
         $this->assertTrue($filter->isActive());
     }
 
@@ -109,10 +109,11 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('type' => EqualType::TYPE_IS_NOT_EQUAL, 'value' => 2));
 
         $this->assertEquals(array(
-            'alias <> :field_name_0',
+            'alias NOT IN :field_name_0',
             'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL',
         ), $builder->query[0]->getParts());
-        $this->assertEquals(array('field_name_0' => 2), $builder->parameters);
+
+        $this->assertEquals(array('field_name_0' => array(2)), $builder->parameters);
         $this->assertTrue($filter->isActive());
     }
 
@@ -160,7 +161,8 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array(
             'o.association_mapping',
-            's_association_mapping = :field_name_0',
+            'in_s_association_mapping',
+            'in_s_association_mapping IN :field_name_0',
         ), $builder->query);
         $this->assertTrue($filter->isActive());
     }
@@ -192,7 +194,8 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
             'o.association_mapping',
             's_association_mapping.sub_association_mapping',
             's_association_mapping_sub_association_mapping.sub_sub_association_mapping',
-            's_association_mapping_sub_association_mapping_sub_sub_association_mapping = :field_name_0',
+            'in_s_association_mapping_sub_association_mapping_sub_sub_association_mapping',
+            'in_s_association_mapping_sub_association_mapping_sub_sub_association_mapping IN :field_name_0',
         ), $builder->query);
         $this->assertTrue($filter->isActive());
     }

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -78,8 +78,8 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
 
         // the alias is now computer by the entityJoin method
         $this->assertEquals(array(
-            'alias NOT IN :field_name_0', 
-            'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'
+            'alias NOT IN :field_name_0',
+            'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL',
         ), $builder->query[0]->getParts());
         $this->assertEquals(array('field_name_0' => array('1', '2')), $builder->parameters);
         $this->assertTrue($filter->isActive());
@@ -109,8 +109,8 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->filter($builder, 'alias', 'field', array('type' => EqualType::TYPE_IS_NOT_EQUAL, 'value' => 2));
 
         $this->assertEquals(array(
-            'alias <> :field_name_0', 
-            'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'
+            'alias <> :field_name_0',
+            'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL',
         ), $builder->query[0]->getParts());
         $this->assertEquals(array('field_name_0' => 2), $builder->parameters);
         $this->assertTrue($filter->isActive());
@@ -159,8 +159,8 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
         $filter->apply($builder, array('type' => EqualType::TYPE_IS_EQUAL, 'value' => 'asd'));
 
         $this->assertEquals(array(
-            'o.association_mapping', 
-            's_association_mapping = :field_name_0'
+            'o.association_mapping',
+            's_association_mapping = :field_name_0',
         ), $builder->query);
         $this->assertTrue($filter->isActive());
     }

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -75,7 +75,7 @@ class ModelFilterTest extends \PHPUnit_Framework_TestCase
             'type' => EqualType::TYPE_IS_NOT_EQUAL,
             'value' => array('1', '2'),
         ));
-        
+
         // the alias is now computer by the entityJoin method
         $this->assertEquals(array('alias NOT IN :field_name_0', 'IDENTITY('.$builder->getRootAlias().'.field_name) IS NULL'), $builder->query[0]->getParts());
         $this->assertEquals(array('field_name_0' => array('1', '2')), $builder->parameters);

--- a/Tests/Filter/QueryBuilder.php
+++ b/Tests/Filter/QueryBuilder.php
@@ -71,7 +71,7 @@ class QueryBuilder
      */
     public function getRootAlias()
     {
-        return 'o';
+        return current(($this->getRootAliases()));
     }
 
     /**
@@ -128,6 +128,14 @@ class QueryBuilder
      */
     public function getAllAliases()
     {
-        return array($this->getRootAlias());
+        return $this->getRootAliases();
+    }
+
+    /**
+     * @return array
+     */
+    public function getRootAliases()
+    {
+        return array('o');
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch because it's a bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Consider NULL values when using 'is not equal' advanced model filter
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation

## Subject

<!-- Describe your Pull Request content here -->

TYPE_IS_NOT_EQUAL advanced filter should consider also the NULL values. Instead of

$alias NOT LIKE != :$parameterName

you should have

$alias NOT LIKE != :$parameterName OR $alias.$field IS NULL

If you have the following values for an entity filter 

[3, NULL, 5]

If you filter by << does not contain '3' >>, it should return [NULL, '5'], not only ['5'] as it is implemented right now.