### PR TITLE
Use the right array conversion for filter value

### DIFF
--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -33,7 +33,7 @@ class ModelFilter extends Filter
         }
 
         if (!is_array($data['value'])) {
-            $data['value'] = (array) $data['value'];
+            $data['value'] = array($data['value']);
         }
 
         $this->handleMultiple($queryBuilder, $alias, $data);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it's a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #652

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Use the right array conversion for filter value

```
## Subject

The filter value object was converted to array by mistake, now it's just added as the first and unique item of an array, in order to be well processed by the handleMultiple() method.
