### PR TITLE
Add `simplethings/entity-audit-bundle:>=2.0` to `conflict` section at `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
     "provide": {
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"
     },
+    "conflict": {
+        "simplethings/entity-audit-bundle": ">=2.0"
+    },
     "autoload": {
         "psr-4": { "Sonata\\DoctrineORMAdminBundle\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
I am targeting this branch, because currently there is an issue when trying to use `simplethings/entity-audit-bundle:^2.0@dev`.

## Changelog
```markdown
### Fixed
- Fixed `AddAuditEntityCompilerPass::process()` when definition `simplethings.entityaudit.audited_entities` is not present, as of `2.x` version for `simplethings/entity-audit-bundle`.
```
Closes #688.
