### PR TITLE
use createMock() instead of deprecated getMock()

### DIFF
--- a/Tests/Admin/FieldDescriptionTest.php
+++ b/Tests/Admin/FieldDescriptionTest.php
@@ -158,7 +158,7 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 
     public function testGetAssociationAdmin()
     {
-        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\Admin');
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
         $adminMock->expects($this->once())
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface'));
@@ -171,7 +171,7 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 
     public function testHasAssociationAdmin()
     {
-        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\Admin');
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
         $adminMock->expects($this->once())
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface'));

--- a/Tests/Admin/FieldDescriptionTest.php
+++ b/Tests/Admin/FieldDescriptionTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\DoctrineORMAdminBundle\Tests\Admin;
 
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
+class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 {
     public function testOptions()
     {

--- a/Tests/Admin/FieldDescriptionTest.php
+++ b/Tests/Admin/FieldDescriptionTest.php
@@ -131,7 +131,7 @@ class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetParent()
     {
-        $adminMock = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $field = new FieldDescription();
         $field->setParent($adminMock);
 
@@ -148,7 +148,7 @@ class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAdmin()
     {
-        $adminMock = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $field = new FieldDescription();
         $field->setAdmin($adminMock);
 
@@ -157,9 +157,7 @@ class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAssociationAdmin()
     {
-        $adminMock = $this->getMockBuilder('Sonata\AdminBundle\Admin\Admin')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\Admin');
         $adminMock->expects($this->once())
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface'));
@@ -172,9 +170,7 @@ class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
     public function testHasAssociationAdmin()
     {
-        $adminMock = $this->getMockBuilder('Sonata\AdminBundle\Admin\Admin')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\Admin');
         $adminMock->expects($this->once())
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface'));
@@ -190,7 +186,9 @@ class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetValue()
     {
-        $mockedObject = $this->getMock('stdClass', array('myMethod'));
+        $mockedObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('myMethod'))
+            ->getMock();
         $mockedObject->expects($this->once())
             ->method('myMethod')
             ->will($this->returnValue('myMethodValue'));
@@ -206,7 +204,9 @@ class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetValueWhenCannotRetrieve()
     {
-        $mockedObject = $this->getMock('stdClass', array('myMethod'));
+        $mockedObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('myMethod'))
+            ->getMock();
         $mockedObject->expects($this->never())
             ->method('myMethod')
             ->will($this->returnValue('myMethodValue'));
@@ -333,12 +333,16 @@ class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetValueForEmbeddedObject()
     {
-        $mockedEmbeddedObject = $this->getMock('stdClass', array('myMethod'));
+        $mockedEmbeddedObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('myMethod'))
+            ->getMock();
         $mockedEmbeddedObject->expects($this->once())
                     ->method('myMethod')
                     ->will($this->returnValue('myMethodValue'));
 
-        $mockedObject = $this->getMock('stdClass', array('getMyEmbeddedObject'));
+        $mockedObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getMyEmbeddedObject'))
+            ->getMock();
         $mockedObject->expects($this->once())
             ->method('getMyEmbeddedObject')
             ->will($this->returnValue($mockedEmbeddedObject));

--- a/Tests/Builder/DatagridBuilderTest.php
+++ b/Tests/Builder/DatagridBuilderTest.php
@@ -43,30 +43,29 @@ final class DatagridBuilderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
-        $this->filterFactory = $this->getMock('Sonata\AdminBundle\Filter\FilterFactoryInterface');
-        $this->typeGuesser = $this->getMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $this->formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $this->filterFactory = $this->createMock('Sonata\AdminBundle\Filter\FilterFactoryInterface');
+        $this->typeGuesser = $this->createMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
 
         $this->datagridBuilder = new DatagridBuilder($this->formFactory, $this->filterFactory, $this->typeGuesser);
     }
 
     public function testGetBaseDatagrid()
     {
-        $admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AbstractAdmin')
-            ->disableOriginalConstructor()->getMock();
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
         $admin->expects($this->once())->method('getPagerType')->willReturn(Pager::TYPE_SIMPLE);
         $admin->expects($this->once())->method('getClass')->willReturn('Foo\Bar');
         $admin->expects($this->once())->method('createQuery')
-            ->willReturn($this->getMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+            ->willReturn($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
         $admin->expects($this->once())->method('getList')
-            ->willReturn($this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection'));
+            ->willReturn($this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection'));
 
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelManager->expects($this->once())->method('getIdentifierFieldNames')->willReturn(array('id'));
         $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
 
         $this->formFactory->expects($this->once())->method('createNamedBuilder')
-            ->willReturn($this->getMock('Symfony\Component\Form\FormBuilderInterface'));
+            ->willReturn($this->createMock('Symfony\Component\Form\FormBuilderInterface'));
 
         $this->assertInstanceOf('Sonata\AdminBundle\Datagrid\Datagrid', $this->datagridBuilder->getBaseDatagrid($admin));
     }

--- a/Tests/Builder/DatagridBuilderTest.php
+++ b/Tests/Builder/DatagridBuilderTest.php
@@ -15,12 +15,13 @@ use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\Filter\FilterFactoryInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\DoctrineORMAdminBundle\Builder\DatagridBuilder;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class DatagridBuilderTest extends \PHPUnit_Framework_TestCase
+final class DatagridBuilderTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var TypeGuesserInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -75,7 +75,7 @@ final class FormContractorTest extends PHPUnit_Framework_TestCase
         if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
             $classTypes = array(
                 'Sonata\AdminBundle\Form\Type\ModelType',
-                'Sonata\AdminBundle\Form\Type\ModelTypeList',
+                'Sonata\AdminBundle\Form\Type\ModelListType',
                 'Sonata\AdminBundle\Form\Type\ModelHiddenType',
                 'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
             );

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -13,12 +13,13 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\DoctrineORMAdminBundle\Builder\FormContractor;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class FormContractorTest extends \PHPUnit_Framework_TestCase
+final class FormContractorTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var FormFactoryInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -32,7 +32,7 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $this->formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $this->formContractor = new FormContractor($this->formFactory);
     }
@@ -40,7 +40,7 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
     public function testGetFormBuilder()
     {
         $this->formFactory->expects($this->once())->method('createNamedBuilder')
-            ->willReturn($this->getMock('Symfony\Component\Form\FormBuilderInterface'));
+            ->willReturn($this->createMock('Symfony\Component\Form\FormBuilderInterface'));
 
         $this->assertInstanceOf(
             'Symfony\Component\Form\FormBuilderInterface',
@@ -50,14 +50,14 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultOptionsForSonataFormTypes()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelClass = 'FooEntity';
 
         $admin->method('getModelManager')->willReturn($modelManager);
         $admin->method('getClass')->willReturn($modelClass);
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->method('getAdmin')->willReturn($admin);
         $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
@@ -85,11 +85,7 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
                     // add class type.
                     $classType,
                     // add instance of class type.
-                    get_class(
-                        $this->getMockBuilder($classType)
-                            ->disableOriginalConstructor()
-                            ->getMock()
-                    )
+                    get_class($this->createMock($classType))
                 );
             }
 
@@ -130,15 +126,13 @@ final class FormContractorTest extends \PHPUnit_Framework_TestCase
     public function testAdminClassAttachForNotMappedField()
     {
         // Given
-        $modelManager = $this->getMockBuilder('Sonata\DoctrineORMAdminBundle\Model\ModelManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $modelManager = $this->createMock('Sonata\DoctrineORMAdminBundle\Model\ModelManager');
         $modelManager->method('hasMetadata')->willReturn(false);
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->method('getModelManager')->willReturn($modelManager);
 
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->method('getMappingType')->willReturn('simple');
         $fieldDescription->method('getType')->willReturn('sonata_type_model_list');
         $fieldDescription->method('getOption')->with($this->logicalOr(

--- a/Tests/Datagrid/ProxyQueryTest.php
+++ b/Tests/Datagrid/ProxyQueryTest.php
@@ -75,7 +75,11 @@ class ProxyQueryTest extends PHPUnit_Framework_TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $q = $this->createMock('PDOStatement');
+        // NEXT MAJOR: Replace this when dropping PHP < 5.6
+        // $q = $this->createMock('PDOStatement');
+        $q = $this->getMockBuilder('stdClass')
+            ->setMethods(array('execute'))
+            ->getMock();
         $q->expects($this->any())
             ->method('execute')
             ->willReturn(array(array($id => $value)));

--- a/Tests/Datagrid/ProxyQueryTest.php
+++ b/Tests/Datagrid/ProxyQueryTest.php
@@ -16,8 +16,9 @@ use Doctrine\ORM\Query\Expr\From;
 use Doctrine\ORM\Query\Expr\OrderBy;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ProxyQueryTest extends \PHPUnit_Framework_TestCase
+class ProxyQueryTest extends PHPUnit_Framework_TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/Tests/Datagrid/ProxyQueryTest.php
+++ b/Tests/Datagrid/ProxyQueryTest.php
@@ -45,9 +45,7 @@ class ProxyQueryTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetFixedQueryBuilder($class, $alias, $id, $expectedId, $value, $identifierType)
     {
-        $meta = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $meta = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataInfo');
         $meta->expects($this->any())
             ->method('getIdentifierFieldNames')
             ->willReturn(array($id));
@@ -55,28 +53,20 @@ class ProxyQueryTest extends \PHPUnit_Framework_TestCase
             ->method('getTypeOfField')
             ->willReturn($identifierType);
 
-        $mf = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataFactory')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mf = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataFactory');
         $mf->expects($this->any())
             ->method('getMetadataFor')
             ->with($this->equalTo($class))
             ->willReturn($meta);
 
-        $platform = $this->getMockBuilder('Doctrine\DBAL\Platforms\PostgreSqlPlatform')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $platform = $this->createMock('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
 
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $conn = $this->createMock('Doctrine\DBAL\Connection');
         $conn->expects($this->any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $em = $this->createMock('Doctrine\ORM\EntityManager');
         $em->expects($this->any())
             ->method('getMetadataFactory')
             ->willReturn($mf);
@@ -84,7 +74,7 @@ class ProxyQueryTest extends \PHPUnit_Framework_TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $q = $this->getMock('PDOStatement');
+        $q = $this->createMock('PDOStatement');
         $q->expects($this->any())
             ->method('execute')
             ->willReturn(array(array($id => $value)));

--- a/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
@@ -37,7 +37,7 @@ class AddAuditEntityCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcess($force, array $services)
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 
         $container
             ->expects($this->any())

--- a/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
@@ -12,9 +12,10 @@
 namespace Sonata\DoctrineORMAdminBundle\Tests\DependencyInjection\Compiler;
 
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddAuditEntityCompilerPass;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\Definition;
 
-class AddAuditEntityCompilerPassTest extends \PHPUnit_Framework_TestCase
+class AddAuditEntityCompilerPassTest extends PHPUnit_Framework_TestCase
 {
     public function processDataProvider()
     {

--- a/Tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
@@ -12,9 +12,10 @@
 namespace Sonata\DoctrineORMAdminBundle\Tests\DependencyInjection\Compiler;
 
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddTemplatesCompilerPass;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\Definition;
 
-class AddTemplatesCompilerPassTest extends \PHPUnit_Framework_TestCase
+class AddTemplatesCompilerPassTest extends PHPUnit_Framework_TestCase
 {
     public function testDefaultBehavior()
     {

--- a/Tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
@@ -18,7 +18,7 @@ class AddTemplatesCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
     public function testDefaultBehavior()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 
         $container
             ->expects($this->any())

--- a/Tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
+++ b/Tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
@@ -10,10 +10,11 @@
  */
 
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\SonataDoctrineORMAdminExtension;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class SonataDoctrineORMAdminExtensionTest extends \PHPUnit_Framework_TestCase
+class SonataDoctrineORMAdminExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var ContainerBuilder

--- a/Tests/Filter/BooleanFilterTest.php
+++ b/Tests/Filter/BooleanFilterTest.php
@@ -14,8 +14,9 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 use Sonata\CoreBundle\Form\Type\BooleanType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\BooleanFilter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class BooleanFilterTest extends \PHPUnit_Framework_TestCase
+class BooleanFilterTest extends PHPUnit_Framework_TestCase
 {
     public function testFilterEmpty()
     {

--- a/Tests/Filter/CallbackFilterTest.php
+++ b/Tests/Filter/CallbackFilterTest.php
@@ -13,8 +13,9 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class CallbackFilterTest extends \PHPUnit_Framework_TestCase
+class CallbackFilterTest extends PHPUnit_Framework_TestCase
 {
     public function testFilterClosure()
     {

--- a/Tests/Filter/ChoiceFilterTest.php
+++ b/Tests/Filter/ChoiceFilterTest.php
@@ -14,8 +14,9 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ChoiceFilterTest extends \PHPUnit_Framework_TestCase
+class ChoiceFilterTest extends PHPUnit_Framework_TestCase
 {
     public function testFilterEmpty()
     {

--- a/Tests/Filter/ClassFilterTest.php
+++ b/Tests/Filter/ClassFilterTest.php
@@ -14,8 +14,9 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 use Sonata\CoreBundle\Form\Type\EqualType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\ClassFilter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ClassFilterTest extends \PHPUnit_Framework_TestCase
+class ClassFilterTest extends PHPUnit_Framework_TestCase
 {
     public function testFilterEmpty()
     {

--- a/Tests/Filter/DateRangeFilterTest.php
+++ b/Tests/Filter/DateRangeFilterTest.php
@@ -13,11 +13,12 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\DateRangeFilter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Patrick Landolt <patrick.landolt@artack.ch>
  */
-class DateRangeFilterTest extends \PHPUnit_Framework_TestCase
+class DateRangeFilterTest extends PHPUnit_Framework_TestCase
 {
     public function testFilterEmpty()
     {

--- a/Tests/Filter/FilterTest.php
+++ b/Tests/Filter/FilterTest.php
@@ -13,6 +13,7 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\Filter\Filter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 class FilterTest_Filter extends Filter
 {
@@ -48,7 +49,7 @@ class FilterTest_Filter extends Filter
     }
 }
 
-class FilterTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends PHPUnit_Framework_TestCase
 {
     public function testFieldDescription()
     {

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -15,8 +15,9 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\CoreBundle\Form\Type\EqualType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\ModelFilter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ModelFilterTest extends \PHPUnit_Framework_TestCase
+class ModelFilterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @param array $options

--- a/Tests/Filter/NumberFilterTest.php
+++ b/Tests/Filter/NumberFilterTest.php
@@ -14,8 +14,9 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 use Sonata\AdminBundle\Form\Type\Filter\NumberType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\NumberFilter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class NumberFilterTest extends \PHPUnit_Framework_TestCase
+class NumberFilterTest extends PHPUnit_Framework_TestCase
 {
     public function testFilterEmpty()
     {

--- a/Tests/Filter/StringFilterTest.php
+++ b/Tests/Filter/StringFilterTest.php
@@ -14,8 +14,9 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class StringFilterTest extends \PHPUnit_Framework_TestCase
+class StringFilterTest extends PHPUnit_Framework_TestCase
 {
     public function testEmpty()
     {

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception, $message = '', $code = null)
+    {
+        if (is_callable('parent::expectException')) {
+            parent::expectException($exception);
+
+            if ($message !== '') {
+                parent::expectExceptionMessage($message);
+            }
+
+            if ($code !== null) {
+                parent::expectExceptionCode($code);
+            }
+        }
+
+        return parent::setExpectedException($exception, $message, $code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+    }
+}

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -36,12 +36,12 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testSortParameters()
     {
-        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
 
         $manager = new ModelManager($registry);
 
-        $datagrid1 = $this->getMockBuilder('\Sonata\AdminBundle\Datagrid\Datagrid')->disableOriginalConstructor()->getMock();
-        $datagrid2 = $this->getMockBuilder('\Sonata\AdminBundle\Datagrid\Datagrid')->disableOriginalConstructor()->getMock();
+        $datagrid1 = $this->createMock('Sonata\AdminBundle\Datagrid\Datagrid');
+        $datagrid2 = $this->createMock('Sonata\AdminBundle\Datagrid\Datagrid');
 
         $field1 = new FieldDescription();
         $field1->setName('field1');
@@ -187,9 +187,7 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
 
         $object = new ContainerEntity(new AssociatedEntity(), new EmbeddedEntity());
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $em = $this->createMock('Doctrine\ORM\EntityManager');
 
         /** @var \PHPUnit_Framework_MockObject_MockObject|ModelManager $modelManager */
         $modelManager = $this->getMockBuilder($modelManagerClass)
@@ -297,9 +295,7 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
         $uuid = new NonIntegerIdentifierTestClass('efbcfc4b-8c43-4d42-aa4c-d707e55151ac');
         $entity = new UuidEntity($uuid);
 
-        $meta = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $meta = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataInfo');
         $meta->expects($this->any())
             ->method('getIdentifierValues')
             ->willReturn(array($entity->getId()));
@@ -307,27 +303,19 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getTypeOfField')
             ->willReturn(UuidType::NAME);
 
-        $mf = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataFactory')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mf = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataFactory');
         $mf->expects($this->any())
             ->method('getMetadataFor')
             ->willReturn($meta);
 
-        $platform = $this->getMockBuilder('Doctrine\DBAL\Platforms\PostgreSqlPlatform')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $platform = $this->createMock('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
 
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $conn = $this->createMock('Doctrine\DBAL\Connection');
         $conn->expects($this->any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $em = $this->createMock('Doctrine\ORM\EntityManager');
         $em->expects($this->any())
             ->method('getMetadataFactory')
             ->willReturn($mf);
@@ -335,9 +323,7 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
         $registry->expects($this->any())
             ->method('getManagerForClass')
             ->willReturn($em);
@@ -352,9 +338,7 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
     {
         $entity = new ContainerEntity(new AssociatedEntity(42), new EmbeddedEntity());
 
-        $meta = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $meta = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataInfo');
         $meta->expects($this->any())
             ->method('getIdentifierValues')
             ->willReturn(array($entity->getAssociatedEntity()->getPlainField()));
@@ -362,27 +346,19 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getTypeOfField')
             ->willReturn(null);
 
-        $mf = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataFactory')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mf = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataFactory');
         $mf->expects($this->any())
             ->method('getMetadataFor')
             ->willReturn($meta);
 
-        $platform = $this->getMockBuilder('Doctrine\DBAL\Platforms\PostgreSqlPlatform')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $platform = $this->createMock('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
 
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $conn = $this->createMock('Doctrine\DBAL\Connection');
         $conn->expects($this->any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $em = $this->createMock('Doctrine\ORM\EntityManager');
         $em->expects($this->any())
             ->method('getMetadataFactory')
             ->willReturn($mf);
@@ -390,9 +366,7 @@ class ModelManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
         $registry->expects($this->any())
             ->method('getManagerForClass')
             ->willReturn($em);

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -24,8 +24,9 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntit
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\VersionedEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
+use Sonata\DoctrineORMAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ModelManagerTest extends \PHPUnit_Framework_TestCase
+class ModelManagerTest extends PHPUnit_Framework_TestCase
 {
     public static function setUpBeforeClass()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

