### PR TITLE
fixes #672 build actions field description based on provided type too

### DIFF
--- a/Builder/ListBuilder.php
+++ b/Builder/ListBuilder.php
@@ -79,7 +79,7 @@ class ListBuilder implements ListBuilderInterface
      */
     public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription)
     {
-        if ($fieldDescription->getName() == '_action') {
+        if ($fieldDescription->getName() === '_action' || $fieldDescription->getType() === 'actions') {
             $this->buildActionFieldDescription($fieldDescription);
         }
 
@@ -164,7 +164,7 @@ class ListBuilder implements ListBuilderInterface
         }
 
         if (null === $fieldDescription->getType()) {
-            $fieldDescription->setType('action');
+            $fieldDescription->setType('actions');
         }
 
         if (null === $fieldDescription->getOption('name')) {


### PR DESCRIPTION
I am targeting this branch, because it's a patch.

Closes #672

## Changelog

```markdown
### Fixed
- A list field with `actions` type will get all the required field options just like the `_action` field.
- `_action` field will get a proper `actions` type.
```
## Subject

`ListBuilder` fix.