### PR TITLE
Fixed duplicate translation of "Delete" in edit tab view

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
@@ -56,10 +56,7 @@ file that was distributed with this source code.
             </div>
 
             {% if nested_group_field['_delete'] is defined %}
-                {{ form_row(
-                    nested_group_field['_delete'],
-                    {'label': ('action_delete'|trans({}, 'SonataAdminBundle'))}
-                ) }}
+                {{ form_row(nested_group_field['_delete'], {'label': 'action_delete', 'translation_domain': 'SonataAdminBundle'}) }}
             {% endif %}
         </div>
     {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed duplicate translation of "Delete" in edit tab view
```

## Subject

The translation is already handled in the form component, no need for a manual translation using twig function.
