### PR TITLE
fixes #679 change using preg_replace e modifier to preg_replace_callback

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -700,10 +700,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
      */
     protected function camelize($property)
     {
-        return preg_replace(
-            array('/(^|_)+(.)/e', '/\.(.)/e'),
-            array("strtoupper('\\2')", "'_'.strtoupper('\\1')"),
-            $property
-        );
+        $result = preg_replace_callback('/(^|_)+(.)/', function($matches){ return strtoupper($matches[2]); }, $property);
+        $result = preg_replace_callback('/\.(.)/', function($matches){ return '_'.strtoupper($matches[1]); }, $result);
+        return $result;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a warning removal.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #679

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added

### Changed
- Changed using preg_replace with e modifier to using preg_replace_callback

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
