### PR TITLE
Make the association script skip javascript links for loading via XHR

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -192,7 +192,14 @@ This code manage the many-to-[one|many] association field popup
         var element = jQuery(this);
 
         // return if the link is an anchor inside the same page
-        if (this.nodeName == 'A' && (element.attr('href').length == 0 || element.attr('href')[0] == '#')) {
+        if (
+            this.nodeName === 'A'
+            && (
+                element.attr('href').length === 0
+                || element.attr('href')[0] === '#'
+                || element.attr('href').substr(0, 11) === 'javascript:'
+            )
+        ) {
             Admin.log('[{{ id }}|field_dialog_form_action] element is an anchor, skipping action', this);
             return;
         }

--- a/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -200,7 +200,7 @@ This code manage the many-to-[one|many] association field popup
                 || element.attr('href').substr(0, 11) === 'javascript:'
             )
         ) {
-            Admin.log('[{{ id }}|field_dialog_form_action] element is an anchor, skipping action', this);
+            Admin.log('[{{ id }}|field_dialog_form_action] element is an anchor or a script, skipping action', this);
             return;
         }
 


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

Closes #684.

## Changelog

```markdown
### Fixed
- One-to-many and many-to-many association script will not try to load links with "javascript:" hrefs via XHR.
```

## Subject

One-to-many and many-to-many association script will not try to load links with "javascript:" hrefs via XHR.

Not sure if any other place needs to be changed too, seems to work fine.