### PR TITLE
Entities with construct can be used on Collection and AdminType

### DIFF
--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -157,6 +157,9 @@ class FormContractor implements FormContractorInterface
             $options['delete'] = false;
 
             $options['data_class'] = $fieldDescription->getAssociationAdmin()->getClass();
+            $options['empty_data'] = function () use ($fieldDescription) {
+                return $fieldDescription->getAssociationAdmin()->getNewInstance();
+            };
             $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
         // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony 2.8
         } elseif ('sonata_type_collection' === $type || $this->checkFormClass($type, [CollectionType::class])) {
@@ -174,6 +177,9 @@ class FormContractor implements FormContractorInterface
             $options['type_options'] = [
                 'sonata_field_description' => $fieldDescription,
                 'data_class' => $fieldDescription->getAssociationAdmin()->getClass(),
+                'empty_data' => function () use ($fieldDescription) {
+                    return $fieldDescription->getAssociationAdmin()->getNewInstance();
+                },
             ];
         }
 

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -64,6 +64,7 @@ final class FormContractorTest extends TestCase
     {
         $admin = $this->createMock(AdminInterface::class);
         $modelManager = $this->createMock(ModelManagerInterface::class);
+        $model = $this->createMock(\stdClass::class);
         $modelClass = 'FooEntity';
 
         $admin->method('getModelManager')->willReturn($modelManager);
@@ -73,6 +74,7 @@ final class FormContractorTest extends TestCase
         $fieldDescription->method('getAdmin')->willReturn($admin);
         $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
+        $admin->method('getNewInstance')->willReturn($model);
 
         // NEXT_MAJOR: Use only FQCNs when dropping support for Symfony 2.8
         $modelTypes = [
@@ -110,6 +112,7 @@ final class FormContractorTest extends TestCase
             $this->assertSame($modelClass, $options['data_class']);
             $this->assertFalse($options['btn_add']);
             $this->assertFalse($options['delete']);
+            $this->assertSame($model, $options['empty_data']());
         }
 
         // collection type
@@ -121,6 +124,7 @@ final class FormContractorTest extends TestCase
             $this->assertTrue($options['modifiable']);
             $this->assertSame($fieldDescription, $options['type_options']['sonata_field_description']);
             $this->assertSame($modelClass, $options['type_options']['data_class']);
+            $this->assertSame($model, $options['type_options']['empty_data']());
         }
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/5001

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Now it is possible to use entities with arguments on the constructor on the Collection and Admin types.
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
`empty_data` can be used to override the default behavior when an entity does have a constructor with arguments.

http://symfony.com/doc/master/form/use_empty_data.html#option-1-instantiate-a-new-class

We are using the closure because otherwise it will fail on the collectionType. Probably adminType can use it without closure, have to check.

@Soullivaneuh can you check if this fixes your issue?

This is WIP, because we have to check we don't break anything with it.