### PR TITLE
update one to many documentation

### DIFF
--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -200,8 +200,8 @@ The AdminBundle provides 2 options:
 Advanced Usage: One-to-many
 ---------------------------
 
-Let's say you have a ``Gallery`` that links to some ``Media``s with a join table ``galleryHasMedias``.
-You can easily add a new ``galleryHasMedias`` row by defining one of these options:
+Let's say you have a ``Gallery`` that links to some ``Media``.
+You can easily add a new ``Media`` row by defining one of these options:
 
 * ``edit``: ``inline|standard``, the inline mode allows you to add new rows,
 * ``inline``: ``table|standard``, the fields are displayed into table,
@@ -227,16 +227,23 @@ You can easily add a new ``galleryHasMedias`` row by defining one of these optio
                 ->add('enabled')
                 ->add('name')
                 ->add('defaultFormat')
-                ->add('galleryHasMedias', 'sonata_type_collection', array(), array(
-                    'edit' => 'inline',
-                    'inline' => 'table',
-                    'sortable' => 'position',
-                    'limit' => 3
+                ->add('galleryHasMedias', 'sonata_type_collection', array(
+                        'by_reference' => false
+                    ), 
+                    array(
+                        'edit' => 'inline',
+                        'inline' => 'table',
+                        'sortable' => 'position',
+                        'limit' => 3
                 ))
             ;
         }
     }
+    
+.. note:: 
 
+    You have to define ``setMedias`` method into your ``Gallery`` class and manually attach each ``media`` to the current ``gallery`` and define the media's relation into ``gallery`` as cascade persist.
+    
 By default, position row will be rendered. If you want to hide it, you will need to alter child  admin class and add hidden position field.
 Use code like:
 

--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -242,7 +242,7 @@ You can easily add a new ``Media`` row by defining one of these options:
     
 .. note:: 
 
-    You have to define ``setMedias`` method into your ``Gallery`` class and manually attach each ``media`` to the current ``gallery`` and define the media's relation into ``gallery`` as cascade persist.
+    You have to define the ``setMedias`` method into your ``Gallery`` class and manually attach each ``media`` to the current ``gallery`` and define cascading persistence for the relationship from media to gallery.
     
 By default, position row will be rendered. If you want to hide it, you will need to alter child  admin class and add hidden position field.
 Use code like:

--- a/Resources/doc/reference/form_field_definition.rst
+++ b/Resources/doc/reference/form_field_definition.rst
@@ -217,6 +217,7 @@ You can easily add a new ``Media`` row by defining one of these options:
     use Sonata\AdminBundle\Form\FormMapper;
     use Sonata\AdminBundle\Datagrid\DatagridMapper;
     use Sonata\AdminBundle\Datagrid\ListMapper;
+    use Sonata\CoreBundle\Form\Type\CollectionType;
 
     class GalleryAdmin extends Admin
     {
@@ -227,7 +228,7 @@ You can easily add a new ``Media`` row by defining one of these options:
                 ->add('enabled')
                 ->add('name')
                 ->add('defaultFormat')
-                ->add('galleryHasMedias', 'sonata_type_collection', array(
+                ->add('galleryHasMedias', CollectionType::class, array(
                         'by_reference' => false
                     ), 
                     array(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, to enhance documentation.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/4236

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Simplify and complete documentation for one-to-many relation