### PR TITLE
Drop old Symfony code

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -22,6 +22,8 @@ use Sonata\AdminBundle\Datagrid\SimplePager;
 use Sonata\AdminBundle\Filter\FilterFactoryInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
+use Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 
 class DatagridBuilder implements DatagridBuilderInterface
@@ -126,8 +128,8 @@ class DatagridBuilder implements DatagridBuilderInterface
 
         $fieldDescription->mergeOption('field_options', ['required' => false]);
 
-        // NEXT_MAJOR: Remove first check (when requirement of Symfony is >= 2.8)
-        if ('doctrine_orm_model_autocomplete' === $type || 'Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter' === $type) {
+        // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony 2.8
+        if ('doctrine_orm_model_autocomplete' === $type || ModelAutocompleteFilter::class === $type) {
             $fieldDescription->mergeOption('field_options', [
                 'class' => $fieldDescription->getTargetEntity(),
                 'model_manager' => $fieldDescription->getAdmin()->getModelManager(),
@@ -159,10 +161,7 @@ class DatagridBuilder implements DatagridBuilderInterface
             $defaultOptions['csrf_protection'] = false;
         }
 
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $formType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
-        $formBuilder = $this->formFactory->createNamedBuilder('filter', $formType, [], $defaultOptions);
+        $formBuilder = $this->formFactory->createNamedBuilder('filter', FormType::class, [], $defaultOptions);
 
         return new Datagrid($admin->createQuery(), $admin->getList(), $pager, $formBuilder, $values);
     }

--- a/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
+++ b/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
@@ -16,7 +16,6 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -39,19 +38,6 @@ class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('doctrine_orm.xml');
         $loader->load('doctrine_orm_filter_types.xml');
-
-        // TODO: Go back on xml configuration when bumping requirements to SF 2.6+
-        $doctrineEMDefinition = $container->getDefinition('sonata.admin.entity_manager');
-        // NEXT_MAJOR: remove when dropping Symfony <2.1 support
-        $doctrineFactoryMethod = method_exists('Doctrine\Bundle\DoctrineBundle\Registry', 'getManager')
-            ? 'getManager'
-            : 'getEntityManager';
-        if (method_exists($doctrineEMDefinition, 'setFactory')) {
-            $doctrineEMDefinition->setFactory([new Reference('doctrine'), $doctrineFactoryMethod]);
-        } else {
-            $doctrineEMDefinition->setFactoryService('doctrine');
-            $doctrineEMDefinition->setFactoryMethod($doctrineFactoryMethod);
-        }
 
         $bundles = $container->getParameter('kernel.bundles');
 

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -13,6 +13,8 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
 use Sonata\AdminBundle\Form\Type\Filter\DateType;
 
 abstract class AbstractDateFilter extends Filter
@@ -155,25 +157,14 @@ abstract class AbstractDateFilter extends Filter
      */
     public function getRenderSettings()
     {
-        $name = 'sonata_type_filter_date';
+        $name = DateType::class;
 
-        if ($this->time) {
-            $name .= 'time';
-        }
-
-        if ($this->range) {
-            $name .= '_range';
-        }
-
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $classnames = [
-                'sonata_type_filter_date' => 'Sonata\AdminBundle\Form\Type\Filter\DateType',
-                'sonata_type_filter_date_range' => 'Sonata\AdminBundle\Form\Type\Filter\DateRangeType',
-                'sonata_type_filter_datetime' => 'Sonata\AdminBundle\Form\Type\Filter\DateTimeType',
-                'sonata_type_filter_datetime_range' => 'Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType',
-            ];
-            $name = $classnames[$name];
+        if ($this->time && $this->range) {
+            $name = DateTimeRangeType::class;
+        } elseif ($this->time) {
+            $name = DateTimeType::class;
+        } elseif ($this->range) {
+            $name = DateRangeType::class;
         }
 
         return [$name, [

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -12,7 +12,9 @@
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class BooleanFilter extends Filter
 {
@@ -57,9 +59,7 @@ class BooleanFilter extends Filter
     public function getDefaultOptions()
     {
         return [
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\BooleanType'
-                : 'sonata_type_boolean', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => BooleanType::class,
         ];
     }
 
@@ -68,17 +68,10 @@ class BooleanFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return [$type, [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => HiddenType::class,
             'operator_options' => [],
             'label' => $this->getLabel(),
         ]];

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -12,6 +12,9 @@
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class CallbackFilter extends Filter
 {
@@ -34,12 +37,8 @@ class CallbackFilter extends Filter
     {
         return [
             'callback' => null,
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-                : 'hidden', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => TextType::class,
+            'operator_type' => HiddenType::class,
             'operator_options' => [],
         ];
     }
@@ -49,12 +48,7 @@ class CallbackFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return [$type, [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -14,6 +14,8 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\CoreBundle\Form\Type\EqualType;
 
 class ChoiceFilter extends Filter
 {
@@ -76,15 +78,8 @@ class ChoiceFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return [$type, [
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return [DefaultType::class, [
+            'operator_type' => EqualType::class,
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -12,7 +12,10 @@
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\EqualType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 
 class ClassFilter extends Filter
 {
@@ -53,11 +56,7 @@ class ClassFilter extends Filter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice'
-        );
+        return $this->getOption('field_type', ChoiceType::class);
     }
 
     /**
@@ -70,11 +69,7 @@ class ClassFilter extends Filter
             'choices' => $this->getOption('sub_classes'),
         ];
 
-        // NEXT_MAJOR: Remove (when requirement of Symfony is >= 2.7)
-        if (!method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choiceOptions['choices'] = array_flip($this->getOption('sub_classes'));
-            // NEXT_MAJOR: Remove (when requirement of Symfony is >= 3.0)
-        } elseif (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $choiceOptions['choices_as_values'] = true;
         }
 
@@ -86,15 +81,8 @@ class ClassFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return [$type, [
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return [DefaultType::class, [
+            'operator_type' => EqualType::class,
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/DateFilter.php
+++ b/src/Filter/DateFilter.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+
 class DateFilter extends AbstractDateFilter
 {
     /**
@@ -32,10 +34,6 @@ class DateFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\DateType'
-            : 'date'
-        );
+        return $this->getOption('field_type', DateType::class);
     }
 }

--- a/src/Filter/DateRangeFilter.php
+++ b/src/Filter/DateRangeFilter.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
+use Sonata\CoreBundle\Form\Type\DateRangeType;
+
 class DateRangeFilter extends AbstractDateFilter
 {
     /**
@@ -32,10 +34,6 @@ class DateRangeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\CoreBundle\Form\Type\DateRangeType'
-            : 'sonata_type_date_range'
-        );
+        return $this->getOption('field_type', DateRangeType::class);
     }
 }

--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+
 class DateTimeFilter extends AbstractDateFilter
 {
     /**
@@ -32,10 +34,6 @@ class DateTimeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'
-            : 'datetime'
-        );
+        return $this->getOption('field_type', DateTimeType::class);
     }
 }

--- a/src/Filter/DateTimeRangeFilter.php
+++ b/src/Filter/DateTimeRangeFilter.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
+use Sonata\CoreBundle\Form\Type\DateTimeRangeType;
+
 class DateTimeRangeFilter extends AbstractDateFilter
 {
     /**
@@ -32,10 +34,6 @@ class DateTimeRangeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\CoreBundle\Form\Type\DateTimeRangeType'
-            : 'sonata_type_datetime_range'
-        );
+        return $this->getOption('field_type', DateTimeRangeType::class);
     }
 }

--- a/src/Filter/ModelAutocompleteFilter.php
+++ b/src/Filter/ModelAutocompleteFilter.php
@@ -14,6 +14,8 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\CoreBundle\Form\Type\EqualType;
 
 class ModelAutocompleteFilter extends Filter
@@ -45,13 +47,9 @@ class ModelAutocompleteFilter extends Filter
     {
         return [
             'field_name' => false,
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\AdminBundle\Form\Type\ModelAutocompleteType'
-                : 'sonata_type_model_autocomplete', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => ModelAutocompleteType::class,
             'field_options' => [],
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => EqualType::class,
             'operator_options' => [],
         ];
     }
@@ -61,12 +59,7 @@ class ModelAutocompleteFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return [$type, [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -15,7 +15,9 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\EqualType;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 
 class ModelFilter extends Filter
 {
@@ -47,13 +49,9 @@ class ModelFilter extends Filter
         return [
             'mapping_type' => false,
             'field_name' => false,
-            'field_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Bridge\Doctrine\Form\Type\EntityType'
-                : 'entity', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'field_type' => EntityType::class,
             'field_options' => [],
-            'operator_type' => method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                : 'sonata_type_equal', // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+            'operator_type' => EqualType::class,
             'operator_options' => [],
         ];
     }
@@ -63,12 +61,7 @@ class ModelFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\DefaultType'
-            : 'sonata_type_filter_default';
-
-        return [$type, [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -52,12 +52,7 @@ class NumberFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\NumberType'
-            : 'sonata_type_filter_number';
-
-        return [$type, [
+        return [NumberType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -74,12 +74,7 @@ class StringFilter extends Filter
      */
     public function getRenderSettings()
     {
-        // NEXT_MAJOR: Remove this line when drop Symfony <2.8 support
-        $type = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\Filter\ChoiceType'
-            : 'sonata_type_filter_choice';
-
-        return [$type, [
+        return [ChoiceType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/TimeFilter.php
+++ b/src/Filter/TimeFilter.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
+
 class TimeFilter extends AbstractDateFilter
 {
     /**
@@ -32,10 +34,6 @@ class TimeFilter extends AbstractDateFilter
      */
     public function getFieldType()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return $this->getOption('field_type', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TimeType'
-            : 'time'
-        );
+        return $this->getOption('field_type', TimeType::class);
     }
 }

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -13,7 +13,12 @@ namespace Sonata\DoctrineORMAdminBundle\Guesser;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\CoreBundle\Form\Type\BooleanType;
+use Sonata\CoreBundle\Form\Type\EqualType;
 use Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
@@ -46,16 +51,9 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                 case ClassMetadataInfo::ONE_TO_MANY:
                 case ClassMetadataInfo::MANY_TO_ONE:
                 case ClassMetadataInfo::MANY_TO_MANY:
-                    // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8).
-                    $options['operator_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                        ? 'Sonata\CoreBundle\Form\Type\EqualType'
-                        : 'sonata_type_equal';
+                    $options['operator_type'] = EqualType::class;
                     $options['operator_options'] = [];
-
-                    // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                    $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                        ? 'Symfony\Bridge\Doctrine\Form\Type\EntityType'
-                        : 'entity';
+                    $options['field_type'] = EntityType::class;
                     $options['field_options'] = [
                         'class' => $mapping['targetEntity'],
                     ];
@@ -75,11 +73,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
         switch ($metadata->getTypeOfField($propertyName)) {
             case 'boolean':
-                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Sonata\CoreBundle\Form\Type\BooleanType'
-                    : 'sonata_type_boolean';
-                $options['field_options'] = [];
+                $options['field_type'] = BooleanType::class;
 
                 return new TypeGuess('doctrine_orm_boolean', $options, Guess::HIGH_CONFIDENCE);
             case 'datetime':
@@ -93,18 +87,12 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             case 'integer':
             case 'bigint':
             case 'smallint':
-                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\NumberType'
-                    : 'number';
+                $options['field_type'] = NumberType::class;
 
                 return new TypeGuess('doctrine_orm_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'string':
             case 'text':
-                // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-                $options['field_type'] = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                    ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                    : 'text';
+                $options['field_type'] = TextType::class;
 
                 return new TypeGuess('doctrine_orm_string', $options, Guess::MEDIUM_CONFIDENCE);
             case 'time':

--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -2,6 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.admin.entity_manager" class="Doctrine\ORM\EntityManager" public="false">
+            <factory service="doctrine" method="getManager" />
             <argument>%sonata_doctrine_orm_admin.entity_manager%</argument>
         </service>
         <service id="sonata.admin.manager.orm" class="Sonata\DoctrineORMAdminBundle\Model\ModelManager">

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -14,6 +14,11 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\Type\AdminType;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+use Sonata\AdminBundle\Form\Type\ModelHiddenType;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\AdminBundle\Form\Type\ModelType;
+use Sonata\CoreBundle\Form\Type\CollectionType;
 use Sonata\DoctrineORMAdminBundle\Builder\FormContractor;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -64,36 +69,25 @@ final class FormContractorTest extends TestCase
         $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
 
+        // NEXT_MAJOR: Use only FQCNs when dropping support for Symfony 2.8
         $modelTypes = [
             'sonata_type_model',
             'sonata_type_model_list',
             'sonata_type_model_hidden',
             'sonata_type_model_autocomplete',
+            ModelType::class,
+            ModelListType::class,
+            ModelHiddenType::class,
+            ModelAutocompleteType::class,
         ];
-        $adminTypes = ['sonata_type_admin'];
-        $collectionTypes = ['sonata_type_collection'];
-        // NEXT_MAJOR: Use only FQCNs when dropping support for Symfony <2.8
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $classTypes = [
-                'Sonata\AdminBundle\Form\Type\ModelType',
-                'Sonata\AdminBundle\Form\Type\ModelListType',
-                'Sonata\AdminBundle\Form\Type\ModelHiddenType',
-                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType',
-            ];
-
-            foreach ($classTypes as $classType) {
-                array_push(
-                    $modelTypes,
-                    // add class type.
-                    $classType,
-                    // add instance of class type.
-                    get_class($this->createMock($classType))
-                );
-            }
-
-            $adminTypes[] = 'Sonata\AdminBundle\Form\Type\AdminType';
-            $collectionTypes[] = 'Sonata\CoreBundle\Form\Type\CollectionType';
-        }
+        $adminTypes = [
+            'sonata_type_admin',
+            AdminType::class,
+        ];
+        $collectionTypes = [
+            'sonata_type_collection',
+            CollectionType::class,
+        ];
 
         // model types
         foreach ($modelTypes as $formType) {

--- a/tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
@@ -12,7 +12,6 @@
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\SonataDoctrineORMAdminExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 
 class SonataDoctrineORMAdminExtensionTest extends TestCase
 {
@@ -34,14 +33,7 @@ class SonataDoctrineORMAdminExtensionTest extends TestCase
         $loader->load([], $this->configuration);
 
         $definition = $this->configuration->getDefinition('sonata.admin.entity_manager');
-        $doctrineServiceId = 'doctrine';
-        $doctrineFactoryMethod = 'getEntityManager';
 
-        if (method_exists($definition, 'getFactory')) {
-            $this->assertEquals([new Reference($doctrineServiceId), $doctrineFactoryMethod], $definition->getFactory());
-        } else {
-            $this->assertEquals($doctrineServiceId, $definition->getFactoryService());
-            $this->assertEquals($doctrineFactoryMethod, $definition->getFactoryMethod());
-        }
+        $this->assertNotNull($definition->getFactory());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Subject

<!-- Describe your Pull Request content here -->
Removing old code that never gets executed because we dropped SF 2.3 to 2.7