### PR TITLE
Update `AddAuditEntityCompilerPass` in order to allow use of decoupled `simplethings/entity-audit-bundle:^2.0@dev`

### DIFF
--- a/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
@@ -26,7 +25,7 @@ class AddAuditEntityCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('simplethings_entityaudit.config')) {
+        if (!$container->hasDefinition('simplethings_entityaudit.config') || !$container->hasDefinition('simplethings.entityaudit.audited_entities')) {
             return;
         }
 

--- a/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
@@ -43,7 +43,7 @@ class AddAuditEntityCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('hasDefinition')
             ->will($this->returnCallback(function ($id) {
-                if ('simplethings_entityaudit.config' === $id) {
+                if ('simplethings_entityaudit.config' === $id || 'simplethings.entityaudit.audited_entities' === $id) {
                     return true;
                 }
             }))


### PR DESCRIPTION
I am targeting this branch, because currently there is an issue when trying to use `simplethings/entity-audit-bundle:^2.0@dev`.

## Changelog

### Fixed
- Fixed `AddAuditEntityCompilerPass::process()` when definition `simplethings.entityaudit.audited_entities` is not present, as of `2.x` version for `simplethings/entity-audit-bundle`.

## To do

- [ ] Validate with core members if this change must be replaced with a `conflict` definition at `composer.json`;
- [ ] Check if this requires an extra build pass using the constraint `simplethings/entity-audit-bundle:^2.0@dev` at `composer.json`.