### PR TITLE
fix one to many inline table

### DIFF
--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
@@ -22,8 +22,9 @@ file that was distributed with this source code.
                         {% if nested_field.vars['required'] %}
                             class="required"
                         {% endif %}
-                        {% if (((nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']))
-                            or (nested_field.vars.sonata_admin.field_description and nested_field.vars.sonata_admin.field_description.type == 'Sonata\\AdminBundle\\Form\\Type\\ModelHiddenType')) %}
+                        {% if ((nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']))
+                            or (nested_field.vars.sonata_admin.field_description
+                            and nested_field.vars.sonata_admin.field_description.type == 'Sonata\\AdminBundle\\Form\\Type\\ModelHiddenType') %}
                             style="display:none;"
                         {% endif %}
                     >
@@ -44,8 +45,9 @@ file that was distributed with this source code.
                         control-group
                         {% if nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}
                         "
-                        {% if (((nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']))
-                            or (nested_field.vars.sonata_admin.field_description and nested_field.vars.sonata_admin.field_description.type == 'Sonata\\AdminBundle\\Form\\Type\\ModelHiddenType')) %}
+                        {% if ((nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']))
+                            or (nested_field.vars.sonata_admin.field_description
+                            and nested_field.vars.sonata_admin.field_description.type == 'Sonata\\AdminBundle\\Form\\Type\\ModelHiddenType') %}
                             style="display:none;"
                         {% endif %}
                     >

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
@@ -22,7 +22,8 @@ file that was distributed with this source code.
                         {% if nested_field.vars['required'] %}
                             class="required"
                         {% endif %}
-                        {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
+                        {% if (((nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']))
+                            or (nested_field.vars.sonata_admin.field_description and nested_field.vars.sonata_admin.field_description.type == 'Sonata\\AdminBundle\\Form\\Type\\ModelHiddenType')) %}
                             style="display:none;"
                         {% endif %}
                     >
@@ -43,7 +44,8 @@ file that was distributed with this source code.
                         control-group
                         {% if nested_field.vars.errors|length > 0 %} error sonata-ba-field-error{% endif %}
                         "
-                        {% if (nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']) %}
+                        {% if (((nested_field.vars['attr']['hidden'] is defined) and (nested_field.vars['attr']['hidden']))
+                            or (nested_field.vars.sonata_admin.field_description and nested_field.vars.sonata_admin.field_description.type == 'Sonata\\AdminBundle\\Form\\Type\\ModelHiddenType')) %}
                             style="display:none;"
                         {% endif %}
                     >


### PR DESCRIPTION
I am targeting this branch, because there is no BC-break.

Closes #790

## Changelog

```markdown
### Added
- Unnecessary table cell when using collections with **ModelHiddenType** now is hidden
```

## Subject
Changes inside `edit_orm_one_to_many_inline_table.html.twig` template.
