### PR TITLE
Add json_array to type guesser

### DIFF
--- a/src/Guesser/TypeGuesser.php
+++ b/src/Guesser/TypeGuesser.php
@@ -47,6 +47,7 @@ class TypeGuesser extends AbstractTypeGuesser
         switch ($metadata->getTypeOfField($propertyName)) {
             case 'array':
             case 'json':
+            case 'json_array':
                 return new TypeGuess('array', [], Guess::HIGH_CONFIDENCE);
             case 'boolean':
                 return new TypeGuess('boolean', [], Guess::HIGH_CONFIDENCE);

--- a/tests/Guesser/TypeGuesserTest.php
+++ b/tests/Guesser/TypeGuesserTest.php
@@ -118,6 +118,11 @@ class TypeGuesserTest extends TestCase
                 $array,
                 Guess::HIGH_CONFIDENCE,
             ],
+            'json_array' => [
+                'json_array',
+                $array,
+                Guess::HIGH_CONFIDENCE,
+            ],
             'json' => [
                 'json',
                 $array,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/3135

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added json_array to type guesser
```