### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,23 +17,23 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "doctrine/orm": "^2.4.5",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/exporter": "^1.3.1",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/doctrine-bridge": "^2.4 || ^3.0",
-        "symfony/form": "^2.3 || ^3.0",
-        "symfony/framework-bundle": "^2.2 || ^3.0",
-        "symfony/security": "^2.3 || ^3.0",
-        "symfony/security-acl": "^2.2 || ^3.0"
+        "symfony/console": "^2.8 || ^3.2",
+        "symfony/doctrine-bridge": "^2.8 || ^3.2",
+        "symfony/form": "^2.8 || ^3.2",
+        "symfony/framework-bundle": "^2.8 || ^3.2",
+        "symfony/security": "^2.8 || ^3.2",
+        "symfony/security-acl": "^2.8 || ^3.0"
     },
     "require-dev": {
         "knplabs/knp-menu-bundle": "^2.1.1",
         "simplethings/entity-audit-bundle": "0.1 - 0.9 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "simplethings/entity-audit-bundle": "If you want to support for versioning of entities and their associations."


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
