### PR TITLE
Fixed wrong translation in one_to_many template

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
@@ -50,7 +50,7 @@ file that was distributed with this source code.
                             {% set dummy = nested_group_field.setrendered %}
                         {% else %}
                             {% if field_name == '_delete' %}
-                                {{ form_widget(nested_field, {'label_render': false}) }}
+                                {{ form_widget(nested_field, { label: false }) }}
                             {% else %}
                                 {{ form_widget(nested_field) }}
                             {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed wrong translation in delete checkbox in `edit_orm_one_to_many_inline_table.html.twig`
```
## Subject

When adding a collection field to the admin form with a sortable position, the `Delete` button will be translated by mistake. The label isn't visible at all in this view.

<!-- Describe your Pull Request content here -->
<img width="1048" alt="bildschirmfoto 2017-02-04 um 18 40 35" src="https://cloud.githubusercontent.com/assets/3440437/22620317/8bfd04c2-eb09-11e6-9104-a32fa628ba6a.PNG">
