### PR TITLE
making error more verbose on field's miswriting

### DIFF
--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -66,6 +66,9 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             }
         }
 
+        if( ! $metadata->hasField($propertyName)){
+            throw new \RuntimeException("No mapping found for field '$propertyName' in $class");
+        }
         $options['field_name'] = $metadata->fieldMappings[$propertyName]['fieldName'];
 
         switch ($metadata->getTypeOfField($propertyName)) {

--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -66,7 +66,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             }
         }
 
-        if( ! $metadata->hasField($propertyName)){
+        if (!$metadata->hasField($propertyName)){
             throw new \RuntimeException("No mapping found for field '$propertyName' in $class");
         }
         $options['field_name'] = $metadata->fieldMappings[$propertyName]['fieldName'];

--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -66,7 +66,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             }
         }
 
-        if (!$metadata->hasField($propertyName)){
+        if (!$metadata->hasField($propertyName)) {
             throw new \RuntimeException("No mapping found for field '$propertyName' in $class");
         }
         $options['field_name'] = $metadata->fieldMappings[$propertyName]['fieldName'];


### PR DESCRIPTION
I am targeting this branch, because the change I'm requesting is minor and the 3.x is the dedicated one.

## Changelog
Throwing a better exception when FilterType guesser doesn't find a field

```markdown
### Changed
- Throw an error if the field doesn't exist
```

## Subject

This is a partial response to the issue I raised here : https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/695  where @jlamur suggested me to do a PR.

Suggested fixes are : 
> * The exception must be more verbose (something like No mapping found for field 'costHt'),
> * The DatagridMapper/Builder should be consistent with other Builders by accepting entity field names (and not column names).

My code doesn't fix the whole issue since the other part is still being investigated. I just offer to make the exception more verbose (something like No mapping found for field 'name')
