### PR TITLE
Reset page to first 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.4](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/compare/3.1.3...3.1.4) - 2017-03-23
+### Fixed
+- Fixed broken translation in oneToMany table view
+- Fixed wrong translation in delete checkbox in `edit_orm_one_to_many_inline_table.html.twig`
+
+### Security
+- Fixed view - check specific item collection, not to the whole collection.
+
 ## [3.1.3](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/compare/3.1.2...3.1.3) - 2017-01-17
 ### Fixed
 - Consider NULL values when using 'is not equal' advanced model filter

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -8,10 +8,9 @@ The ``Doctrine ORM Admin`` provides services to work with the ``Admin Bundle`` a
 * `Sonata Users <https://groups.google.com/group/sonata-users>`_: For questions on how to use Sonata bundles on your project
 * `Sonata Devs <https://groups.google.com/group/sonata-devs>`_: For questions regarding the development of Sonata bundles
 
-Reference Guide
----------------
-
 .. toctree::
+   :caption: Reference Guide
+   :name: reference-guide
    :maxdepth: 1
    :numbered:
 
@@ -26,10 +25,9 @@ Reference Guide
    reference/query_proxy
    reference/troubleshootings
 
-Tutorial
---------
-
 .. toctree::
+   :caption: Tutorials
+   :name: tutorials
    :maxdepth: 1
    :numbered:
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Added check if offset is higher or equals result count and forced to show 
results from the first page in such case.

### Fixes
- Fixes a bug when all items were deleted(with a batch deletion) from the second page on the admin list and we were redirected to the same page with empty result list and without page selector
