### PR TITLE
Replace references to ClassMetadataInfo

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Builder;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
@@ -91,7 +91,12 @@ class DatagridBuilder implements DatagridBuilderInterface
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
         $fieldDescription->setOption('name', $fieldDescription->getOption('name', $fieldDescription->getName()));
 
-        if (in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY, ClassMetadataInfo::MANY_TO_ONE, ClassMetadataInfo::ONE_TO_ONE])) {
+        if (in_array($fieldDescription->getMappingType(), [
+            ClassMetadata::ONE_TO_MANY,
+            ClassMetadata::MANY_TO_MANY,
+            ClassMetadata::MANY_TO_ONE,
+            ClassMetadata::ONE_TO_ONE,
+        ])) {
             $admin->attachAdminClass($fieldDescription);
         }
     }

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Builder;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
@@ -141,7 +141,10 @@ class FormContractor implements FormContractorInterface
                 ));
             }
 
-            if (!in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE_TO_ONE, ClassMetadataInfo::MANY_TO_ONE])) {
+            if (!in_array($fieldDescription->getMappingType(), [
+                ClassMetadata::ONE_TO_ONE,
+                ClassMetadata::MANY_TO_ONE,
+            ])) {
                 throw new \RuntimeException(sprintf(
                     'You are trying to add `sonata_type_admin` field `%s` which is not One-To-One or  Many-To-One.'
                     .' Maybe you want `sonata_type_collection` instead?',
@@ -183,10 +186,10 @@ class FormContractor implements FormContractorInterface
     private function hasAssociation(FieldDescriptionInterface $fieldDescription)
     {
         return in_array($fieldDescription->getMappingType(), [
-            ClassMetadataInfo::ONE_TO_MANY,
-            ClassMetadataInfo::MANY_TO_MANY,
-            ClassMetadataInfo::MANY_TO_ONE,
-            ClassMetadataInfo::ONE_TO_ONE,
+            ClassMetadata::ONE_TO_MANY,
+            ClassMetadata::MANY_TO_MANY,
+            ClassMetadata::MANY_TO_ONE,
+            ClassMetadata::ONE_TO_ONE,
         ]);
     }
 

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Builder;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -114,25 +114,25 @@ class ListBuilder implements ListBuilderInterface
 
             if (!$fieldDescription->getTemplate()) {
                 switch ($fieldDescription->getMappingType()) {
-                    case ClassMetadataInfo::MANY_TO_ONE:
+                    case ClassMetadata::MANY_TO_ONE:
                         $fieldDescription->setTemplate(
                             'SonataDoctrineORMAdminBundle:CRUD:list_orm_many_to_one.html.twig'
                         );
 
                         break;
-                    case ClassMetadataInfo::ONE_TO_ONE:
+                    case ClassMetadata::ONE_TO_ONE:
                         $fieldDescription->setTemplate(
                             'SonataDoctrineORMAdminBundle:CRUD:list_orm_one_to_one.html.twig'
                         );
 
                         break;
-                    case ClassMetadataInfo::ONE_TO_MANY:
+                    case ClassMetadata::ONE_TO_MANY:
                         $fieldDescription->setTemplate(
                             'SonataDoctrineORMAdminBundle:CRUD:list_orm_one_to_many.html.twig'
                         );
 
                         break;
-                    case ClassMetadataInfo::MANY_TO_MANY:
+                    case ClassMetadata::MANY_TO_MANY:
                         $fieldDescription->setTemplate(
                             'SonataDoctrineORMAdminBundle:CRUD:list_orm_many_to_many.html.twig'
                         );
@@ -142,7 +142,12 @@ class ListBuilder implements ListBuilderInterface
             }
         }
 
-        if (in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::MANY_TO_ONE, ClassMetadataInfo::ONE_TO_ONE, ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY])) {
+        if (in_array($fieldDescription->getMappingType(), [
+            ClassMetadata::MANY_TO_ONE,
+            ClassMetadata::ONE_TO_ONE,
+            ClassMetadata::ONE_TO_MANY,
+            ClassMetadata::MANY_TO_MANY,
+        ])) {
             $admin->attachAdminClass($fieldDescription);
         }
     }

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Builder;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -90,25 +90,25 @@ class ShowBuilder implements ShowBuilderInterface
 
             if (!$fieldDescription->getTemplate()) {
                 switch ($fieldDescription->getMappingType()) {
-                    case ClassMetadataInfo::MANY_TO_ONE:
+                    case ClassMetadata::MANY_TO_ONE:
                         $fieldDescription->setTemplate(
                             'SonataDoctrineORMAdminBundle:CRUD:show_orm_many_to_one.html.twig'
                         );
 
                         break;
-                    case ClassMetadataInfo::ONE_TO_ONE:
+                    case ClassMetadata::ONE_TO_ONE:
                         $fieldDescription->setTemplate(
                             'SonataDoctrineORMAdminBundle:CRUD:show_orm_one_to_one.html.twig'
                         );
 
                         break;
-                    case ClassMetadataInfo::ONE_TO_MANY:
+                    case ClassMetadata::ONE_TO_MANY:
                         $fieldDescription->setTemplate(
                             'SonataDoctrineORMAdminBundle:CRUD:show_orm_one_to_many.html.twig'
                         );
 
                         break;
-                    case ClassMetadataInfo::MANY_TO_MANY:
+                    case ClassMetadata::MANY_TO_MANY:
                         $fieldDescription->setTemplate(
                             'SonataDoctrineORMAdminBundle:CRUD:show_orm_many_to_many.html.twig'
                         );
@@ -119,10 +119,10 @@ class ShowBuilder implements ShowBuilderInterface
         }
 
         switch ($fieldDescription->getMappingType()) {
-            case ClassMetadataInfo::MANY_TO_ONE:
-            case ClassMetadataInfo::ONE_TO_ONE:
-            case ClassMetadataInfo::ONE_TO_MANY:
-            case ClassMetadataInfo::MANY_TO_MANY:
+            case ClassMetadata::MANY_TO_ONE:
+            case ClassMetadata::ONE_TO_ONE:
+            case ClassMetadata::ONE_TO_MANY:
+            case ClassMetadata::MANY_TO_MANY:
                 $admin->attachAdminClass($fieldDescription);
 
                 break;

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -12,7 +12,7 @@
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\EqualType;
@@ -82,7 +82,7 @@ class ModelFilter extends Filter
 
             $or->add($queryBuilder->expr()->notIn($alias, ':'.$parameterName));
 
-            if (ClassMetadataInfo::MANY_TO_MANY === $this->getOption('mapping_type')) {
+            if (ClassMetadata::MANY_TO_MANY === $this->getOption('mapping_type')) {
                 $or->add(
                     sprintf('%s.%s IS EMPTY', $this->getParentAlias($queryBuilder, $alias), $this->getFieldName())
                 );
@@ -103,10 +103,10 @@ class ModelFilter extends Filter
     protected function association(ProxyQueryInterface $queryBuilder, $data)
     {
         $types = [
-            ClassMetadataInfo::ONE_TO_ONE,
-            ClassMetadataInfo::ONE_TO_MANY,
-            ClassMetadataInfo::MANY_TO_MANY,
-            ClassMetadataInfo::MANY_TO_ONE,
+            ClassMetadata::ONE_TO_ONE,
+            ClassMetadata::ONE_TO_MANY,
+            ClassMetadata::MANY_TO_MANY,
+            ClassMetadata::MANY_TO_ONE,
         ];
 
         if (!in_array($this->getOption('mapping_type'), $types)) {

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Guesser;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\CoreBundle\Form\Type\BooleanType;
 use Sonata\CoreBundle\Form\Type\EqualType;
@@ -44,10 +44,10 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             $mapping = $metadata->getAssociationMapping($propertyName);
 
             switch ($mapping['type']) {
-                case ClassMetadataInfo::ONE_TO_ONE:
-                case ClassMetadataInfo::ONE_TO_MANY:
-                case ClassMetadataInfo::MANY_TO_ONE:
-                case ClassMetadataInfo::MANY_TO_MANY:
+                case ClassMetadata::ONE_TO_ONE:
+                case ClassMetadata::ONE_TO_MANY:
+                case ClassMetadata::MANY_TO_ONE:
+                case ClassMetadata::MANY_TO_MANY:
                     $options['operator_type'] = EqualType::class;
                     $options['operator_options'] = [];
                     $options['field_type'] = EntityType::class;

--- a/src/Guesser/TypeGuesser.php
+++ b/src/Guesser/TypeGuesser.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Guesser;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
@@ -30,16 +30,16 @@ class TypeGuesser extends AbstractTypeGuesser
             $mapping = $metadata->getAssociationMapping($propertyName);
 
             switch ($mapping['type']) {
-                case ClassMetadataInfo::ONE_TO_MANY:
+                case ClassMetadata::ONE_TO_MANY:
                     return new TypeGuess('orm_one_to_many', [], Guess::HIGH_CONFIDENCE);
 
-                case ClassMetadataInfo::MANY_TO_MANY:
+                case ClassMetadata::MANY_TO_MANY:
                     return new TypeGuess('orm_many_to_many', [], Guess::HIGH_CONFIDENCE);
 
-                case ClassMetadataInfo::MANY_TO_ONE:
+                case ClassMetadata::MANY_TO_ONE:
                     return new TypeGuess('orm_many_to_one', [], Guess::HIGH_CONFIDENCE);
 
-                case ClassMetadataInfo::ONE_TO_ONE:
+                case ClassMetadata::ONE_TO_ONE:
                     return new TypeGuess('orm_one_to_one', [], Guess::HIGH_CONFIDENCE);
             }
         }

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -15,8 +15,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\From;
 use Doctrine\ORM\Query\Expr\OrderBy;
@@ -92,7 +92,7 @@ class ProxyQueryTest extends TestCase
      */
     public function testGetFixedQueryBuilder($class, $alias, $id, $expectedId, $value, $identifierType)
     {
-        $meta = $this->createMock(ClassMetadataInfo::class);
+        $meta = $this->createMock(ClassMetadata::class);
         $meta->expects($this->any())
             ->method('getIdentifierFieldNames')
             ->willReturn([$id]);

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\CoreBundle\Form\Type\EqualType;
@@ -136,7 +136,7 @@ class ModelFilterTest extends TestCase
         $this->expectException(\RuntimeException::class);
 
         $filter = new ModelFilter();
-        $filter->initialize('field_name', ['mapping_type' => ClassMetadataInfo::ONE_TO_ONE]);
+        $filter->initialize('field_name', ['mapping_type' => ClassMetadata::ONE_TO_ONE]);
 
         $builder = new ProxyQuery(new QueryBuilder());
 
@@ -148,7 +148,7 @@ class ModelFilterTest extends TestCase
     {
         $filter = new ModelFilter();
         $filter->initialize('field_name', [
-            'mapping_type' => ClassMetadataInfo::ONE_TO_ONE,
+            'mapping_type' => ClassMetadata::ONE_TO_ONE,
             'field_name' => 'field_name',
             'association_mapping' => [
                 'fieldName' => 'association_mapping',
@@ -171,7 +171,7 @@ class ModelFilterTest extends TestCase
     {
         $filter = new ModelFilter();
         $filter->initialize('field_name', [
-            'mapping_type' => ClassMetadataInfo::ONE_TO_ONE,
+            'mapping_type' => ClassMetadata::ONE_TO_ONE,
             'field_name' => 'field_name',
             'parent_association_mappings' => [
                 [

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -19,7 +19,6 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
@@ -324,7 +323,7 @@ class ModelManagerTest extends TestCase
         $uuid = new NonIntegerIdentifierTestClass('efbcfc4b-8c43-4d42-aa4c-d707e55151ac');
         $entity = new UuidEntity($uuid);
 
-        $meta = $this->createMock(ClassMetadataInfo::class);
+        $meta = $this->createMock(ClassMetadata::class);
         $meta->expects($this->any())
             ->method('getIdentifierValues')
             ->willReturn([$entity->getId()]);
@@ -367,7 +366,7 @@ class ModelManagerTest extends TestCase
     {
         $entity = new ContainerEntity(new AssociatedEntity(42, new EmbeddedEntity()), new EmbeddedEntity());
 
-        $meta = $this->createMock(ClassMetadataInfo::class);
+        $meta = $this->createMock(ClassMetadata::class);
         $meta->expects($this->any())
             ->method('getIdentifierValues')
             ->willReturn([$entity->getAssociatedEntity()->getPlainField()]);
@@ -490,7 +489,7 @@ class ModelManagerTest extends TestCase
         $modelManager = $this->createMock(ObjectManager::class);
         $registry = $this->createMock(RegistryInterface::class);
 
-        $classMetadata = new ClassMetadataInfo($class);
+        $classMetadata = new ClassMetadata($class);
         $classMetadata->reflClass = new \ReflectionClass($class);
 
         $modelManager->expects($this->once())


### PR DESCRIPTION

I am targeting this branch, because this is BC.

```markdown
#### Fixed
- deprecation about `Doctrine\ORM\Mapping\ClassMetadataInfo`
```

## Subject

This class is deprecated. See https://github.com/doctrine/doctrine2/pull/6886