### PR TITLE
sonate_admin.value shouldn't be a condition for the add button

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -85,7 +85,6 @@ file that was distributed with this source code.
                 {% if sonata_admin.field_description.associationadmin.hasroute('create')
                     and sonata_admin.field_description.associationadmin.isGranted('CREATE')
                     and btn_add
-                    and sonata_admin.value == null
                 %}
                     <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_dialog_form_add_{{ id }}(this);"
@@ -95,7 +94,8 @@ file that was distributed with this source code.
                         <i class="fa fa-plus-circle"></i>
                         {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
-                {% elseif sonata_admin.field_description.associationadmin.hasroute('edit')
+                {% endif %}
+                {% if sonata_admin.field_description.associationadmin.hasroute('edit')
                     and sonata_admin.field_description.associationadmin.isGranted('EDIT')
                     and btn_edit
                     and sonata_admin.value != null


### PR DESCRIPTION
I am targeting this branch, because it's a non BC bugfix.

## Changelog

```markdown
### Fixed
Allow to `add` a new Model even if one is already selected
```

## To do
- [x] Update the tests
- [x] Update the documentation
- [ ] Add an upgrade note

## Subject

Introduced with #708 was an additional condition for the `add` button which shouldn't be there. This prevents creating new models if one is already selected. If this behaviour is still needed it can be archived in the Admin::configureFormFields method simply by setting the `btn_add` option to `false`.