### PR TITLE
Change minimum doctrine/orm version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
-        "doctrine/orm": "^2.3",
+        "doctrine/orm": "^2.4.5",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/exporter": "^1.3.1",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #731

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Change minimum doctrine/orm version to 2.4.5 because QueryBuilder bug on PHP7 and HHVM
```

## Subject

<!-- Describe your Pull Request content here -->
#730 test case revealed Doctrine bug in version < 2.4.5 on master branch, see #731. But I noticed that 3.x is affected too. Test fail on my local env in 3.x.