### PR TITLE
Maintain File input state when adding to collections.

### DIFF
--- a/Resources/views/CRUD/edit_orm_one_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_association_script.html.twig
@@ -46,8 +46,16 @@ This code manage the one-to-many association field popup
                 if (!html.length) {
                     return;
                 }
+                var $newForm = jQuery(jQuery.parseHTML(html));
+                var $oldForm = jQuery('#field_container_{{ id }}');
 
-                jQuery('#field_container_{{ id }}').replaceWith(html); // replace the html
+                // Maintain state of file inputs
+                $oldForm.find('input[type="file"]').each(function(){
+                    var id = '#'+$(this).attr('id');
+                    $newForm.find(id).replaceWith($(this));
+                });
+
+                $oldForm.replaceWith($newForm); // replace the html
 
                 Admin.shared_setup(jQuery('#field_container_{{ id }}'));
 

--- a/Resources/views/CRUD/edit_orm_one_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_one_association_script.html.twig
@@ -46,7 +46,7 @@ This code manage the one-to-many association field popup
                 if (!html.length) {
                     return;
                 }
-                var $newForm = jQuery(jQuery.parseHTML(html));
+                var $newForm = jQuery(html);
                 var $oldForm = jQuery('#field_container_{{ id }}');
 
                 // Maintain state of file inputs


### PR DESCRIPTION
I am targeting this branch, because it is BC bug fix .

Fixes https://github.com/sonata-project/SonataAdminBundle/issues/4227 for Doctrine ORM
Related to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/590

## Changelog
```markdown

### Fixed
- Patched collection form handling script to maintain File input state when new items are added to collections

```

## Subject
When adding items to collection, full form is returned and re-rendered. This update copies over the file input state into the newly fetched form.
