### PR TITLE
Add doctrine/doctrine-bundle to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
+        "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.4.5",
         "sonata-project/admin-bundle": "^3.29",
         "sonata-project/core-bundle": "^3.8",


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Added doctrine/doctrine-bundle to composer.json
```

## Subject

Some services from this bundle require `doctrine` service, but there is no `doctrine/doctrine-bundle` in `require` section of composer.json

Also to install AdminBundle and DoctrineORMAdminBundle with Flex, users will have to add doctrine-bundle manualy (recipe is not accepted on this moment):

```
composer create-project symfony/skeleton .
composer config extra.symfony.allow-contrib true
composer require sonata-project/doctrine-orm-admin-bundle doctrine/doctrine-bundle
```