### PR TITLE
Pager: reset also groupBy dql part

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -42,7 +42,7 @@ class Pager extends BasePager
             current($this->getCountColumn())
         ));
 
-        return $countQuery->resetDQLPart('orderBy')->getQuery()->getSingleScalarResult();
+        return $countQuery->resetDQLPart('orderBy')->resetDQLPart('groupBy')->getQuery()->getSingleScalarResult();
     }
 
     public function getResults($hydrationMode = Query::HYDRATE_OBJECT)


### PR DESCRIPTION
I am targeting this branch, because it affects also existing functionality.

## Changelog
Pager: reset also groupBy dql part

## Subject
When in the Admin class, the `createQuery()` method has a `->groupBy` specified,
then the admin filter functionality with an empty result set fails.

```php
public function createQuery($context = 'list')
    {
        /** @var \Sonata\AdminBundle\Datagrid\ProxyQueryInterface|QueryBuilder $query */
        $query = parent::createQuery($context);

        $alias = current($query->getRootAliases());

        $query->select("NEW NS\AdminBundle\Dto\InterfaceDto($alias.id, $alias.name, COUNT(pim.config))")
            ->leftJoin("{$alias}.interface", 'pi')
            ->leftJoin(Configuration::class, 'pic', Join::WITH, 'pi.id = pic.interface')
            ->innerJoin(InterfaceMapping::class, 'pim', Join::WITH, 'pim.configuration = pic.id')
            ->setMaxResults(1)
            ->groupBy("$alias.id")
        ;

        return $query;
    }
```