### PR TITLE
Replace FQCN strings with ::class constants

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -334,7 +334,7 @@ class ProxyQuery implements ProxyQueryInterface
     }
 
     /**
-     * @param array $idSelects List of column identifiers to skip.
+     * @param array $idSelects List of column identifiers to skip
      */
     private function addOrderedColumns(QueryBuilder $queryBuilder, array $idSelects)
     {

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -12,6 +12,10 @@
 namespace Sonata\DoctrineORMAdminBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 
 class FieldDescriptionTest extends TestCase
@@ -133,7 +137,7 @@ class FieldDescriptionTest extends TestCase
 
     public function testGetParent()
     {
-        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminMock = $this->createMock(AdminInterface::class);
         $field = new FieldDescription();
         $field->setParent($adminMock);
 
@@ -150,7 +154,7 @@ class FieldDescriptionTest extends TestCase
 
     public function testGetAdmin()
     {
-        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminMock = $this->createMock(AdminInterface::class);
         $field = new FieldDescription();
         $field->setAdmin($adminMock);
 
@@ -159,10 +163,10 @@ class FieldDescriptionTest extends TestCase
 
     public function testGetAssociationAdmin()
     {
-        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $adminMock = $this->createMock(AbstractAdmin::class);
         $adminMock->expects($this->once())
             ->method('setParentFieldDescription')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface'));
+            ->with($this->isInstanceOf(FieldDescriptionInterface::class));
 
         $field = new FieldDescription();
         $field->setAssociationAdmin($adminMock);
@@ -172,10 +176,10 @@ class FieldDescriptionTest extends TestCase
 
     public function testHasAssociationAdmin()
     {
-        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $adminMock = $this->createMock(AbstractAdmin::class);
         $adminMock->expects($this->once())
             ->method('setParentFieldDescription')
-            ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface'));
+            ->with($this->isInstanceOf(FieldDescriptionInterface::class));
 
         $field = new FieldDescription();
 
@@ -203,7 +207,7 @@ class FieldDescriptionTest extends TestCase
 
     public function testGetValueWhenCannotRetrieve()
     {
-        $this->expectException(\Sonata\AdminBundle\Exception\NoValueException::class);
+        $this->expectException(NoValueException::class);
 
         $mockedObject = $this->getMockBuilder('stdClass')
             ->setMethods(['myMethod'])

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -12,10 +12,16 @@
 namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\FilterFactoryInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\DoctrineORMAdminBundle\Builder\DatagridBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**
@@ -44,30 +50,30 @@ final class DatagridBuilderTest extends TestCase
 
     protected function setUp()
     {
-        $this->formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $this->filterFactory = $this->createMock('Sonata\AdminBundle\Filter\FilterFactoryInterface');
-        $this->typeGuesser = $this->createMock('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $this->formFactory = $this->createMock(FormFactoryInterface::class);
+        $this->filterFactory = $this->createMock(FilterFactoryInterface::class);
+        $this->typeGuesser = $this->createMock(TypeGuesserInterface::class);
 
         $this->datagridBuilder = new DatagridBuilder($this->formFactory, $this->filterFactory, $this->typeGuesser);
     }
 
     public function testGetBaseDatagrid()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $admin = $this->createMock(AbstractAdmin::class);
         $admin->expects($this->once())->method('getPagerType')->willReturn(Pager::TYPE_SIMPLE);
         $admin->expects($this->once())->method('getClass')->willReturn('Foo\Bar');
         $admin->expects($this->once())->method('createQuery')
-            ->willReturn($this->createMock('Sonata\AdminBundle\Datagrid\ProxyQueryInterface'));
+            ->willReturn($this->createMock(ProxyQueryInterface::class));
         $admin->expects($this->once())->method('getList')
-            ->willReturn($this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionCollection'));
+            ->willReturn($this->createMock(FieldDescriptionCollection::class));
 
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->expects($this->once())->method('getIdentifierFieldNames')->willReturn(['id']);
         $admin->expects($this->once())->method('getModelManager')->willReturn($modelManager);
 
         $this->formFactory->expects($this->once())->method('createNamedBuilder')
-            ->willReturn($this->createMock('Symfony\Component\Form\FormBuilderInterface'));
+            ->willReturn($this->createMock(FormBuilderInterface::class));
 
-        $this->assertInstanceOf('Sonata\AdminBundle\Datagrid\Datagrid', $this->datagridBuilder->getBaseDatagrid($admin));
+        $this->assertInstanceOf(Datagrid::class, $this->datagridBuilder->getBaseDatagrid($admin));
     }
 }

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -13,13 +13,18 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\Type\AdminType;
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\CoreBundle\Form\Type\CollectionType;
 use Sonata\DoctrineORMAdminBundle\Builder\FormContractor;
+use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 
 /**
@@ -39,7 +44,7 @@ final class FormContractorTest extends TestCase
 
     protected function setUp()
     {
-        $this->formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $this->formFactory = $this->createMock(FormFactoryInterface::class);
 
         $this->formContractor = new FormContractor($this->formFactory);
     }
@@ -47,24 +52,24 @@ final class FormContractorTest extends TestCase
     public function testGetFormBuilder()
     {
         $this->formFactory->expects($this->once())->method('createNamedBuilder')
-            ->willReturn($this->createMock('Symfony\Component\Form\FormBuilderInterface'));
+            ->willReturn($this->createMock(FormBuilderInterface::class));
 
         $this->assertInstanceOf(
-            'Symfony\Component\Form\FormBuilderInterface',
+            FormBuilderInterface::class,
             $this->formContractor->getFormBuilder('test', ['foo' => 'bar'])
         );
     }
 
     public function testDefaultOptionsForSonataFormTypes()
     {
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $admin = $this->createMock(AdminInterface::class);
+        $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelClass = 'FooEntity';
 
         $admin->method('getModelManager')->willReturn($modelManager);
         $admin->method('getClass')->willReturn($modelClass);
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->method('getAdmin')->willReturn($admin);
         $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
@@ -122,13 +127,13 @@ final class FormContractorTest extends TestCase
     public function testAdminClassAttachForNotMappedField()
     {
         // Given
-        $modelManager = $this->createMock('Sonata\DoctrineORMAdminBundle\Model\ModelManager');
+        $modelManager = $this->createMock(ModelManager::class);
         $modelManager->method('hasMetadata')->willReturn(false);
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->method('getModelManager')->willReturn($modelManager);
 
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->method('getMappingType')->willReturn('simple');
         $fieldDescription->method('getType')->willReturn('sonata_type_model_list');
         $fieldDescription->method('getOption')->with($this->logicalOr(

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -13,6 +13,7 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
@@ -48,12 +49,12 @@ class ListBuilderTest extends TestCase
 
     protected function setUp()
     {
-        $this->typeGuesser = $this->prophesize('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+        $this->typeGuesser = $this->prophesize(TypeGuesserInterface::class);
 
-        $this->modelManager = $this->prophesize('Sonata\DoctrineORMAdminBundle\Model\ModelManager');
+        $this->modelManager = $this->prophesize(ModelManager::class);
         $this->modelManager->hasMetadata(Argument::any())->willReturn(false);
 
-        $this->admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $this->admin = $this->prophesize(AbstractAdmin::class);
         $this->admin->getClass()->willReturn('Foo');
         $this->admin->getModelManager()->willReturn($this->modelManager);
         $this->admin->addListFieldDescription(Argument::any(), Argument::any())

--- a/tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
@@ -13,6 +13,7 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddAuditEntityCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 class AddAuditEntityCompilerPassTest extends TestCase
@@ -38,7 +39,7 @@ class AddAuditEntityCompilerPassTest extends TestCase
      */
     public function testProcess($force, array $services)
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock(ContainerBuilder::class);
 
         $container
             ->expects($this->any())

--- a/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
@@ -13,13 +13,14 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddTemplatesCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 class AddTemplatesCompilerPassTest extends TestCase
 {
     public function testDefaultBehavior()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $container = $this->createMock(ContainerBuilder::class);
 
         $container
             ->expects($this->any())

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -13,6 +13,7 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\CoreBundle\Form\Type\EqualType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\ModelFilter;
@@ -26,7 +27,7 @@ class ModelFilterTest extends TestCase
      */
     public function getFieldDescription(array $options)
     {
-        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->expects($this->once())->method('getOptions')->will($this->returnValue($options));
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('field_name'));
 

--- a/tests/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Guesser/FilterTypeGuesserTest.php
@@ -11,8 +11,11 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Guesser;
 
+use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Guesser\FilterTypeGuesser;
+use Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException;
+use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 
 class FilterTypeGuesserTest extends TestCase
 {
@@ -23,13 +26,13 @@ class FilterTypeGuesserTest extends TestCase
     protected function setUp()
     {
         $this->guesser = new FilterTypeGuesser();
-        $this->modelManager = $this->prophesize('Sonata\DoctrineORMAdminBundle\Model\ModelManager');
-        $this->metadata = $this->prophesize('Doctrine\ORM\Mapping\ClassMetadata');
+        $this->modelManager = $this->prophesize(ModelManager::class);
+        $this->metadata = $this->prophesize(ClassMetadata::class);
     }
 
     public function testThrowsOnMissingField()
     {
-        $this->expectException(\Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException::class);
+        $this->expectException(MissingPropertyMetadataException::class);
 
         $class = 'My\Model';
         $property = 'whatever';

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -11,40 +11,53 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Model;
 
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Version;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\Datagrid;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Exception\LockException;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\AssociatedEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ContainerEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\SimpleEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\VersionedEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class ModelManagerTest extends TestCase
 {
     public static function setUpBeforeClass()
     {
         if (!Type::hasType('uuid')) {
-            Type::addType('uuid', 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType');
+            Type::addType('uuid', UuidType::class);
         }
     }
 
     public function testSortParameters()
     {
-        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock(RegistryInterface::class);
 
         $manager = new ModelManager($registry);
 
-        $datagrid1 = $this->createMock('Sonata\AdminBundle\Datagrid\Datagrid');
-        $datagrid2 = $this->createMock('Sonata\AdminBundle\Datagrid\Datagrid');
+        $datagrid1 = $this->createMock(Datagrid::class);
+        $datagrid2 = $this->createMock(Datagrid::class);
 
         $field1 = new FieldDescription();
         $field1->setName('field1');
@@ -108,7 +121,7 @@ class ModelManagerTest extends TestCase
     {
         $object = new VersionedEntity();
 
-        $modelManager = $this->getMockBuilder('Sonata\DoctrineORMAdminBundle\Model\ModelManager')
+        $modelManager = $this->getMockBuilder(ModelManager::class)
             ->disableOriginalConstructor()
             ->setMethods(['getMetadata'])
             ->getMock();
@@ -144,12 +157,12 @@ class ModelManagerTest extends TestCase
     {
         $object = new VersionedEntity();
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+        $em = $this->getMockBuilder(EntityManager::class)
             ->disableOriginalConstructor()
             ->setMethods(['lock'])
             ->getMock();
 
-        $modelManager = $this->getMockBuilder('Sonata\DoctrineORMAdminBundle\Model\ModelManager')
+        $modelManager = $this->getMockBuilder(ModelManager::class)
             ->disableOriginalConstructor()
             ->setMethods(['getMetadata', 'getEntityManager'])
             ->getMock();
@@ -169,7 +182,7 @@ class ModelManagerTest extends TestCase
                 ->method('lock')
                 ->will($this->throwException(OptimisticLockException::lockFailed($object)));
 
-            $this->expectException('Sonata\AdminBundle\Exception\LockException');
+            $this->expectException(LockException::class);
         }
 
         $modelManager->lock($object, 123);
@@ -183,14 +196,14 @@ class ModelManagerTest extends TestCase
             return;
         }
 
-        $containerEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ContainerEntity';
-        $associatedEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\AssociatedEntity';
-        $embeddedEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity';
-        $modelManagerClass = 'Sonata\DoctrineORMAdminBundle\Model\ModelManager';
+        $containerEntityClass = ContainerEntity::class;
+        $associatedEntityClass = AssociatedEntity::class;
+        $embeddedEntityClass = EmbeddedEntity::class;
+        $modelManagerClass = ModelManager::class;
 
         $object = new ContainerEntity(new AssociatedEntity(null, new EmbeddedEntity()), new EmbeddedEntity());
 
-        $em = $this->createMock('Doctrine\ORM\EntityManager');
+        $em = $this->createMock(EntityManager::class);
 
         /** @var \PHPUnit_Framework_MockObject_MockObject|ModelManager $modelManager */
         $modelManager = $this->getMockBuilder($modelManagerClass)
@@ -237,7 +250,7 @@ class ModelManagerTest extends TestCase
 
     public function getMetadataForEmbeddedEntity()
     {
-        $metadata = new ClassMetadata('Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity');
+        $metadata = new ClassMetadata(EmbeddedEntity::class);
 
         $metadata->fieldMappings = [
             'plainField' => [
@@ -252,9 +265,9 @@ class ModelManagerTest extends TestCase
 
     public function getMetadataForAssociatedEntity()
     {
-        $embeddedEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity';
+        $embeddedEntityClass = EmbeddedEntity::class;
 
-        $metadata = new ClassMetadata('Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\AssociatedEntity');
+        $metadata = new ClassMetadata(AssociatedEntity::class);
 
         $metadata->fieldMappings = [
             'plainField' => [
@@ -276,9 +289,9 @@ class ModelManagerTest extends TestCase
 
     public function getMetadataForContainerEntity()
     {
-        $containerEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ContainerEntity';
-        $associatedEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\AssociatedEntity';
-        $embeddedEntityClass = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\Embeddable\EmbeddedEntity';
+        $containerEntityClass = ContainerEntity::class;
+        $associatedEntityClass = AssociatedEntity::class;
+        $embeddedEntityClass = EmbeddedEntity::class;
 
         $metadata = new ClassMetadata($containerEntityClass);
 
@@ -311,7 +324,7 @@ class ModelManagerTest extends TestCase
         $uuid = new NonIntegerIdentifierTestClass('efbcfc4b-8c43-4d42-aa4c-d707e55151ac');
         $entity = new UuidEntity($uuid);
 
-        $meta = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataInfo');
+        $meta = $this->createMock(ClassMetadataInfo::class);
         $meta->expects($this->any())
             ->method('getIdentifierValues')
             ->willReturn([$entity->getId()]);
@@ -319,19 +332,19 @@ class ModelManagerTest extends TestCase
             ->method('getTypeOfField')
             ->willReturn(UuidType::NAME);
 
-        $mf = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataFactory');
+        $mf = $this->createMock(ClassMetadataFactory::class);
         $mf->expects($this->any())
             ->method('getMetadataFor')
             ->willReturn($meta);
 
-        $platform = $this->createMock('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
+        $platform = $this->createMock(PostgreSqlPlatform::class);
 
-        $conn = $this->createMock('Doctrine\DBAL\Connection');
+        $conn = $this->createMock(Connection::class);
         $conn->expects($this->any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
-        $em = $this->createMock('Doctrine\ORM\EntityManager');
+        $em = $this->createMock(EntityManager::class);
         $em->expects($this->any())
             ->method('getMetadataFactory')
             ->willReturn($mf);
@@ -339,7 +352,7 @@ class ModelManagerTest extends TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->any())
             ->method('getManagerForClass')
             ->willReturn($em);
@@ -354,7 +367,7 @@ class ModelManagerTest extends TestCase
     {
         $entity = new ContainerEntity(new AssociatedEntity(42, new EmbeddedEntity()), new EmbeddedEntity());
 
-        $meta = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataInfo');
+        $meta = $this->createMock(ClassMetadataInfo::class);
         $meta->expects($this->any())
             ->method('getIdentifierValues')
             ->willReturn([$entity->getAssociatedEntity()->getPlainField()]);
@@ -362,19 +375,19 @@ class ModelManagerTest extends TestCase
             ->method('getTypeOfField')
             ->willReturn(null);
 
-        $mf = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataFactory');
+        $mf = $this->createMock(ClassMetadataFactory::class);
         $mf->expects($this->any())
             ->method('getMetadataFor')
             ->willReturn($meta);
 
-        $platform = $this->createMock('Doctrine\DBAL\Platforms\PostgreSqlPlatform');
+        $platform = $this->createMock(PostgreSqlPlatform::class);
 
-        $conn = $this->createMock('Doctrine\DBAL\Connection');
+        $conn = $this->createMock(Connection::class);
         $conn->expects($this->any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
-        $em = $this->createMock('Doctrine\ORM\EntityManager');
+        $em = $this->createMock(EntityManager::class);
         $em->expects($this->any())
             ->method('getMetadataFactory')
             ->willReturn($mf);
@@ -382,7 +395,7 @@ class ModelManagerTest extends TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->createMock(RegistryInterface::class);
         $registry->expects($this->any())
             ->method('getManagerForClass')
             ->willReturn($em);
@@ -417,13 +430,13 @@ class ModelManagerTest extends TestCase
      */
     public function testSortableInDataSourceIterator($sortBy, $sortOrder, $isAddOrderBy)
     {
-        $datagrid = $this->getMockForAbstractClass('Sonata\AdminBundle\Datagrid\DatagridInterface');
-        $configuration = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
+        $datagrid = $this->getMockForAbstractClass(DatagridInterface::class);
+        $configuration = $this->getMockBuilder(Configuration::class)->getMock();
         $configuration->expects($this->any())
             ->method('getDefaultQueryHints')
             ->willReturn([]);
 
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+        $em = $this->getMockBuilder(EntityManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -431,12 +444,12 @@ class ModelManagerTest extends TestCase
             ->method('getConfiguration')
             ->willReturn($configuration);
 
-        $queryBuilder = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+        $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$em])
             ->getMock();
         $query = new Query($em);
 
-        $proxyQuery = $this->getMockBuilder('Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery')
+        $proxyQuery = $this->getMockBuilder(ProxyQuery::class)
             ->setConstructorArgs([$queryBuilder])
             ->setMethods(['getSortBy', 'getSortOrder', 'getRootAliases'])
             ->getMock();
@@ -464,18 +477,18 @@ class ModelManagerTest extends TestCase
             ->method('getQuery')
             ->willReturn($proxyQuery);
 
-        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')->getMock();
+        $registry = $this->getMockBuilder(RegistryInterface::class)->getMock();
         $manager = new ModelManager($registry);
         $manager->getDataSourceIterator($datagrid, []);
     }
 
     public function testModelReverseTransform()
     {
-        $class = 'Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\SimpleEntity';
+        $class = SimpleEntity::class;
 
-        $metadataFactory = $this->createMock('Doctrine\ORM\Mapping\ClassMetadataFactory');
-        $modelManager = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
-        $registry = $this->createMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $modelManager = $this->createMock(ObjectManager::class);
+        $registry = $this->createMock(RegistryInterface::class);
 
         $classMetadata = new ClassMetadataInfo($class);
         $classMetadata->reflClass = new \ReflectionClass($class);


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog

```markdown
### Fixed
 - Replaced FQCN strings with `::class` constants
```