### PR TITLE
Prevent null check when relationship is many to many

### DIFF
--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -100,9 +100,15 @@ class ModelFilter extends Filter
 
             $or->add($queryBuilder->expr()->notIn($alias, ':'.$parameterName));
 
-            $or->add($queryBuilder->expr()->isNull(
-                sprintf('IDENTITY(%s.%s)', $this->getParentAlias($queryBuilder, $alias), $this->getFieldName())
-            ));
+            if ($this->getOption('mapping_type') === ClassMetadataInfo::MANY_TO_MANY) {
+                $or->add(
+                    sprintf('%s.%s IS EMPTY', $this->getParentAlias($queryBuilder, $alias), $this->getFieldName())
+                );
+            } else {
+                $or->add($queryBuilder->expr()->isNull(
+                    sprintf('IDENTITY(%s.%s)', $this->getParentAlias($queryBuilder, $alias), $this->getFieldName())
+                ));
+            }
 
             $this->applyWhere($queryBuilder, $or);
         } else {


### PR DESCRIPTION
I am targeting this branch, because this is a bug fix.

## Changelog

```markdown
### Fixed
Fixed wrong DQL generated for many to many relationship when filtering with not equals
```

## Subject

Currently when using the `ModelFilter` for a many to many relationship and choosing the not equals from advanced filters, will trigger an Exception.

```
[Semantical Error] line 0, col 134 near 'xxx) IS NUL': Error: Invalid PathExpression. Must be a SingleValuedAssociationField.
```