### PR TITLE
Remove deprecated translation logic

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
@@ -23,11 +23,7 @@ file that was distributed with this source code.
                             style="display:none;"
                         {% endif %}
                     >
-                        {{ nested_field.vars['sonata_admin'].admin.trans(
-                            nested_field.vars.label,
-                            {},
-                            nested_field.vars.translation_domain
-                        ) }}
+                        {{ nested_field.vars.label|trans({}, nested_field.vars.translation_domain) }}
                     </th>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
I am targetting this branch, because this is BC.

Partially closes sonata-project/SonataAdminBundle#4229

## Changelog

```markdown
### Changed
- translation in twig templates uses the twig translation filter

## Subject

Removes deprecated translations calls from the `AdminInterface::trans` method.
