### PR TITLE
Replace string operation on OrderBy by AST walker

### DIFF
--- a/src/Datagrid/OrderByToSelectWalker.php
+++ b/src/Datagrid/OrderByToSelectWalker.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Datagrid;
+
+use Doctrine\ORM\Query\AST\Functions\IdentityFunction;
+use Doctrine\ORM\Query\AST\OrderByClause;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\AST\SelectExpression;
+use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\TreeWalkerAdapter;
+
+/**
+ * Finds all PathExpressions in an AST's OrderByClause, and ensures that
+ * the referenced fields are present in the SelectClause of the passed AST.
+ *
+ * Inspired by Doctrine\ORM\Tools\Pagination classes.
+ *
+ * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
+ */
+final class OrderByToSelectWalker extends TreeWalkerAdapter
+{
+    public function walkSelectStatement(SelectStatement $AST)
+    {
+        if (!$AST->orderByClause instanceof OrderByClause) {
+            return;
+        }
+
+        // Get a map of referenced identifiers to field names.
+        $selects = [];
+        foreach ($AST->orderByClause->orderByItems as $item) {
+            if (!$item->expression instanceof PathExpression) {
+                continue;
+            }
+
+            $pathExpression = $item->expression;
+            $idVar = $pathExpression->identificationVariable;
+            $field = $pathExpression->field;
+            if (!isset($selects[$idVar])) {
+                $selects[$idVar] = [];
+            }
+            $selects[$idVar][$field] = $pathExpression;
+        }
+
+        // Loop the select clause of the AST and exclude items from $selects
+        // that are already being selected in the query.
+        foreach ($AST->selectClause->selectExpressions as $selectExpression) {
+            if ($selectExpression instanceof SelectExpression) {
+                $idVar = $selectExpression->expression;
+                if ($idVar instanceof IdentityFunction) {
+                    $idVar = $idVar->pathExpression->identificationVariable;
+                }
+                if (!is_string($idVar)) {
+                    continue;
+                }
+                $field = $selectExpression->fieldIdentificationVariable;
+                if (null === $field) {
+                    // No need to add this select, as we're already fetching the whole object.
+                    unset($selects[$idVar]);
+                } else {
+                    unset($selects[$idVar][$field]);
+                }
+            }
+        }
+
+        // Add select items which were not excluded to the AST's select clause.
+        foreach ($selects as $idVar => $fields) {
+            foreach ($fields as $field => $expression) {
+                $AST->selectClause->selectExpressions[] = new SelectExpression(
+                    $this->createSelectExpressionItem($expression), null
+                );
+            }
+        }
+    }
+
+    /**
+     * Retrieve either an IdentityFunction (IDENTITY(u.assoc)) or a state field (u.name).
+     *
+     * @return IdentityFunction|PathExpression
+     */
+    private function createSelectExpressionItem(PathExpression $pathExpression)
+    {
+        if (PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION === $pathExpression->type) {
+            $identity = new IdentityFunction('identity');
+
+            $identity->pathExpression = clone $pathExpression;
+
+            return $identity;
+        }
+
+        return clone $pathExpression;
+    }
+}

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -279,7 +279,6 @@ class ProxyQuery implements ProxyQueryInterface
         // step 3 : retrieve the different subjects ids
         $selects = [];
         $idxSelect = '';
-        $idSelects = [];
         foreach ($idNames as $idName) {
             $select = sprintf('%s.%s', $rootAlias, $idName);
             // Put the ID select on this array to use it on results QB
@@ -289,7 +288,6 @@ class ProxyQuery implements ProxyQueryInterface
             // Should work only with doctrine/orm: ~2.2
             $idSelect = $select;
             if ($metadata->hasAssociation($idName)) {
-                $idSelects[] = $idSelect;
                 $idSelect = sprintf('IDENTITY(%s) as %s', $idSelect, $idName);
             }
             $idxSelect .= ('' !== $idxSelect ? ', ' : '').$idSelect;
@@ -303,9 +301,9 @@ class ProxyQuery implements ProxyQueryInterface
         For any particular x-value in the table there might be many different y
         values.  Which one will you use to sort that x-value in the output?
         */
-        $this->addOrderedColumns($queryBuilderId, $idSelects);
-
-        $results = $queryBuilderId->getQuery()->execute([], Query::HYDRATE_ARRAY);
+        $queryId = $queryBuilderId->getQuery();
+        $queryId->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [OrderByToSelectWalker::class]);
+        $results = $queryId->execute([], Query::HYDRATE_ARRAY);
         $platform = $queryBuilderId->getEntityManager()->getConnection()->getDatabasePlatform();
         $idxMatrix = [];
         foreach ($results as $id) {
@@ -331,23 +329,5 @@ class ProxyQuery implements ProxyQueryInterface
         }
 
         return $queryBuilder;
-    }
-
-    /**
-     * @param array $idSelects List of column identifiers to skip
-     */
-    private function addOrderedColumns(QueryBuilder $queryBuilder, array $idSelects)
-    {
-        /* For each ORDER BY clause defined directly in the DQL parts of the query,
-           we add an entry in the SELECT clause. Skip ids that have already been added
-           to the SELECT as IDENTITY(id) */
-        foreach ((array) $queryBuilder->getDqlPart('orderBy') as $part) {
-            foreach ($part->getParts() as $orderBy) {
-                $id = preg_replace("/\s+(ASC|DESC)$/i", '', $orderBy);
-                if (!in_array($id, $idSelects, true)) {
-                    $queryBuilder->addSelect($id);
-                }
-            }
-        }
     }
 }

--- a/tests/Datagrid/OrderByToSelectWalkerTest.php
+++ b/tests/Datagrid/OrderByToSelectWalkerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Datagrid;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Version;
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineORMAdminBundle\Datagrid\OrderByToSelectWalker;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\Menu;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\StoreProduct;
+use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
+
+/**
+ * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
+ */
+final class OrderByToSelectWalkerTest extends TestCase
+{
+    /**
+     * @var EntityManager
+     */
+    private $em;
+
+    protected function setUp()
+    {
+        $this->em = DoctrineTestHelper::createTestEntityManager();
+    }
+
+    protected function tearDown()
+    {
+        $this->em = null;
+    }
+
+    public function testOrderByCompositeId()
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('IDENTITY(o.store) as store, IDENTITY(o.product) as product')
+            ->distinct()
+            ->from(StoreProduct::class, 'o')
+            ->orderBy('o.name', 'ASC')
+            ->addOrderBy('o.product', 'DESC');
+
+        $query = $qb->getQuery();
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [OrderByToSelectWalker::class]);
+
+        $this->assertEquals(
+            // NEXT_MAJOR: Remove this check when dropping support for doctrine/orm < 2.5
+            version_compare(Version::VERSION, '2.5') < 0
+                ? 'SELECT DISTINCT s0_.store_id AS sclr0, s0_.product_id AS sclr1, s0_.name AS name2 FROM StoreProduct s0_ ORDER BY s0_.name ASC, s0_.product_id DESC'
+                : 'SELECT DISTINCT s0_.store_id AS sclr_0, s0_.product_id AS sclr_1, s0_.name AS name_2 FROM StoreProduct s0_ ORDER BY s0_.name ASC, s0_.product_id DESC',
+            $query->getSQL()
+        );
+    }
+
+    public function testOrderByCompositeIdWholeObject()
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('o')
+            ->distinct()
+            ->from(StoreProduct::class, 'o')
+            ->orderBy('o.name', 'ASC')
+            ->addOrderBy('o.product', 'DESC');
+
+        $query = $qb->getQuery();
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [OrderByToSelectWalker::class]);
+
+        $this->assertEquals(
+            // NEXT_MAJOR: Remove this check when dropping support for doctrine/orm < 2.5
+            version_compare(Version::VERSION, '2.5') < 0
+                ? 'SELECT DISTINCT s0_.name AS name0, s0_.store_id AS store_id1, s0_.product_id AS product_id2 FROM StoreProduct s0_ ORDER BY s0_.name ASC, s0_.product_id DESC'
+                : 'SELECT DISTINCT s0_.name AS name_0, s0_.store_id AS store_id_1, s0_.product_id AS product_id_2 FROM StoreProduct s0_ ORDER BY s0_.name ASC, s0_.product_id DESC',
+            $query->getSQL()
+        );
+    }
+
+    public function testOrderByAssociation()
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('m.id')
+            ->distinct()
+            ->from(Menu::class, 'm')
+            ->orderBy('m.root, m.lft');
+
+        $query = $qb->getQuery();
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [OrderByToSelectWalker::class]);
+
+        $this->assertEquals(
+            // NEXT_MAJOR: Remove this check when dropping support for doctrine/orm < 2.5
+            version_compare(Version::VERSION, '2.5') < 0
+                ? 'SELECT DISTINCT m0_.id AS id0, m0_.tree_root AS sclr1, m0_.lft AS lft2 FROM Menu m0_ ORDER BY m0_.tree_root ASC, m0_.lft ASC'
+                : 'SELECT DISTINCT m0_.id AS id_0, m0_.tree_root AS sclr_1, m0_.lft AS lft_2 FROM Menu m0_ ORDER BY m0_.tree_root ASC, m0_.lft ASC',
+            $query->getSQL()
+        );
+    }
+}

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -20,7 +20,6 @@ use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\From;
 use Doctrine\ORM\Query\Expr\OrderBy;
-use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\TestCase;
@@ -29,13 +28,10 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Query\FooWalker;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
-use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity;
 
 class ProxyQueryTest extends TestCase
 {
-    const DOUBLE_NAME_CLASS = DoubleNameEntity::class;
-
     /**
      * @var EntityManager
      */
@@ -54,7 +50,7 @@ class ProxyQueryTest extends TestCase
 
         $schemaTool = new SchemaTool($this->em);
         $classes = [
-            $this->em->getClassMetadata(self::DOUBLE_NAME_CLASS),
+            $this->em->getClassMetadata(DoubleNameEntity::class),
         ];
 
         try {
@@ -124,8 +120,11 @@ class ProxyQueryTest extends TestCase
         // NEXT MAJOR: Replace this when dropping PHP < 5.6
         // $q = $this->createMock('PDOStatement');
         $q = $this->getMockBuilder('stdClass')
-            ->setMethods(['execute'])
+            ->setMethods(['execute', 'setHint'])
             ->getMock();
+        $q->expects($this->once())
+           ->method('setHint')
+           ->willReturn($q);
         $q->expects($this->any())
             ->method('execute')
             ->willReturn([[$id => $value]]);
@@ -172,31 +171,6 @@ class ProxyQueryTest extends TestCase
         $pq->execute();
     }
 
-    public function testAddOrderedColumns()
-    {
-        $qb = $this->em->createQueryBuilder()
-                       ->select('o.id')
-                       ->distinct()
-                       ->from(self::DOUBLE_NAME_CLASS, 'o')
-                       ->orderBy('o.name', 'ASC')
-                       ->addOrderBy('o.name2', 'DESC');
-
-        $pq = $this->getMockBuilder(ProxyQuery::class)
-                   ->disableOriginalConstructor()
-                   ->getMock();
-
-        $reflection = new \ReflectionClass(get_class($pq));
-        $method = $reflection->getMethod('addOrderedColumns');
-        $method->setAccessible(true);
-        $method->invoke($pq, $qb, []);
-
-        $dqlPart = $qb->getDqlPart('select');
-        $this->assertCount(3, $dqlPart);
-        $this->assertEquals('o.id', $dqlPart[0]);
-        $this->assertEquals('o.name', $dqlPart[1]);
-        $this->assertEquals('o.name2', $dqlPart[2]);
-    }
-
     public function testSetHint()
     {
         $entity1 = new DoubleNameEntity(1, 'Foo', null);
@@ -207,8 +181,8 @@ class ProxyQueryTest extends TestCase
         $this->em->flush();
 
         $qb = $this->em->createQueryBuilder()
-                       ->select('o.id')
-                       ->from(self::DOUBLE_NAME_CLASS, 'o');
+            ->select('o.id')
+            ->from(DoubleNameEntity::class, 'o');
 
         $pq = new ProxyQuery($qb);
         $pq->setHint(
@@ -220,29 +194,5 @@ class ProxyQueryTest extends TestCase
         $result = $pq->execute();
 
         $this->assertEquals(2, $result[0]['id']);
-    }
-
-    public function testAddOrderedColumnsCompositeId()
-    {
-        $qb = $this->em->createQueryBuilder()
-            ->select('IDENTITY(o.id1) as id1, IDENTITY(o.id2) as id2')
-            ->distinct()
-            ->from(CompositeIntIdEntity::class, 'o')
-            ->orderBy('o.id1', 'ASC')
-            ->addOrderBy('o.id2', 'ASC');
-
-        $pq = $this->createMock(ProxyQuery::class);
-
-        $reflection = new \ReflectionClass(get_class($pq));
-        $method = $reflection->getMethod('addOrderedColumns');
-        $method->setAccessible(true);
-        $method->invoke($pq, $qb, ['o.id1', 'o.id2']);
-
-        $dqlPart = $qb->getDqlPart('select');
-        $this->assertCount(1, $dqlPart);
-        /** @var Select $select */
-        $select = $dqlPart[0];
-        $this->assertInstanceOf(Select::class, $select);
-        $this->assertEquals('IDENTITY(o.id1) as id1, IDENTITY(o.id2) as id2', $select->getParts()[0]);
     }
 }

--- a/tests/Fixtures/Entity/ORM/Menu.php
+++ b/tests/Fixtures/Entity/ORM/Menu.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Menu
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(name="lft", type="integer")
+     */
+    private $lft;
+
+    /**
+     * @ORM\Column(name="lvl", type="integer")
+     */
+    private $lvl;
+
+    /**
+     * @ORM\Column(name="rgt", type="integer")
+     */
+    private $rgt;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Menu")
+     * @ORM\JoinColumn(name="tree_root", referencedColumnName="id", onDelete="CASCADE")
+     */
+    private $root;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Menu", inversedBy="children")
+     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    private $parent;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Menu", mappedBy="parent")
+     * @ORM\OrderBy({"lft" = "ASC"})
+     */
+    private $children;
+}

--- a/tests/Fixtures/Entity/ORM/Product.php
+++ b/tests/Fixtures/Entity/ORM/Product.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Product
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="StoreProduct", mappedBy="product")
+     */
+    private $products;
+}

--- a/tests/Fixtures/Entity/ORM/Store.php
+++ b/tests/Fixtures/Entity/ORM/Store.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Store
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="StoreProduct", mappedBy="store")
+     */
+    private $stores;
+}

--- a/tests/Fixtures/Entity/ORM/StoreProduct.php
+++ b/tests/Fixtures/Entity/ORM/StoreProduct.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class StoreProduct
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="Store", inversedBy="stores")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     * @ORM\Id()
+     * @ORM\GeneratedValue("NONE")
+     */
+    protected $store;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Product", inversedBy="products")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     * @ORM\Id()
+     * @ORM\GeneratedValue("NONE")
+     */
+    protected $product;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    protected $name;
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #776

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed invalid PathExpression error in ProxyQuery
```

## To do
- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
`ProxyQuery::addOrderedColumns` does not support all syntax variants and operate on an unparsed query. AST walker solves adding missing items from OrderBy to Select problem in the right way. Fix Invalid PathExpression error.