### PR TITLE
Fixed deprecated method calls

### DIFF
--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -41,7 +41,7 @@ class Pager extends BasePager
 
         $countQuery->select(sprintf(
             'count(DISTINCT %s.%s) as cnt',
-            $countQuery->getRootAlias(),
+            current($countQuery->getRootAliases()),
             current($this->getCountColumn())
         ));
 

--- a/Datagrid/ProxyQuery.php
+++ b/Datagrid/ProxyQuery.php
@@ -251,7 +251,7 @@ class ProxyQuery implements ProxyQueryInterface
      */
     public function entityJoin(array $associationMappings)
     {
-        $alias = $this->queryBuilder->getRootAlias();
+        $alias = current($this->queryBuilder->getRootAliases());
 
         $newAlias = 's';
 

--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -475,7 +475,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
             $ands = [];
             foreach ($fieldNames as $posName => $name) {
                 $parameterName = sprintf('field_%s_%s_%d', $prefix, $name, $pos);
-                $ands[] = sprintf('%s.%s = :%s', $qb->getRootAlias(), $name, $parameterName);
+                $ands[] = sprintf('%s.%s = :%s', current($qb->getRootAliases()), $name, $parameterName);
                 $qb->setParameter($parameterName, $ids[$posName]);
             }
 
@@ -490,7 +490,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
      */
     public function batchDelete($class, ProxyQueryInterface $queryProxy)
     {
-        $queryProxy->select('DISTINCT '.$queryProxy->getRootAlias());
+        $queryProxy->select('DISTINCT '.current($queryProxy->getRootAliases()));
 
         try {
             $entityManager = $this->getEntityManager($class);
@@ -522,7 +522,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $datagrid->buildPager();
         $query = $datagrid->getQuery();
 
-        $query->select('DISTINCT '.$query->getRootAlias());
+        $query->select('DISTINCT '.current($query->getRootAliases()));
         $query->setFirstResult($firstResult);
         $query->setMaxResults($maxResult);
 

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -438,7 +438,7 @@ class ModelManagerTest extends TestCase
 
         $proxyQuery = $this->getMockBuilder('Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery')
             ->setConstructorArgs([$queryBuilder])
-            ->setMethods(['getSortBy', 'getSortOrder'])
+            ->setMethods(['getSortBy', 'getSortOrder', 'getRootAliases'])
             ->getMock();
 
         $proxyQuery->expects($this->any())
@@ -451,6 +451,10 @@ class ModelManagerTest extends TestCase
 
         $queryBuilder->expects($isAddOrderBy ? $this->atLeastOnce() : $this->never())
             ->method('addOrderBy');
+
+        $proxyQuery->expects($this->any())
+            ->method('getRootAliases')
+            ->willReturn(['a']);
 
         $queryBuilder->expects($this->any())
             ->method('getQuery')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed deprecated method calls
```

## Subject

This should fix https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/745
