### PR TITLE
Change minimum doctrine/orm version on master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "doctrine/orm": "^2.3",
+        "doctrine/orm": "^2.4.5",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/exporter": "^1.3.1",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting master branch, to prove that it works. Afterwards it should be targeted 3.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Change minimum doctrine/orm version to 2.4.5
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Target PR to 3.x

## Subject

<!-- Describe your Pull Request content here -->
#730 test case revealed strange Doctrine bug in version < 2.4.5 https://github.com/doctrine/doctrine2/pull/1142. I wonder how it passed 3.x tests because now it does not pass them too (in my local env). If it pass tests on master it should be retargeted to 3.x.

<details><summary>See stack trace with --prefer-lowest</summary>
<p>

```
..................................E............................... 65 / 94 ( 69%)
......................S..WWWW.                                     94 / 94 (100%)

Time: 5.5 seconds, Memory: 38.00MB

There was 1 error:

1) Sonata\DoctrineORMAdminBundle\Tests\Datagrid\ProxyQueryTest::testSetHint
Doctrine\ORM\Query\QueryException: [Syntax Error] line 0, col 82: Error: Expected Literal, got 'ORDER'

/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:44
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:396
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2363
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2550
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2485
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2453
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2427
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2414
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2749
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2277
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2177
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2153
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2121
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2096
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:1209
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:759
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:726
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:229
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:304
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:233
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:245
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/AbstractQuery.php:737
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/Datagrid/ProxyQuery.php:147
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/Tests/Datagrid/ProxyQueryTest.php:211

Caused by
Doctrine\ORM\Query\QueryException: SELECT o.id FROM Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity o WHERE  ORDER BY o.id ASC

/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:39
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:396
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2363
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2550
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2485
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2453
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2427
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2414
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2749
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2277
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2177
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2153
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2121
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:2096
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:1209
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:759
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:726
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:229
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php:304
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:233
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/Query.php:245
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/vendor/doctrine/orm/lib/Doctrine/ORM/AbstractQuery.php:737
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/Datagrid/ProxyQuery.php:147
/home/travis/build/sonata-project/SonataDoctrineORMAdminBundle/Tests/Datagrid/ProxyQueryTest.php:211
```

</p>
</details>