### PR TITLE
Adapt the getFixedQueryBuilder function to be compatible with Postgresql

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -328,6 +328,17 @@ class ProxyQuery implements ProxyQueryInterface
             $queryBuilderId->addSelect($sortBy);
         }
 
+        /* For each ORDER BY clause defined directly in the DQL parts of the query,
+           we add an entry in the SELECT clause. */
+        $dqlParts = $queryBuilderId->getDqlParts();
+        if ($dqlParts['orderBy'] && count($dqlParts['orderBy'])) {
+            foreach ($dqlParts['orderBy'] as $part) {
+                foreach ($part->getParts() as $orderBy) {
+                    $queryBuilderId->addSelect(preg_replace("/\s+(ASC|DESC)$/i", '', $orderBy));
+                }
+            }
+        }
+
         $results = $queryBuilderId->getQuery()->execute(array(), Query::HYDRATE_ARRAY);
         $platform = $queryBuilderId->getEntityManager()->getConnection()->getDatabasePlatform();
         $idxMatrix = array();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because I found bug in this version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes  #458, #210

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Adapt the getFixedQueryBuilder function to be compatible with Postgresql : For any orderBy clause defined directly in the dqlParts, we add a select
entry in the query. 

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests

## Subject

Without this fix database returns an error:
``` 
SQLSTATE[42P10]: Invalid column reference: 7 ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list 
```

Full db query:

```sql
SELECT DISTINCT p0_.id AS id_0, p0_.id AS id_1 FROM product_part_code p0_ LEFT JOIN product_part p1_ ON p0_.part_id = p1_.id ORDER BY p1_.name ASC, p0_.is_active DESC, p0_.id DESC, p0_.id DESC LIMIT 32 OFFSET 0
```

This change preserve ids ordering.
I am reusing code from SonataDatagridBundle : https://github.com/sonata-project/SonataDatagridBundle/commit/a2d2c88b2c1db6defa2feede3fe60e8704eba0c1
