### PR TITLE
Fix sorting by multiple columns in PostgreSQL and MySQL 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/exporter": "^1.3.1",
         "symfony/console": "^2.3 || ^3.0",
-        "symfony/doctrine-bridge": "^2.2 || ^3.0",
+        "symfony/doctrine-bridge": "^2.4 || ^3.0",
         "symfony/form": "^2.3 || ^3.0",
         "symfony/framework-bundle": "^2.2 || ^3.0",
         "symfony/security": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is bug fix.

Closes #458, closes #210, closes #694, closes #703

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix sorting by multiple columns in custom createQuery in PostgreSQL and MySQL 5.7
```
## Subject
This is continuation of #703. Multiple orderBy in custom createQuery causes errors.
PostgreSQL:
`SQLSTATE[42P10]: Invalid column reference: 7 ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list `
MySQL 5.7 with ONLY_FULL_GROUP_BY mode (which is default):
`SQLSTATE[HY000]: General error: 3065 Expression #1 of ORDER BY clause is not in SELECT list, references column 'mydb.c0_.mycolumn' which is not in SELECT list; this is incompatible with DISTINCT").`
I adapted solution proposed by @jerome-fix and added tests.
