### PR TITLE
Refresh edit button URL if item is replaced with list/add action

### DIFF
--- a/src/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -473,6 +473,14 @@ This code manage the many-to-[one|many] association field popup
                     jQuery('#field_widget_{{ id }}').html(html);
                 }
             });
+
+            {% if btn_edit %}
+                var edit_button_url = '{{
+                    associationadmin.generateUrl('edit', {'id' : 'OBJECT_ID'})
+                }}'.replace('OBJECT_ID', jQuery(this).val());
+
+                jQuery('#field_actions_{{ id }} a.btn-warning').attr('href', edit_button_url);
+            {% endif %}
         });
 
     {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am adding fix for edit button that was always opening initial item in popup even if you replace that item with list/add action. 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added refresh of edit button URL if item was replaced by add/list action

### Fixed
- Issue with edit button always showing initial item in popup
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

## Subject

As pointed out to me in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/765#issuecomment-348928269 by n3o77 if you replace the item with list/add action edit button will still open the initial item in the popup and that is wrong. I added javascript code that is loaded if `btn_edit` is enabled, and it will change the URL of edit button when updating the label.
