### PR TITLE
Fixed exception on missing field order by 

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -509,7 +509,11 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $query->setMaxResults($maxResult);
 
         if ($query instanceof ProxyQueryInterface) {
-            $query->addOrderBy($query->getSortBy(), $query->getSortOrder());
+            $sortBy = $query->getSortBy();
+
+            if (!empty($sortBy)) {
+                $query->addOrderBy($sortBy, $query->getSortOrder());
+            }
 
             $query = $query->getQuery();
         }


### PR DESCRIPTION
Closes https://github.com/sonata-project/SonataAdminBundle/issues/4333

## Changelog
```markdown
### Fixed
- Fixed `ModelManager::getDataSourceIterator` when` getSortBy` is empty
```

## To do

- [x] Update the tests

## Subject
If you try use export functionality without ordering and disabled sort primary key you got exception.

## Example Code
### Entity
```php
<?php

namespace AppBundle\Entity;

use Doctrine\ORM\Mapping as ORM;

/**
 * Post
 *
 * @ORM\Table(name="post")
 * @ORM\Entity(repositoryClass="AppBundle\Repository\PostRepository")
 */
class Post
{
    /**
     * @var int
     *
     * @ORM\Column(name="id", type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    private $id;

    /**
     * @var string
     *
     * @ORM\Column(name="name", type="string", length=255)
     */
    private $name;


    /**
     * Get id
     *
     * @return int
     */
    public function getId()
    {
        return $this->id;
    }

    /**
     * Set name
     *
     * @param string $name
     *
     * @return Post
     */
    public function setName($name)
    {
        $this->name = $name;

        return $this;
    }

    /**
     * Get name
     *
     * @return string
     */
    public function getName()
    {
        return $this->name;
    }
}


```
### Admin

```php
<?php

namespace AppBundle\Admin;

use Sonata\AdminBundle\Admin\AbstractAdmin;
use Sonata\AdminBundle\Show\ShowMapper;
use Sonata\AdminBundle\Form\FormMapper;
use Sonata\AdminBundle\Datagrid\ListMapper;
use Sonata\AdminBundle\Datagrid\DatagridMapper;

/**
 * Class PostAdmin
 */
class PostAdmin extends AbstractAdmin
{
    /**
     * {@inheritdoc}
     */
    protected function configureFormFields(FormMapper $formMapper)
    {
        $formMapper
            ->add('id', 'int', array(
                'label' => 'Post Title'
            ))
            ->add('name', 'text', array(
                'label' => 'name'
            ))
        ;
    }

    /**
     * {@inheritdoc}
     */
    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
    {
        $datagridMapper
            ->add('id')
            ->add('name')
        ;
    }

    /**
     * {@inheritdoc}
     */
    protected function configureListFields(ListMapper $listMapper)
    {
        $listMapper
            ->addIdentifier('id', null, array(
                'sortable' => false, // If you disabled sortable you got exception
            ))
            ->add('name')
        ;
    }

    /**
     * {@inheritdoc}
     */
    protected function configureShowFields(ShowMapper $showMapper)
    {
        $showMapper
            ->add('id')
            ->add('name')
        ;
    }

}
```