### PR TITLE
Add support for "date*_immutable" types

### DIFF
--- a/docs/tutorial/creating_your_first_admin_class/defining_entities.rst
+++ b/docs/tutorial/creating_your_first_admin_class/defining_entities.rst
@@ -104,6 +104,11 @@ Post
         protected $created_at;
 
         /**
+         * @ORM\Column(type="datetime_immutable")
+         */
+        protected $updated_at;
+
+        /**
          * @ORM\OneToMany(targetEntity="Comment", mappedBy="post")
          */
         protected $comments;

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -74,10 +74,13 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
                 return new TypeGuess('doctrine_orm_boolean', $options, Guess::HIGH_CONFIDENCE);
             case 'datetime':
+            case 'datetime_immutable':
             case 'vardatetime':
             case 'datetimetz':
+            case 'datetimetz_immutable':
                 return new TypeGuess('doctrine_orm_datetime', $options, Guess::HIGH_CONFIDENCE);
             case 'date':
+            case 'date_immutable':
                 return new TypeGuess('doctrine_orm_date', $options, Guess::HIGH_CONFIDENCE);
             case 'decimal':
             case 'float':
@@ -93,6 +96,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
                 return new TypeGuess('doctrine_orm_string', $options, Guess::MEDIUM_CONFIDENCE);
             case 'time':
+            case 'time_immutable':
                 return new TypeGuess('doctrine_orm_time', $options, Guess::HIGH_CONFIDENCE);
             default:
                 return new TypeGuess('doctrine_orm_string', $options, Guess::LOW_CONFIDENCE);

--- a/src/Guesser/TypeGuesser.php
+++ b/src/Guesser/TypeGuesser.php
@@ -51,10 +51,13 @@ class TypeGuesser extends AbstractTypeGuesser
             case 'boolean':
                 return new TypeGuess('boolean', [], Guess::HIGH_CONFIDENCE);
             case 'datetime':
+            case 'datetime_immutable':
             case 'vardatetime':
             case 'datetimetz':
+            case 'datetimetz_immutable':
                 return new TypeGuess('datetime', [], Guess::HIGH_CONFIDENCE);
             case 'date':
+            case 'date_immutable':
                 return new TypeGuess('date', [], Guess::HIGH_CONFIDENCE);
             case 'decimal':
             case 'float':
@@ -68,6 +71,7 @@ class TypeGuesser extends AbstractTypeGuesser
             case 'text':
                 return new TypeGuess('textarea', [], Guess::MEDIUM_CONFIDENCE);
             case 'time':
+            case 'time_immutable':
                 return new TypeGuess('time', [], Guess::HIGH_CONFIDENCE);
             default:
                 return new TypeGuess('text', [], Guess::LOW_CONFIDENCE);

--- a/tests/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Guesser/FilterTypeGuesserTest.php
@@ -141,6 +141,11 @@ class FilterTypeGuesserTest extends TestCase
                 $datetimeType = 'doctrine_orm_datetime',
                 Guess::HIGH_CONFIDENCE,
             ],
+            'datetime_immutable' => [
+                'datetime_immutable',
+                $datetimeType,
+                Guess::HIGH_CONFIDENCE,
+            ],
             'vardatetime' => [
                 'vardatetime',
                 $datetimeType,
@@ -151,9 +156,19 @@ class FilterTypeGuesserTest extends TestCase
                 $datetimeType,
                 Guess::HIGH_CONFIDENCE,
             ],
+            'datetimetz_immutable' => [
+                'datetimetz_immutable',
+                $datetimeType,
+                Guess::HIGH_CONFIDENCE,
+            ],
             'date' => [
                 'date',
-                'doctrine_orm_date',
+                $dateType = 'doctrine_orm_date',
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'date_immutable' => [
+                'date_immutable',
+                $dateType,
                 Guess::HIGH_CONFIDENCE,
             ],
             'decimal' => [
@@ -200,7 +215,12 @@ class FilterTypeGuesserTest extends TestCase
             ],
             'time' => [
                 'time',
-                'doctrine_orm_time',
+                $timeType = 'doctrine_orm_time',
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'time_immutable' => [
+                'time_immutable',
+                $timeType,
                 Guess::HIGH_CONFIDENCE,
             ],
             'somefake' => [

--- a/tests/Guesser/TypeGuesserTest.php
+++ b/tests/Guesser/TypeGuesserTest.php
@@ -133,6 +133,11 @@ class TypeGuesserTest extends TestCase
                 $datetime,
                 Guess::HIGH_CONFIDENCE,
             ],
+            'datetime_immutable' => [
+                'datetime_immutable',
+                $datetime,
+                Guess::HIGH_CONFIDENCE,
+            ],
             'vardatetime' => [
                 'vardatetime',
                 $datetime,
@@ -143,8 +148,18 @@ class TypeGuesserTest extends TestCase
                 $datetime,
                 Guess::HIGH_CONFIDENCE,
             ],
+            'datetimetz_immutable' => [
+                'datetimetz_immutable',
+                $datetime,
+                Guess::HIGH_CONFIDENCE,
+            ],
             'date' => [
                 $date = 'date',
+                $date,
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'date_immutable' => [
+                'date_immutable',
                 $date,
                 Guess::HIGH_CONFIDENCE,
             ],
@@ -185,6 +200,11 @@ class TypeGuesserTest extends TestCase
             ],
             'time' => [
                 $time = 'time',
+                $time,
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'time_immutable' => [
+                'time_immutable',
                 $time,
                 Guess::HIGH_CONFIDENCE,
             ],


### PR DESCRIPTION
I am targeting this branch, because this a fix for missing "date*_immutable" types.

## Changelog
```markdown
### Added
- Support for "datetime_immutable", "datetimetz_immutable", "date_immutable" and "time_immutable" Doctrine types at `TypeGuesser::guessType()` and `FilterTypeGuesser::guessType()`.
### Fixed
- "nl2br() expects parameter 1 to be string, object given" error caused at `base_show_field.html.twig`.
```

## To do

- [x] Update the tests
- [x] Update the documentation

## Subject

Add support for "date*_immutable" types.
