### PR TITLE
AuditReader service made public to remove Symfony 3.4 deprecation notice

### DIFF
--- a/src/Resources/config/audit.xml
+++ b/src/Resources/config/audit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.admin.audit.orm.reader" class="Sonata\DoctrineORMAdminBundle\Model\AuditReader">
+        <service id="sonata.admin.audit.orm.reader" class="Sonata\DoctrineORMAdminBundle\Model\AuditReader" public="true">
             <argument type="service" id="simplethings_entityaudit.reader" on-invalid="ignore"/>
         </service>
         <service id="sonata.admin_doctrine_orm.block.audit" class="Sonata\DoctrineORMAdminBundle\Block\AuditBlockService">


### PR DESCRIPTION
I am targeting this branch, because there is no BC-break.

Closes #801

## Changelog

```markdown
### Fixed
 - Symfony 3.4 deprecation notice about getting private service AuditReader from the container
```
## Subject

Services are private by default in symfony 3.4. AuditReader service is fetched directly from the container in Sonata\AdminBundle\Model\AuditManager::getReader. This action triggers a deprecation notice: The "sonata.admin.audit.orm.reader" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0
Fixes #801
