### PR TITLE
Fix check access to object in view

### DIFF
--- a/Resources/views/CRUD/list_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_many.html.twig
@@ -24,17 +24,18 @@ file that was distributed with this source code.
         {% endfor %}
     {% else %}
         {% for element in value%}
-            {{ block('relation_value') }}{% if not loop.last %}, {% endif %}
+            {{ block('relation_value') }}
+            {% if not loop.last %}, {% endif %}
         {% endfor %}
     {% endif %}
 {% endblock %}
 
 {%- block relation_link -%}
     <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
-        {{ element|render_relation_element(field_description) }}
+        {{- element|render_relation_element(field_description) -}}
     </a>
 {%- endblock -%}
 
 {%- block relation_value -%}
-    {{ element|render_relation_element(field_description) }}
+    {{- element|render_relation_element(field_description) -}}
 {%- endblock -%}

--- a/Resources/views/CRUD/list_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_many_to_many.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
     {% set route_name = field_description.options.route.name %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) %}
         {% for element in value %}
-            {%- if field_description.associationadmin.hasAccess(route_name, value) -%}
+            {%- if field_description.associationadmin.hasAccess(route_name, element) -%}
                 {{ block('relation_link') }}
             {%- else -%}
                 {{ block('relation_value') }}

--- a/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -31,10 +31,10 @@ file that was distributed with this source code.
 
 {%- block relation_link -%}
     <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
-        {{ element|render_relation_element(field_description) }}
+        {{- element|render_relation_element(field_description) -}}
     </a>
 {%- endblock -%}
 
 {%- block relation_value -%}
-    {{ element|render_relation_element(field_description) }}
+    {{- element|render_relation_element(field_description) -}}
 {%- endblock -%}

--- a/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
     {% set route_name = field_description.options.route.name %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) %}
         {% for element in value %}
-            {%- if field_description.associationadmin.hasAccess(route_name, value) -%}
+            {%- if field_description.associationadmin.hasAccess(route_name, element) -%}
                 {{ block('relation_link') }}
             {%- else -%}
                 {{ block('relation_value') }}

--- a/Resources/views/CRUD/list_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/list_orm_one_to_one.html.twig
@@ -13,7 +13,10 @@ file that was distributed with this source code.
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}
-    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
+    {% if field_description.hasAssociationAdmin
+    and field_description.associationadmin.id(value)
+    and field_description.associationadmin.hasRoute(route_name)
+    and field_description.associationadmin.hasAccess(route_name, value) %}
         <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
     {% else %}
         {{ value|render_relation_element(field_description) }}

--- a/Resources/views/CRUD/show_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_many.html.twig
@@ -11,12 +11,14 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
-{% block field%}
+{% block field %}
     <ul class="sonata-ba-show-many-to-many">
     {% set route_name = field_description.options.route.name %}
         {% for element in value %}
             <li>
-                {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value)%}
+                {% if field_description.hasassociationadmin
+                and field_description.associationadmin.hasRoute(route_name)
+                and field_description.associationadmin.hasAccess(route_name, element) %}
                     <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
                         {{ element|render_relation_element(field_description) }}
                     </a>

--- a/Resources/views/CRUD/show_orm_many_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_many_to_one.html.twig
@@ -14,7 +14,9 @@ file that was distributed with this source code.
 {% block field %}
     {% if value %}
         {% set route_name = field_description.options.route.name %}
-        {% if field_description.hasAssociationAdmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
+        {% if field_description.hasAssociationAdmin
+        and field_description.associationadmin.hasRoute(route_name)
+        and field_description.associationadmin.hasAccess(route_name, value) %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
                 {{ value|render_relation_element(field_description) }}
             </a>

--- a/Resources/views/CRUD/show_orm_one_to_many.html.twig
+++ b/Resources/views/CRUD/show_orm_one_to_many.html.twig
@@ -11,12 +11,18 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
-{% block field%}
+{% block field %}
     <ul class="sonata-ba-show-one-to-many">
     {% set route_name = field_description.options.route.name %}
     {% for element in value%}
-        {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
-            <li><a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">{{ element|render_relation_element(field_description) }}</a></li>
+        {% if field_description.hasassociationadmin
+        and field_description.associationadmin.hasRoute(route_name)
+        and field_description.associationadmin.hasAccess(route_name, element) %}
+            <li>
+                <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
+                    {{ element|render_relation_element(field_description) }}
+                </a>
+            </li>
         {% else %}
             <li>{{ element|render_relation_element(field_description) }}</li>
         {% endif %}

--- a/Resources/views/CRUD/show_orm_one_to_one.html.twig
+++ b/Resources/views/CRUD/show_orm_one_to_one.html.twig
@@ -13,7 +13,10 @@ file that was distributed with this source code.
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}
-    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) and field_description.associationadmin.hasRoute(route_name) and field_description.associationadmin.hasAccess(route_name, value) %}
+    {% if field_description.hasAssociationAdmin
+    and field_description.associationadmin.id(value)
+    and field_description.associationadmin.hasRoute(route_name)
+    and field_description.associationadmin.hasAccess(route_name, value) %}
         <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
             {{ value|render_relation_element(field_description) }}
         </a>


### PR DESCRIPTION
Should be check access to the element, not for whole collection.

I am targetting this branch, because this a bugfix.

## Changelog

```markdown
### Security
- Fixed view - check specific item collection, not to the whole collection.
```
## Subject

The error occurs in the view that displays the individual elements of the relationship many-to-many.
