### PR TITLE
Increase dependency of simplethings audit bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "require-dev": {
         "knplabs/knp-menu-bundle": "^2.1.1",
-        "simplethings/entity-audit-bundle": "0.1 - 0.9 || ^1.0",
+        "simplethings/entity-audit-bundle": "^0.9 || ^1.0",
         "sonata-project/block-bundle": "^3.11",
         "symfony/phpunit-bridge": "^3.3 || ^4.0"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!-- 
## Changelog

MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/


<!-- REMOVE EMPTY SECTIONS
```markdown
### Changed
- Minimum version of SimpleThingsEntityAuditBundle
```
-->

## Subject

Currently, new tests that I added https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/807 are failing because the minimum version is `0.1`, raising the minimum version of `SimpleThingsEntityAuditBundle` fixes the problem.
