### PR TITLE
Fix issue with embedded fields as filters

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -69,23 +69,49 @@ class DatagridBuilder implements DatagridBuilderInterface
         $fieldDescription->setAdmin($admin);
 
         if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
-            list($metadata, $lastPropertyName, $parentAssociationMappings) = $admin->getModelManager()->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
+            list($metadata, $lastPropertyName, $parentAssociationMappings) = $admin->getModelManager()
+                ->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
 
             // set the default field mapping
             if (isset($metadata->fieldMappings[$lastPropertyName])) {
-                $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $metadata->fieldMappings[$lastPropertyName]));
+                $fieldDescription->setOption(
+                    'field_mapping',
+                    $fieldDescription->getOption(
+                        'field_mapping',
+                        $fieldMapping = $metadata->fieldMappings[$lastPropertyName]
+                    )
+                );
 
-                if ($metadata->fieldMappings[$lastPropertyName]['type'] == 'string') {
+                if ('string' == $fieldMapping['type']) {
                     $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
+                }
+
+                if (!empty($embeddedClasses = $metadata->embeddedClasses)
+                    && isset($fieldMapping['declaredField'])
+                    && array_key_exists($fieldMapping['declaredField'], $embeddedClasses)
+                ) {
+                    $fieldDescription->setOption(
+                        'field_name',
+                        $fieldMapping['fieldName']
+                    );
                 }
             }
 
             // set the default association mapping
             if (isset($metadata->associationMappings[$lastPropertyName])) {
-                $fieldDescription->setOption('association_mapping', $fieldDescription->getOption('association_mapping', $metadata->associationMappings[$lastPropertyName]));
+                $fieldDescription->setOption(
+                    'association_mapping',
+                    $fieldDescription->getOption(
+                        'association_mapping',
+                        $metadata->associationMappings[$lastPropertyName]
+                    )
+                );
             }
 
-            $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $parentAssociationMappings));
+            $fieldDescription->setOption(
+                'parent_association_mappings',
+                $fieldDescription->getOption('parent_association_mappings', $parentAssociationMappings)
+            );
         }
 
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -127,11 +127,18 @@ final class DatagridBuilderTest extends TestCase
         $this->modelManager->hasMetadata(Argument::any())->willReturn(true);
 
         $this->modelManager->getParentMetadataForProperty(Argument::cetera())
-            ->willReturn([$classMetadata, 2, $parentAssociationMapping = []])
+            ->willReturn([$classMetadata, 'someField', $parentAssociationMapping = []])
             ->shouldBeCalledTimes(1);
 
-        $classMetadata->fieldMappings = [2 => [1 => 'test', 'type' => 'string']];
-        $classMetadata->associationMappings = [2 => ['fieldName' => 'fakeField']];
+        $classMetadata->fieldMappings = [
+            'someField' => [
+                'type' => 'string',
+                'declaredField' => 'someFieldDeclared',
+                'fieldName' => 'fakeField',
+            ],
+        ];
+        $classMetadata->associationMappings = ['someField' => ['fieldName' => 'fakeField']];
+        $classMetadata->embeddedClasses = ['someFieldDeclared' => ['fieldName' => 'fakeField']];
 
         $this->datagridBuilder->fixFieldDescription($this->admin->reveal(), $fieldDescription);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #788

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- embedded fields not working as filters
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

Fixes issue where wrong name was used for queries when the field is embedded. (This took a lot of time to debug)
