### PR TITLE
Deprecate current templates and start using templates from SonataAdminBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "doctrine/orm": "^2.4.5",
-        "sonata-project/admin-bundle": "^3.26.0",
-        "sonata-project/core-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.29",
+        "sonata-project/core-bundle": "^3.8",
         "sonata-project/exporter": "^1.3.1",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/doctrine-bridge": "^2.8 || ^3.2 || ^4.0",

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -129,25 +129,25 @@ class ListBuilder implements ListBuilderInterface
                 switch ($fieldDescription->getMappingType()) {
                     case ClassMetadataInfo::MANY_TO_ONE:
                         $fieldDescription->setTemplate(
-                            'SonataDoctrineORMAdminBundle:CRUD:list_orm_many_to_one.html.twig'
+                            'SonataAdminBundle:CRUD/Association:list_many_to_one.html.twig'
                         );
 
                         break;
                     case ClassMetadataInfo::ONE_TO_ONE:
                         $fieldDescription->setTemplate(
-                            'SonataDoctrineORMAdminBundle:CRUD:list_orm_one_to_one.html.twig'
+                            'SonataAdminBundle:CRUD/Association:list_one_to_one.html.twig'
                         );
 
                         break;
                     case ClassMetadataInfo::ONE_TO_MANY:
                         $fieldDescription->setTemplate(
-                            'SonataDoctrineORMAdminBundle:CRUD:list_orm_one_to_many.html.twig'
+                            'SonataAdminBundle:CRUD/Association:list_one_to_many.html.twi'
                         );
 
                         break;
                     case ClassMetadataInfo::MANY_TO_MANY:
                         $fieldDescription->setTemplate(
-                            'SonataDoctrineORMAdminBundle:CRUD:list_orm_many_to_many.html.twig'
+                            'SonataAdminBundle:CRUD/Association:list_many_to_many.html.twig'
                         );
 
                         break;

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -102,25 +102,25 @@ class ShowBuilder implements ShowBuilderInterface
                 switch ($fieldDescription->getMappingType()) {
                     case ClassMetadataInfo::MANY_TO_ONE:
                         $fieldDescription->setTemplate(
-                            'SonataDoctrineORMAdminBundle:CRUD:show_orm_many_to_one.html.twig'
+                            'SonataAdminBundle:CRUD/Association:show_many_to_one.html.twig'
                         );
 
                         break;
                     case ClassMetadataInfo::ONE_TO_ONE:
                         $fieldDescription->setTemplate(
-                            'SonataDoctrineORMAdminBundle:CRUD:show_orm_one_to_one.html.twig'
+                            'SonataAdminBundle:CRUD/Association:show_one_to_one.html.twig'
                         );
 
                         break;
                     case ClassMetadataInfo::ONE_TO_MANY:
                         $fieldDescription->setTemplate(
-                            'SonataDoctrineORMAdminBundle:CRUD:show_orm_one_to_many.html.twig'
+                            'SonataAdminBundle:CRUD/Association:show_one_to_many.html.twig'
                         );
 
                         break;
                     case ClassMetadataInfo::MANY_TO_MANY:
                         $fieldDescription->setTemplate(
-                            'SonataDoctrineORMAdminBundle:CRUD:show_orm_many_to_many.html.twig'
+                            'SonataAdminBundle:CRUD/Association:show_many_to_many.html.twig'
                         );
 
                         break;

--- a/src/Resources/views/CRUD/edit_modal.html.twig
+++ b/src/Resources/views/CRUD/edit_modal.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_modal.html.twig' %}
+
 <div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">

--- a/src/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -16,6 +16,8 @@ This code manage the many-to-[one|many] association field popup
 
 #}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_many_script.html.twig' %}
+
 {% autoescape false %}
 
 {% set associationadmin = sonata_admin.field_description.associationadmin %}

--- a/src/Resources/views/CRUD/edit_orm_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_many_to_many.html.twig
@@ -8,6 +8,9 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_many_to_many.html.twig' %}
+
 {% if sonata_admin.field_description.hasassociationadmin %}
     <div id="field_container_{{ id }}" class="field-container">
         <span id="field_widget_{{ id }}" >

--- a/src/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_many_to_one.html.twig' %}
+
 {% if not sonata_admin.field_description.hasassociationadmin%}
     {{ value|render_relation_element(sonata_admin.field_description) }}
 {% elseif sonata_admin.edit == 'inline' %}

--- a/src/Resources/views/CRUD/edit_orm_one_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_association_script.html.twig
@@ -16,6 +16,8 @@ This code manage the one-to-many association field popup
 
 #}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_one_script.html.twig' %}
+
 {% autoescape false %}
 
 <!-- edit one association -->

--- a/src/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -8,6 +8,9 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_one_to_many.html.twig' %}
+
 {% if not sonata_admin.field_description.hasassociationadmin %}
     {% for element in value %}
         {{ element|render_relation_element(sonata_admin.field_description) }}

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
@@ -8,6 +8,9 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_one_to_many_inline_table.html.twig' %}
+
 <table class="table table-bordered">
     <thead>
         <tr>

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
@@ -8,6 +8,9 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_one_to_many_inline_tabs.html.twig' %}
+
 <div class="sonata-ba-tabs">
     {% for nested_group_field in form.children %}
         <div>

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_table.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_table.html.twig
@@ -8,6 +8,9 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig' %}
+
 <script type="text/javascript">
     jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody').first().sortable({
         axis: 'y',

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_tabs.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_tabs.html.twig
@@ -8,6 +8,9 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
+
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_one_to_many_sortable_script_tabs.html.twig' %}
+
 <script type="text/javascript">
     jQuery('div#field_container_{{ id }} .sonata-ba-tabs').sortable({
         axis: 'y',

--- a/src/Resources/views/CRUD/edit_orm_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_one.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/edit_one_to_one.html.twig' %}
+
 {% if not sonata_admin.field_description.hasassociationadmin%}
     {{ value|render_relation_element(sonata_admin.field_description) }}
 {% elseif sonata_admin.edit == 'inline' %}

--- a/src/Resources/views/CRUD/list_orm_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/list_orm_many_to_many.html.twig
@@ -11,6 +11,8 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/list_many_to_many.html.twig' %}
+
 {% block field %}
     {% set route_name = field_description.options.route.name %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) %}

--- a/src/Resources/views/CRUD/list_orm_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/list_orm_many_to_one.html.twig
@@ -11,6 +11,8 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/list_many_to_one.html.twig' %}
+
 {% block field %}
     {% if value %}
         {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -11,6 +11,8 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/list_one_to_many.html.twig' %}
+
 {% block field %}
     {% set route_name = field_description.options.route.name %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) %}

--- a/src/Resources/views/CRUD/list_orm_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/list_orm_one_to_one.html.twig
@@ -11,6 +11,8 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/list_one_to_one.html.twig' %}
+
 {% block field %}
     {% set route_name = field_description.options.route.name %}
     {% if field_description.hasAssociationAdmin

--- a/src/Resources/views/CRUD/show_orm_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/show_orm_many_to_many.html.twig
@@ -11,6 +11,8 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/show_many_to_one.html.twig' %}
+
 {% block field %}
     <ul class="sonata-ba-show-many-to-many">
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/show_orm_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/show_orm_many_to_one.html.twig
@@ -11,6 +11,8 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/show_many_to_one.html.twig' %}
+
 {% block field %}
     {% if value %}
         {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/show_orm_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/show_orm_one_to_many.html.twig
@@ -11,6 +11,8 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/show_one_to_many.html.twig' %}
+
 {% block field %}
     <ul class="sonata-ba-show-one-to-many">
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/show_orm_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/show_orm_one_to_one.html.twig
@@ -11,6 +11,8 @@ file that was distributed with this source code.
 
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
+{% sonata_template_deprecate '@SonataAdminBundle/CRUD/Association/show_one_to_one.html.twig' %}
+
 {% block field %}
     {% set route_name = field_description.options.route.name %}
     {% if field_description.hasAssociationAdmin

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -14,19 +14,19 @@ file that was distributed with this source code.
 
 {# Custom Sonata Admin Extension #}
 {% block sonata_admin_orm_one_to_one_widget %}
-    {% include 'SonataDoctrineORMAdminBundle:CRUD:edit_orm_one_to_one.html.twig' %}
+    {% include 'SonataAdminBundle:CRUD/Association:edit_one_to_one.html.twig' %}
 {% endblock %}
 
 {% block sonata_admin_orm_many_to_many_widget %}
-    {% include 'SonataDoctrineORMAdminBundle:CRUD:edit_orm_many_to_many.html.twig' %}
+    {% include 'SonataAdminBundle:CRUD/Association:edit_many_to_many.html.twig' %}
 {% endblock %}
 
 {% block sonata_admin_orm_many_to_one_widget %}
-    {% include 'SonataDoctrineORMAdminBundle:CRUD:edit_orm_many_to_one.html.twig' %}
+    {% include 'SonataAdminBundle:CRUD/Association:edit_many_to_one.html.twig' %}
 {% endblock %}
 
 {% block sonata_admin_orm_one_to_many_widget %}
-    {% include 'SonataDoctrineORMAdminBundle:CRUD:edit_orm_one_to_many.html.twig' %}
+    {% include 'SonataAdminBundle:CRUD/Association:edit_one_to_many.html.twig' %}
 {% endblock %}
 
 {% block sonata_type_model_widget %}
@@ -146,7 +146,7 @@ file that was distributed with this source code.
         </div>
     </div>
 
-    {% include 'SonataDoctrineORMAdminBundle:CRUD:edit_orm_many_association_script.html.twig' %}
+    {% include 'SonataAdminBundle:CRUD/Association:edit_many_script.html.twig' %}
 {% endblock %}
 
 {% block sonata_type_admin_widget %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am deprecating templates from this bundle and switching to templates in `SonataAdminBundle`

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Switched to templates from SonataAdminBundle
### Deprecated
- Association templates
```

## To do

- [x] Wait for merge of https://github.com/sonata-project/SonataAdminBundle/pull/4828
- [x] Wait for merge of https://github.com/sonata-project/SonataAdminBundle/pull/4844
- [x] Wait for merge of https://github.com/sonata-project/SonataCoreBundle/pull/495
- [x] Wait for new release of [SonataAdminBundle](https://github.com/sonata-project/SonataAdminBundle) to bump composer version
- [x] Wait for new release of [SonataCoreBundle](https://github.com/sonata-project/SonataCoreBundle) to bump composer version
- [x] Compare Templates between bundles

## Subject

After ElectricMaxxx mentioned [here](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/770#issuecomment-349443898) that templates were moved to `SonataAdminBundle` I saw that we are still using the ones from `SonataDoctrineORMAdminBundle` so here is the depreciation of old ones and switching to new ones.
