### PR TITLE
Fixed wrong entity link in list view

### DIFF
--- a/Resources/views/CRUD/list_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_one.html.twig
@@ -14,7 +14,11 @@ file that was distributed with this source code.
 {% block field %}
     {% if value %}
         {% set route_name = field_description.options.route.name %}
-        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
+        {% if not field_description.options.identifier|default(false) and
+              field_description.hasAssociationAdmin and
+              field_description.associationadmin.hasRoute(route_name) and
+              field_description.associationadmin.hasAccess(route_name, value)
+        %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
                 {{ value|render_relation_element(field_description) }}
             </a>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed wrong link generation when calling `DatagridMapper::addIdentifier` on mapped field

```

## Subject

When calling `DatagridMapper::addIdentifier` on a mapped field, the link is generated to the fields admin edit page instead of the current admin edit page.
