### PR TITLE
throw MissingPropertyMetadataException if propertyName could not be found in mappings

### DIFF
--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -13,6 +13,7 @@ namespace Sonata\DoctrineORMAdminBundle\Guesser;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
@@ -64,6 +65,10 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
                     return new TypeGuess('doctrine_orm_model', $options, Guess::HIGH_CONFIDENCE);
             }
+        }
+
+        if (!array_key_exists($propertyName, $metadata->fieldMappings)) {
+            throw new MissingPropertyMetadataException($class, $property);
         }
 
         $options['field_name'] = $metadata->fieldMappings[$propertyName]['fieldName'];

--- a/Model/MissingPropertyMetadataException.php
+++ b/Model/MissingPropertyMetadataException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Model;
+
+class MissingPropertyMetadataException extends \LogicException
+{
+    public function __construct($class, $property)
+    {
+        parent::__construct(sprintf(
+            'No metadata found for property `%s::$%s`.'
+            .' Please make sure your Doctrine mapping is properly configured.',
+            $class,
+            $property
+        ));
+    }
+}

--- a/Model/MissingPropertyMetadataException.php
+++ b/Model/MissingPropertyMetadataException.php
@@ -11,7 +11,10 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Model;
 
-class MissingPropertyMetadataException extends \LogicException
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+final class MissingPropertyMetadataException extends \LogicException
 {
     public function __construct($class, $property)
     {

--- a/Model/MissingPropertyMetadataException.php
+++ b/Model/MissingPropertyMetadataException.php
@@ -16,6 +16,10 @@ namespace Sonata\DoctrineORMAdminBundle\Model;
  */
 final class MissingPropertyMetadataException extends \LogicException
 {
+    /**
+     * @param string $class
+     * @param string $property
+     */
     public function __construct($class, $property)
     {
         parent::__construct(sprintf(

--- a/Tests/Guesser/FilterTypeGuesserTest.php
+++ b/Tests/Guesser/FilterTypeGuesserTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Sonata\DoctrineORMAdminBundle\Tests\Guesser;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineORMAdminBundle\Guesser\FilterTypeGuesser;
+
+class FilterTypeGuesserTest extends TestCase
+{
+    private $guesser;
+    private $modelManager;
+
+    protected function setUp()
+    {
+        $this->guesser = new FilterTypeGuesser();
+        $this->modelManager = $this->prophesize('Sonata\DoctrineORMAdminBundle\Model\ModelManager');
+        $this->metadata = $this->prophesize('Doctrine\ORM\Mapping\ClassMetadata');
+    }
+
+    /**
+     * @expectException Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException
+     */
+    public function testThrowsOnMissingField()
+    {
+        $class = 'My\Model';
+        $property = 'whatever';
+        $this->modelManager->getParentMetadataForProperty($class, $property)->willReturn([
+            $this->metadata->reveal(),
+            $property,
+            'parent mappings, no idea what it looks like'
+        ]);
+        $this->guesser->guessType($class, $property, $this->modelManager->reveal());
+    }
+}

--- a/Tests/Guesser/FilterTypeGuesserTest.php
+++ b/Tests/Guesser/FilterTypeGuesserTest.php
@@ -27,7 +27,7 @@ class FilterTypeGuesserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectException Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException
+     * @expectedException \Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException
      */
     public function testThrowsOnMissingField()
     {

--- a/Tests/Guesser/FilterTypeGuesserTest.php
+++ b/Tests/Guesser/FilterTypeGuesserTest.php
@@ -1,13 +1,23 @@
 <?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\DoctrineORMAdminBundle\Tests\Guesser;
 
-use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Guesser\FilterTypeGuesser;
 
-class FilterTypeGuesserTest extends TestCase
+class FilterTypeGuesserTest extends \PHPUnit_Framework_TestCase
 {
     private $guesser;
     private $modelManager;
+    private $metadata;
 
     protected function setUp()
     {
@@ -23,11 +33,11 @@ class FilterTypeGuesserTest extends TestCase
     {
         $class = 'My\Model';
         $property = 'whatever';
-        $this->modelManager->getParentMetadataForProperty($class, $property)->willReturn([
+        $this->modelManager->getParentMetadataForProperty($class, $property)->willReturn(array(
             $this->metadata->reveal(),
             $property,
-            'parent mappings, no idea what it looks like'
-        ]);
+            'parent mappings, no idea what it looks like',
+        ));
         $this->guesser->guessType($class, $property, $this->modelManager->reveal());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #599
Closes #695 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `MissingPropertyMetadataException` if property name is not found in field mappings
```

## Subject

<!-- Describe your Pull Request content here -->

throw `MissingPropertyMetadataException` if propertyName could not be found in mappings

This is based on: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/599/files#r69381571