### PR TITLE
Validate setSortOrder input

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -150,6 +150,13 @@ class ProxyQuery implements ProxyQueryInterface
 
     public function setSortOrder($sortOrder)
     {
+        if (!in_array(strtoupper($sortOrder), $validSortOrders = ['ASC', 'DESC'])) {
+            throw new \InvalidArgumentException(sprintf(
+                '"%s" is not a valid sort order, valid values are "%s"',
+                $sortOrder,
+                implode(', ', $validSortOrders)
+            ));
+        }
         $this->sortOrder = $sortOrder;
 
         return $this;

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -195,4 +195,36 @@ class ProxyQueryTest extends TestCase
 
         $this->assertEquals(2, $result[0]['id']);
     }
+
+    public function testSortOrderValidatesItsInput()
+    {
+        $query = new ProxyQuery($this->em->createQueryBuilder());
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            '"ASC,injection" is not a valid sort order, valid values are "ASC, DESC"'
+        );
+        $query->setSortOrder('ASC,injection');
+    }
+
+    public function validSortOrders()
+    {
+        return [
+            ['ASC'],
+            ['DESC'],
+            ['asc'],
+            ['desc'],
+            ['AsC'],
+            ['deSc'],
+        ];
+    }
+
+    /**
+     * @dataProvider validSortOrders
+     */
+    public function testItAllowsSortOrdersWithStrangeCase($validValue)
+    {
+        $query = new ProxyQuery($this->em->createQueryBuilder());
+        $query->setSortOrder($validValue);
+        $this->assertSame($validValue, $query->getSortOrder());
+    }
 }


### PR DESCRIPTION
I am targeting this branch, because this is BC.


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Security
- `setSortOrder` input is now validated
```
