### PR TITLE
Avoid preg_replace's e modifier

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -714,7 +714,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     }
 
     /**
-     * method taken from PropertyPath.
+     * method taken from Symfony\Component\PropertyAccess\PropertyAccessor.
      *
      * @param string $property
      *
@@ -722,10 +722,6 @@ class ModelManager implements ModelManagerInterface, LockInterface
      */
     protected function camelize($property)
     {
-        return preg_replace(
-            array('/(^|_)+(.)/e', '/\.(.)/e'),
-            array("strtoupper('\\2')", "'_'.strtoupper('\\1')"),
-            $property
-        );
+        return str_replace(' ', '', ucwords(str_replace('_', ' ', $property)));
     }
 }

--- a/Tests/Fixtures/Entity/SimpleEntity.php
+++ b/Tests/Fixtures/Entity/SimpleEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity;
+
+class SimpleEntity
+{
+    private $schmeckles;
+    private $multiWordProperty;
+
+    public function getSchmeckles()
+    {
+        return $this->schmeckles;
+    }
+
+    public function setSchmeckles($value)
+    {
+        $this->schmeckles = $value;
+    }
+
+    public function getMultiWordProperty()
+    {
+        return $this->multiWordProperty;
+    }
+
+    public function setMultiWordProperty($value)
+    {
+        $this->multiWordProperty = $value;
+    }
+}


### PR DESCRIPTION
It is deprecated.
Fixes #679, Closes #681

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is backwards-compatible.

In case of bug fix, `3.x` **MUST** be targeted.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- warning about deprecate "e" modifier for `preg_replace`
```

## Subject

<!-- Describe your Pull Request content here -->
