### PR TITLE
Remove unused dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"
     },
     "require-dev": {
-        "knplabs/knp-menu-bundle": "^2.1.1",
         "simplethings/entity-audit-bundle": "^0.9 || ^1.0",
         "sonata-project/block-bundle": "^3.11",
         "symfony/phpunit-bridge": "^4.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #557 

## Subject

<!-- Describe your Pull Request content here -->
This dependency is not used, it was added because an issue with composer: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/556
Probably with PHP 5.6 the dependency resolution is fast enough to remove it.