### PR TITLE
Edit Inline when using sonata_type_collection with SubClasses is throwing error.

### DIFF
--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
@@ -35,18 +35,20 @@ file that was distributed with this source code.
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">
                                     {% for field_name in form_group.fields %}
-                                        {% set nested_field = nested_group_field.children[field_name] %}
-                                        <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
-                                            {% if associationAdmin.formfielddescriptions[field_name] is defined %}
-                                                {{ form_row(nested_field, {
-                                                    'inline': 'natural',
-                                                    'edit'  : 'inline'
-                                                }) }}
-                                                {% set dummy = nested_group_field.setrendered %}
-                                            {% else %}
-                                                {{ form_row(nested_field) }}
-                                            {% endif %}
-                                        </div>
+                                        {% if nested_group_field.children[field_name] is defined %}
+                                            {% set nested_field = nested_group_field.children[field_name] %}
+                                            <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
+                                                {% if associationAdmin.formfielddescriptions[field_name] is defined %}
+                                                    {{ form_row(nested_field, {
+                                                        'inline': 'natural',
+                                                        'edit'  : 'inline'
+                                                    }) }}
+                                                    {% set dummy = nested_group_field.setrendered %}
+                                                {% else %}
+                                                    {{ form_row(nested_field) }}
+                                                {% endif %}
+                                            </div>
+                                        {% endif %}
                                     {% endfor %}
                                 </div>
                             </fieldset>

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
@@ -34,21 +34,19 @@ file that was distributed with this source code.
                         >
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">
-                                    {% for field_name in form_group.fields %}
-                                        {% if nested_group_field.children[field_name] is defined %}
-                                            {% set nested_field = nested_group_field.children[field_name] %}
-                                            <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
-                                                {% if associationAdmin.formfielddescriptions[field_name] is defined %}
-                                                    {{ form_row(nested_field, {
-                                                        'inline': 'natural',
-                                                        'edit'  : 'inline'
-                                                    }) }}
-                                                    {% set dummy = nested_group_field.setrendered %}
-                                                {% else %}
-                                                    {{ form_row(nested_field) }}
-                                                {% endif %}
-                                            </div>
-                                        {% endif %}
+                                    {% for field_name in form_group.fields if nested_group_field.children[field_name] is defined %}
+                                        {% set nested_field = nested_group_field.children[field_name] %}
+                                        <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
+                                            {% if associationAdmin.formfielddescriptions[field_name] is defined %}
+                                                {{ form_row(nested_field, {
+                                                    'inline': 'natural',
+                                                    'edit'  : 'inline'
+                                                }) }}
+                                                {% set dummy = nested_group_field.setrendered %}
+                                            {% else %}
+                                                {{ form_row(nested_field) }}
+                                            {% endif %}
+                                        </div>
                                     {% endfor %}
                                 </div>
                             </fieldset>


### PR DESCRIPTION
When using setSubClasses and using tabs, error is thrown for fields that are not defined in one of the classes.

I am targeting this branch, because using setSubClasses with the inline and sonata_type_collection which uses `edit_orm_one_to_many_inline_tabs.html.twig` throws an error `Key "...." for array with keys "_delete, title, content ...." does not exist `.

## Changelog

```markdown
### Fixed
- don't display fields that are missing in child classes
```