### PR TITLE
Hide selects added by OrderByToSelectWalker from hydration

### DIFF
--- a/src/Datagrid/OrderByToSelectWalker.php
+++ b/src/Datagrid/OrderByToSelectWalker.php
@@ -75,7 +75,7 @@ final class OrderByToSelectWalker extends TreeWalkerAdapter
         foreach ($selects as $idVar => $fields) {
             foreach ($fields as $field => $expression) {
                 $AST->selectClause->selectExpressions[] = new SelectExpression(
-                    $this->createSelectExpressionItem($expression), null
+                    $this->createSelectExpressionItem($expression), null, true
                 );
             }
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Hide selects added by OrderByToSelectWalker from hydration
```

## Subject
Select expressions added by `OrderByToSelectWalker` should be marked as hidden to prevent pollute query result field set. This class works as expected in ProxyQuery but it can be use in other contexts like https://github.com/sonata-project/SonataAdminBundle/issues/4924.
<!-- Describe your Pull Request content here -->
