### PR TITLE
Allow simplethings/entity-audit-bundle ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "knplabs/knp-menu-bundle": "^2.1.1",
-        "simplethings/entity-audit-bundle": "0.1 - 0.9",
+        "simplethings/entity-audit-bundle": "0.1 - 0.9 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },


### PR DESCRIPTION
I am targetting this branch, because this is BC.

Refs https://github.com/sonata-project/dev-kit/issues/216


This is pedantic because it's only about a development dependency.