### PR TITLE
Fix Invalid PathExpression error in ProxyQuery

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -326,6 +326,7 @@ class ProxyQuery implements ProxyQueryInterface
         // step 3 : retrieve the different subjects ids
         $selects = [];
         $idxSelect = '';
+        $idSelects = [];
         foreach ($idNames as $idName) {
             $select = sprintf('%s.%s', $rootAlias, $idName);
             // Put the ID select on this array to use it on results QB
@@ -335,6 +336,7 @@ class ProxyQuery implements ProxyQueryInterface
             // Should work only with doctrine/orm: ~2.2
             $idSelect = $select;
             if ($metadata->hasAssociation($idName)) {
+                $idSelects[] = $idSelect;
                 $idSelect = sprintf('IDENTITY(%s) as %s', $idSelect, $idName);
             }
             $idxSelect .= ('' !== $idxSelect ? ', ' : '').$idSelect;
@@ -348,7 +350,7 @@ class ProxyQuery implements ProxyQueryInterface
         For any particular x-value in the table there might be many different y
         values.  Which one will you use to sort that x-value in the output?
         */
-        $this->addOrderedColumns($queryBuilderId);
+        $this->addOrderedColumns($queryBuilderId, $idSelects);
 
         $results = $queryBuilderId->getQuery()->execute([], Query::HYDRATE_ARRAY);
         $platform = $queryBuilderId->getEntityManager()->getConnection()->getDatabasePlatform();
@@ -378,13 +380,20 @@ class ProxyQuery implements ProxyQueryInterface
         return $queryBuilder;
     }
 
-    private function addOrderedColumns(QueryBuilder $queryBuilder)
+    /**
+     * @param array $idSelects List of column identifiers to skip.
+     */
+    private function addOrderedColumns(QueryBuilder $queryBuilder, array $idSelects)
     {
         /* For each ORDER BY clause defined directly in the DQL parts of the query,
-           we add an entry in the SELECT clause. */
+           we add an entry in the SELECT clause. Skip ids that have already been added
+           to the SELECT as IDENTITY(id) */
         foreach ((array) $queryBuilder->getDqlPart('orderBy') as $part) {
             foreach ($part->getParts() as $orderBy) {
-                $queryBuilder->addSelect(preg_replace("/\s+(ASC|DESC)$/i", '', $orderBy));
+                $id = preg_replace("/\s+(ASC|DESC)$/i", '', $orderBy);
+                if (!in_array($id, $idSelects, true)) {
+                    $queryBuilder->addSelect($id);
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #766

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed invalid PathExpression error in ProxyQuery
```

## Subject
<!-- Describe your Pull Request content here -->
#728 introduced bug in ProxyQuery for tables with composite keys. `ProxyQuery::addOrderedColumns` should skip columns that have already been added to the SELECT as IDENTITY(column).