### PR TITLE
Allow to set Query hint in createQuery

### DIFF
--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -48,6 +48,13 @@ class ProxyQuery implements ProxyQueryInterface
     protected $entityJoinAliases;
 
     /**
+     * The map of query hints.
+     *
+     * @var array<string,mixed>
+     */
+    private $hints = array();
+
+    /**
      * @param QueryBuilder $queryBuilder
      */
     public function __construct($queryBuilder)
@@ -132,7 +139,12 @@ class ProxyQuery implements ProxyQueryInterface
             }
         }
 
-        return $this->getFixedQueryBuilder($queryBuilder)->getQuery()->execute($params, $hydrationMode);
+        $query = $this->getFixedQueryBuilder($queryBuilder)->getQuery();
+        foreach ($this->hints as $name => $value) {
+            $query->setHint($name, $value);
+        }
+
+        return $query->execute($params, $hydrationMode);
     }
 
     /**
@@ -270,6 +282,24 @@ class ProxyQuery implements ProxyQueryInterface
         }
 
         return $alias;
+    }
+
+    /**
+     * Sets a {@see \Doctrine\ORM\Query} hint. If the hint name is not recognized, it is silently ignored.
+     *
+     * @param string $name  the name of the hint
+     * @param mixed  $value the value of the hint
+     *
+     * @return ProxyQueryInterface
+     *
+     * @see \Doctrine\ORM\Query::setHint
+     * @see \Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER
+     */
+    final public function setHint($name, $value)
+    {
+        $this->hints[$name] = $value;
+
+        return $this;
     }
 
     /**

--- a/Tests/Fixtures/Query/FooWalker.php
+++ b/Tests/Fixtures/Query/FooWalker.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Query;
+
+use Doctrine\ORM\Query\SqlWalker;
+
+final class FooWalker extends SqlWalker
+{
+    public function walkOrderByClause($orderByClause)
+    {
+        return str_replace(' ASC', ' DESC', parent::walkOrderByClause($orderByClause));
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is BC feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes sonata-project/SonataTranslationBundle#162

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ProxyQuery::setHint` which allow to pass Query hint in createQuery
```

## Subject

<!-- Describe your Pull Request content here -->
Right now it is impossible to setHint on Query:
```php
public function createQuery($context = 'list')
{
    $proxyQuery = parent::createQuery($context);

    $proxyQuery->setHint(
        \Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER,
        'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker'
    );

    return $proxyQuery;
}
```
I would like to reduce number of database queries. Using the TranslationBundle it is additional query per row, as described here sonata-project/SonataTranslationBundle#162. `setHint` has the same syntax as in `Doctrine\ORM\AbstractQuery`.
Let me know what do you think about this idea.