### PR TITLE
Update installation documentation for Symfony Flex

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -17,7 +17,7 @@ Use `Composer`:
 
 .. code-block:: bash
 
-    php composer.phar require sonata-project/doctrine-orm-admin-bundle
+    composer require sonata-project/doctrine-orm-admin-bundle
 
 You'll be asked to type in a version constraint. `dev-master` will usually get you the latest, bleeding edge version.
 Check `packagist <https://packagist.org/packages/sonata-project/doctrine-orm-admin-bundle>`_ for stable and legacy versions:
@@ -29,7 +29,23 @@ Check `packagist <https://packagist.org/packages/sonata-project/doctrine-orm-adm
 Enable the bundle
 -----------------
 
-Next, be sure to enable the bundle in your `AppKernel.php` file:
+Next, be sure to enable the bundles in your ``bundles.php`` file if they
+are not already enabled:
+
+.. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle::class => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, you should enable bundles in your
+    ``AppKernel.php``.
 
 .. code-block:: php
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am updating documentation for Symfony Flex.

## Subject

Updating documentation to adopt new flex structure.