### PR TITLE
[Fix] add missing sonata-ba-field-error class

### DIFF
--- a/Resources/views/CRUD/edit_orm_many_to_many.html.twig
+++ b/Resources/views/CRUD/edit_orm_many_to_many.html.twig
@@ -32,7 +32,7 @@ file that was distributed with this source code.
                                 {% for nested_group_field_name, nested_group_field in form.children %}
                                     <tr>
                                         {% for field_name, nested_field in nested_group_field.children %}
-                                            <td class="sonata-ba-td-{{ id }}-{{ field_name  }} control-group{% if nested_field.vars.errors|length > 0 %} error{% endif %}">
+                                            <td class="sonata-ba-td-{{ id }}-{{ field_name  }} control-group{% if nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}">
                                                 {% if sonata_admin.field_description.associationadmin.hasformfielddescriptions(field_name) is defined %}
                                                     {{ form_widget(nested_field) }}
 

--- a/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
@@ -38,7 +38,7 @@ file that was distributed with this source code.
                     <td class="
                         sonata-ba-td-{{ id }}-{{ field_name  }}
                         control-group
-                        {% if nested_field.vars.errors|length > 0 %} error{% endif %}
+                        {% if nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}
                         "
                         {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
                             style="display:none;"


### PR DESCRIPTION
Closes https://github.com/sonata-project/SonataAdminBundle/issues/4533

## Changelog

```markdown
### Fixed
- added the missing `sonata-ba-field-error` class to table fields with errors
```

## Subject

The class `sonata-ba-field-error` was missing so that sub-forms were not correctly handled when inside a tab here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/Resources/public/Admin.js#L329
