### PR TITLE
Fix invalid FieldDescription for association embedded properties

### DIFF
--- a/Admin/FieldDescription.php
+++ b/Admin/FieldDescription.php
@@ -99,7 +99,10 @@ class FieldDescription extends BaseFieldDescription
         // Support embedded object for mapping
         // Ref: http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/tutorials/embeddables.html
         if (isset($fieldMapping['declaredField'])) {
-            $object = $this->getFieldValue($object, $fieldMapping['declaredField']);
+            $parentFields = explode('.', $fieldMapping['declaredField']);
+            foreach ($parentFields as $parentField) {
+                $object = $this->getFieldValue($object, $parentField);
+            }
         }
 
         return $this->getFieldValue($object, $this->fieldName);

--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -82,8 +82,10 @@ class ModelManager implements ModelManagerInterface, LockInterface
     {
         $nameElements = explode('.', $propertyFullName);
         $lastPropertyName = array_pop($nameElements);
+        $propertyName = $lastPropertyName;
         $class = $baseClass;
         $parentAssociationMappings = array();
+        $parentEmbeddedMappings = array();
 
         foreach ($nameElements as $nameElement) {
             $metadata = $this->getMetadata($class);
@@ -92,13 +94,27 @@ class ModelManager implements ModelManagerInterface, LockInterface
                 $parentAssociationMappings[] = $metadata->associationMappings[$nameElement];
                 $class = $metadata->getAssociationTargetClass($nameElement);
             } elseif (isset($metadata->embeddedClasses[$nameElement])) {
-                $parentAssociationMappings = array();
-                $lastPropertyName = $propertyFullName;
-                $class = $baseClass;
+                $parentEmbeddedMappings[] = array(
+                    'class' => $class,
+                    'field' => $nameElement,
+                );
+                $class = $metadata->embeddedClasses[$nameElement]['class'];
             }
         }
 
-        return array($this->getMetadata($class), $lastPropertyName, $parentAssociationMappings);
+        // Support for multi-level embedded properties
+        if (!empty($parentEmbeddedMappings)) {
+            $baseEmbeddedMapping = current($parentEmbeddedMappings);
+            $class = $baseEmbeddedMapping['class'];
+
+            $propertyName = '';
+            foreach ($parentEmbeddedMappings as $embeddedMapping) {
+                $propertyName .= $embeddedMapping['field'].'.';
+            }
+            $propertyName .= $lastPropertyName;
+        }
+
+        return array($this->getMetadata($class), $propertyName, $parentAssociationMappings);
     }
 
     /**

--- a/Tests/Admin/FieldDescriptionTest.php
+++ b/Tests/Admin/FieldDescriptionTest.php
@@ -358,4 +358,33 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('myMethodValue', $field->getValue($mockedObject));
     }
+
+    public function testGetValueForMultiLevelEmbeddedObject()
+    {
+        $mockedChildEmbeddedObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('myMethod'))
+            ->getMock();
+        $mockedChildEmbeddedObject->expects($this->once())
+            ->method('myMethod')
+            ->will($this->returnValue('myMethodValue'));
+        $mockedEmbeddedObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getChild'))
+            ->getMock();
+        $mockedEmbeddedObject->expects($this->once())
+            ->method('getChild')
+            ->will($this->returnValue($mockedChildEmbeddedObject));
+        $mockedObject = $this->getMockBuilder('stdClass')
+            ->setMethods(array('getMyEmbeddedObject'))
+            ->getMock();
+        $mockedObject->expects($this->once())
+            ->method('getMyEmbeddedObject')
+            ->will($this->returnValue($mockedEmbeddedObject));
+        $field = new FieldDescription();
+        $field->setFieldMapping(array(
+            'declaredField' => 'myEmbeddedObject.child', 'type' => 'string', 'fieldName' => 'myMethod',
+        ));
+        $field->setFieldName('myMethod');
+        $field->setOption('code', 'myMethod');
+        $this->assertEquals('myMethodValue', $field->getValue($mockedObject));
+    }
 }

--- a/Tests/Fixtures/Entity/AssociatedEntity.php
+++ b/Tests/Fixtures/Entity/AssociatedEntity.php
@@ -10,13 +10,20 @@ class AssociatedEntity
     protected $plainField;
 
     /**
+     * @var Embeddable\EmbeddedEntity
+     */
+    protected $embeddedEntity;
+
+    /**
      * AssociatedEntity constructor.
      *
-     * @param int $plainField
+     * @param int                       $plainField
+     * @param Embeddable\EmbeddedEntity $embeddedEntity
      */
-    public function __construct($plainField = null)
+    public function __construct($plainField = null, Embeddable\EmbeddedEntity $embeddedEntity)
     {
         $this->plainField = $plainField;
+        $this->embeddedEntity = $embeddedEntity;
     }
 
     /**

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -187,7 +187,7 @@ class ModelManagerTest extends PHPUnit_Framework_TestCase
         $embeddedEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity';
         $modelManagerClass = 'Sonata\DoctrineORMAdminBundle\Model\ModelManager';
 
-        $object = new ContainerEntity(new AssociatedEntity(), new EmbeddedEntity());
+        $object = new ContainerEntity(new AssociatedEntity(null, new EmbeddedEntity()), new EmbeddedEntity());
 
         $em = $this->createMock('Doctrine\ORM\EntityManager');
 
@@ -228,6 +228,10 @@ class ModelManagerTest extends PHPUnit_Framework_TestCase
         list($metadata, $lastPropertyName) = $modelManager
             ->getParentMetadataForProperty($containerEntityClass, 'embeddedEntity.plainField');
         $this->assertEquals($metadata->fieldMappings[$lastPropertyName]['type'], 'boolean');
+
+        list($metadata, $lastPropertyName) = $modelManager
+            ->getParentMetadataForProperty($containerEntityClass, 'associatedEntity.embeddedEntity.plainField');
+        $this->assertEquals($metadata->fieldMappings[$lastPropertyName]['type'], 'boolean');
     }
 
     public function getMetadataForEmbeddedEntity()
@@ -247,6 +251,8 @@ class ModelManagerTest extends PHPUnit_Framework_TestCase
 
     public function getMetadataForAssociatedEntity()
     {
+        $embeddedEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity';
+
         $metadata = new ClassMetadata('Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\AssociatedEntity');
 
         $metadata->fieldMappings = array(
@@ -256,6 +262,13 @@ class ModelManagerTest extends PHPUnit_Framework_TestCase
                 'type' => 'string',
             ),
         );
+
+        $metadata->embeddedClasses['embeddedEntity'] = array(
+            'class' => $embeddedEntityClass,
+            'columnPrefix' => 'embeddedEntity',
+        );
+
+        $metadata->inlineEmbeddable('embeddedEntity', $this->getMetadataForEmbeddedEntity());
 
         return $metadata;
     }
@@ -338,7 +351,7 @@ class ModelManagerTest extends PHPUnit_Framework_TestCase
 
     public function testAssociationIdentifierType()
     {
-        $entity = new ContainerEntity(new AssociatedEntity(42), new EmbeddedEntity());
+        $entity = new ContainerEntity(new AssociatedEntity(42, new EmbeddedEntity()), new EmbeddedEntity());
 
         $meta = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataInfo');
         $meta->expects($this->any())


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's BC bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed invalid FieldDescription for association embedded properties
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
Without this fix the ModelManager is not able to generate valid FieldDescription for association embedded properties.
