### PR TITLE
sonata_type_model_list edit button in dialog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "doctrine/orm": "^2.4.5",
-        "sonata-project/admin-bundle": "^3.1",
+        "sonata-project/admin-bundle": "^3.26.0",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/exporter": "^1.3.1",
         "symfony/console": "^2.8 || ^3.2",

--- a/docs/reference/form_field_definition.rst
+++ b/docs/reference/form_field_definition.rst
@@ -177,6 +177,7 @@ The AdminBundle provides 2 options:
                         'btn_add'       => 'Add author',      //Specify a custom label
                         'btn_list'      => 'button.list',     //which will be translated
                         'btn_delete'    => false,             //or hide the button.
+                        'btn_edit'      => 'Edit',            //Hide add and show edit button when value is set
                         'btn_catalogue' => 'SonataNewsBundle' //Custom translation domain for buttons
                     ), array(
                         'placeholder' => 'No author selected'

--- a/src/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -186,6 +186,46 @@ This code manage the many-to-[one|many] association field popup
         });
     };
 
+    // handle the edit link
+    var field_dialog_form_edit_{{ id }} = function(event) {
+        initialize_popup_{{ id }}();
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        var a = jQuery(this);
+
+        field_dialog_content_{{ id }}.html('');
+
+        Admin.log('[{{ id }}|field_dialog_form_edit] edit link action');
+
+        // retrieve the form element from the related admin generator
+        jQuery.ajax({
+            url: a.attr('href'),
+            dataType: 'html',
+            success: function(html) {
+
+                Admin.log('[{{ id }}|field_dialog_form_edit] ajax success', field_dialog_{{ id }});
+
+                // populate the popup container
+                field_dialog_content_{{ id }}.html(html);
+                field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
+
+                Admin.shared_setup(field_dialog_{{ id }});
+
+                // capture the submit event to make an ajax call, ie : POST data to the
+                // related create admin
+                jQuery('a', field_dialog_{{ id }}).on('click', field_dialog_form_action_{{ id }});
+                jQuery('form', field_dialog_{{ id }}).on('submit', field_dialog_form_action_{{ id }});
+
+                // open the dialog in modal mode
+                field_dialog_{{ id }}.modal();
+
+                Admin.setup_list_modal(field_dialog_{{ id }});
+            }
+        });
+    };
+
     // handle the post data
     var field_dialog_form_action_{{ id }} = function(event) {
 
@@ -334,6 +374,27 @@ This code manage the many-to-[one|many] association field popup
         // add the jQuery event to the a element
         jQuery(link)
             .click(field_dialog_form_add_{{ id }})
+            .trigger('click')
+        ;
+
+        return false;
+    }
+    
+    {#
+        This code is used to define the "edit" popup
+    #}
+    // this function initializes the popup
+    // this can only be done this way as popup can be cascaded
+    function start_field_dialog_form_edit_{{ id }}(link) {
+
+        // remove the html event
+        link.onclick = null;
+
+        initialize_popup_{{ id }}();
+
+        // add the jQuery event to the a element
+        jQuery(link)
+            .click(field_dialog_form_edit_{{ id }})
             .trigger('click')
         ;
 

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -82,7 +82,11 @@ file that was distributed with this source code.
                     </a>
                 {% endif %}
 
-                {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+                {% if sonata_admin.field_description.associationadmin.hasroute('create')
+                    and sonata_admin.field_description.associationadmin.isGranted('CREATE')
+                    and btn_add
+                    and sonata_admin.value == null
+                %}
                     <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_dialog_form_add_{{ id }}(this);"
                         class="btn btn-success btn-sm sonata-ba-action"
@@ -90,6 +94,19 @@ file that was distributed with this source code.
                             >
                         <i class="fa fa-plus-circle"></i>
                         {{ btn_add|trans({}, btn_catalogue) }}
+                    </a>
+                {% elseif sonata_admin.field_description.associationadmin.hasroute('edit')
+                    and sonata_admin.field_description.associationadmin.isGranted('EDIT')
+                    and btn_edit
+                    and sonata_admin.value != null
+                %}
+                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('edit', {'id' : sonata_admin.value.id}) }}"
+                        onclick="return start_field_dialog_form_edit_{{ id }}(this);"
+                        class="btn btn-warning btn-sm sonata-ba-action"
+                        title="{{ btn_edit|trans({}, btn_catalogue) }}"
+                            >
+                        <i class="fa fa-pencil"></i>
+                        {{ btn_edit|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}
             </span>


### PR DESCRIPTION
I am targeting this branch, because I am adding an additional feature.

Closes #707

## Changelog
```markdown
### Added
- Added edit button that opens in dialog instead of add if there is object already in sonata type model list
```

## To do

- [x] Update the tests
- [x] Update the documentation
- [x] Add `btn_edit` option to sonata_type_model_list form type in SonataAdminBundle

## Subject

Instead of add button that would replace the current object with a new one, add edit button that would open the current object in dialog instead of redirecting to edit screen of that object.

## Screenshots

### Before
![deepinscreenshot_select-area_20170815210554](https://user-images.githubusercontent.com/13528674/29331744-c8080724-81fd-11e7-8710-9e3d3eaa4c84.png)
![deepinscreenshot_select-area_20170815210950](https://user-images.githubusercontent.com/13528674/29331836-25cb54ba-81fe-11e7-9704-93065ac1a3a0.png)


### After
![deepinscreenshot_select-area_20170815205438](https://user-images.githubusercontent.com/13528674/29331762-d657ac9e-81fd-11e7-80ba-18de375490d1.png)
![deepinscreenshot_select-area_20170815205456](https://user-images.githubusercontent.com/13528674/29331766-da44dd4a-81fd-11e7-9602-a33a95528682.png)
