### PR TITLE
ModelFilter fix when not_equal filtering for association depth >= 2

### DIFF
--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -140,9 +140,9 @@ class ModelFilter extends Filter
      * Root alias for direct association or entity joined alias for association depth >= 2.
      *
      * @param ProxyQueryInterface $queryBuilder
-     * @param $alias
+     * @param string $alias
      *
-     * @return mixed
+     * @return string
      */
     private function getParentAlias(ProxyQueryInterface $queryBuilder, $alias)
     {

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -140,7 +140,7 @@ class ModelFilter extends Filter
      * Root alias for direct association or entity joined alias for association depth >= 2.
      *
      * @param ProxyQueryInterface $queryBuilder
-     * @param string $alias
+     * @param string              $alias
      *
      * @return string
      */

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -137,7 +137,7 @@ class ModelFilter extends Filter
 
     /**
      * Retrieve the parent alias for given alias.
-     * Root alias for direct association or entity joined alias for association depth >= 2
+     * Root alias for direct association or entity joined alias for association depth >= 2.
      *
      * @param ProxyQueryInterface $queryBuilder
      * @param $alias

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -24,7 +24,6 @@ class ModelFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-
         if (!$data || !is_array($data) || !array_key_exists('value', $data) || empty($data['value'])) {
             return;
         }
@@ -114,12 +113,15 @@ class ModelFilter extends Filter
     }
 
     /**
+     * Retrieve the parent alias for given alias.
+     * Root alias for direct association or entity joined alias for association depth >= 2
+     *
      * @param ProxyQueryInterface $queryBuilder
      * @param $alias
      *
      * @return mixed
      */
-    protected function getParentAlias(ProxyQueryInterface $queryBuilder, $alias)
+    private function getParentAlias(ProxyQueryInterface $queryBuilder, $alias)
     {
         $parentAlias = $rootAlias = current($queryBuilder->getRootAliases());
         $joins = $queryBuilder->getDQLPart('join');

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -113,6 +113,29 @@ class ModelFilter extends Filter
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function association(ProxyQueryInterface $queryBuilder, $data)
+    {
+        $types = array(
+            ClassMetadataInfo::ONE_TO_ONE,
+            ClassMetadataInfo::ONE_TO_MANY,
+            ClassMetadataInfo::MANY_TO_MANY,
+            ClassMetadataInfo::MANY_TO_ONE,
+        );
+
+        if (!in_array($this->getOption('mapping_type'), $types)) {
+            throw new \RuntimeException('Invalid mapping type');
+        }
+
+        $associationMappings = $this->getParentAssociationMappings();
+        $associationMappings[] = $this->getAssociationMapping();
+        $alias = $queryBuilder->entityJoin($associationMappings);
+
+        return array($alias, false);
+    }
+
+    /**
      * Retrieve the parent alias for given alias.
      * Root alias for direct association or entity joined alias for association depth >= 2
      *
@@ -136,28 +159,5 @@ class ModelFilter extends Filter
         }
 
         return $parentAlias;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function association(ProxyQueryInterface $queryBuilder, $data)
-    {
-        $types = array(
-            ClassMetadataInfo::ONE_TO_ONE,
-            ClassMetadataInfo::ONE_TO_MANY,
-            ClassMetadataInfo::MANY_TO_MANY,
-            ClassMetadataInfo::MANY_TO_ONE,
-        );
-
-        if (!in_array($this->getOption('mapping_type'), $types)) {
-            throw new \RuntimeException('Invalid mapping type');
-        }
-
-        $associationMappings = $this->getParentAssociationMappings();
-        $associationMappings[] = $this->getAssociationMapping();
-        $alias = $queryBuilder->entityJoin($associationMappings);
-
-        return array($alias, false);
     }
 }

--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -116,15 +116,16 @@ class ModelFilter extends Filter
     /**
      * @param ProxyQueryInterface $queryBuilder
      * @param $alias
+     *
      * @return mixed
      */
     protected function getParentAlias(ProxyQueryInterface $queryBuilder, $alias)
     {
         $parentAlias = $rootAlias = current($queryBuilder->getRootAliases());
         $joins = $queryBuilder->getDQLPart('join');
-        if(isset($joins[$rootAlias])) {
-            foreach($joins[$rootAlias] as $join) {
-                if($join->getAlias() == $alias) {
+        if (isset($joins[$rootAlias])) {
+            foreach ($joins[$rootAlias] as $join) {
+                if ($join->getAlias() == $alias) {
                     $parts = explode('.', $join->getJoin());
                     $parentAlias = $parts[0];
                     break;


### PR DESCRIPTION
I am targeting this branch, because it does not introduce BC.

## Changelog
```markdown

### Changed
- `ModelFilter::handleMultiple` fix method to retrieve parent alias for building IDENTITY query part
```


## Subject

When trying to use this filter with sub relation field and selecting NOT_EQUAL type filtering it throw an error because it uses root alias instead of parent alias.

**Exemple :** 
relations :
myEntity -> Registration -> Diploma
`$datagridMapper->add('registration.diploma')`
The generated dql will try to test IS NULL on o.diploma instead of s_registration.diploma as expected.