### PR TITLE
 #473. Available disable distinct for ProxyQuery and Pager.

### DIFF
--- a/docs/reference/query_proxy.rst
+++ b/docs/reference/query_proxy.rst
@@ -9,7 +9,15 @@ The ``ProxyQuery`` object is used to add missing features from the original `Doc
 
 * ``execute`` method - no need to call the ``getQuery()`` method,
 * add sort by and sort order options,
-* add preselect id query on left join query, so a limit query will be only applied on the left statement and not on the full select statement. This simulates the original Doctrine 1 behavior.
+* add preselect id query on left join query, so a limit query will be only
+  applied on the left statement and not on the full select statement.
+  This simulates the original Doctrine 1 behavior.
+* By default, Sonata will use the ``DISTINCT`` SQL keyword when fetching
+  the identifiers of the entities that will be displayed in the listing,
+  to avoid duplicates in some cases. Sonata cannot detect whether or not
+  you need ``DISTINCT``, but lets you remove that keyword in case it
+  causes performance issues and you are sure there will be no duplicates.
+  To do so, simply call ``setDistinct(false)``.
 
 
 .. code-block:: php

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -48,6 +48,13 @@ class ProxyQuery implements ProxyQueryInterface
     protected $entityJoinAliases;
 
     /**
+     * For BC reasons, this property is true by default.
+     *
+     * @var bool
+     */
+    private $distinct = true;
+
+    /**
      * The map of query hints.
      *
      * @var array<string,mixed>
@@ -77,6 +84,33 @@ class ProxyQuery implements ProxyQueryInterface
     public function __clone()
     {
         $this->queryBuilder = clone $this->queryBuilder;
+    }
+
+    /**
+     * Optimize queries with a lot of rows.
+     * It is not recommended to use "false" with left joins.
+     *
+     * @param bool $distinct
+     *
+     * @return self
+     */
+    final public function setDistinct($distinct)
+    {
+        if (!is_bool($distinct)) {
+            throw new \InvalidArgumentException('$distinct is not a boolean');
+        }
+
+        $this->distinct = $distinct;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    final public function isDistinct()
+    {
+        return $this->distinct;
     }
 
     public function execute(array $params = [], $hydrationMode = null)
@@ -300,7 +334,7 @@ class ProxyQuery implements ProxyQueryInterface
             $idxSelect .= ('' !== $idxSelect ? ', ' : '').$idSelect;
         }
         $queryBuilderId->select($idxSelect);
-        $queryBuilderId->distinct();
+        $queryBuilderId->distinct($this->isDistinct());
 
         // for SELECT DISTINCT, ORDER BY expressions must appear in idxSelect list
         /* Consider

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Datagrid;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Tools\Pagination\CountWalker;
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Tests\Filter\QueryBuilder;
+
+class PagerTest extends TestCase
+{
+    public function dataGetComputeNbResult()
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider dataGetComputeNbResult
+     *
+     * @param bool $distinct
+     */
+    public function testComputeNbResult($distinct)
+    {
+        $q = $this->getMockBuilder(AbstractQuery::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getSingleScalarResult', 'getHint', 'setHint'])
+            ->getMockForAbstractClass();
+
+        $q->expects($this->once())
+            ->method('getSingleScalarResult');
+
+        $q->expects($this->once())
+            ->method('getHint')
+            ->willReturn(null);
+
+        $q->expects($this->exactly(2))
+            ->method('setHint')
+            ->withConsecutive(
+                [$this->equalTo(CountWalker::HINT_DISTINCT), $this->equalTo($distinct)],
+                [$this->equalTo(Query::HINT_CUSTOM_TREE_WALKERS), $this->equalTo([CountWalker::class])]
+            );
+
+        $qb = $this->getMockBuilder(QueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getQuery'])
+            ->getMock();
+
+        $qb->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($q);
+
+        $pq = new ProxyQuery($qb);
+        $pq->setDistinct($distinct);
+
+        $pager = new Pager();
+        $pager->setQuery($pq);
+        $pager->computeNbResult();
+    }
+}

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -72,21 +72,17 @@ class ProxyQueryTest extends TestCase
     public function dataGetFixedQueryBuilder()
     {
         return [
-            ['aaa', 'bbb', 'id', 'id_idx', 33, Type::INTEGER],
-            ['aaa', 'bbb', 'associatedId', 'associatedId_idx', 33, null],
-            ['aaa', 'bbb', 'id.value', 'id_value_idx', 33, Type::INTEGER],
-            ['aaa', 'bbb', 'id.uuid', 'id_uuid_idx', new NonIntegerIdentifierTestClass('80fb6f91-bba1-4d35-b3d4-e06b24494e85'), UuidType::NAME],
+            ['aaa', 'bbb', 'id', 'id_idx', 33, Type::INTEGER, true],
+            ['aaa', 'bbb', 'associatedId', 'associatedId_idx', 33, null, true],
+            ['aaa', 'bbb', 'id.value', 'id_value_idx', 33, Type::INTEGER, false],
+            ['aaa', 'bbb', 'id.uuid', 'id_uuid_idx', new NonIntegerIdentifierTestClass('80fb6f91-bba1-4d35-b3d4-e06b24494e85'), UuidType::NAME, false],
         ];
     }
 
     /**
      * @dataProvider dataGetFixedQueryBuilder
-     *
-     * @param $class
-     * @param $alias
-     * @param $id
      */
-    public function testGetFixedQueryBuilder($class, $alias, $id, $expectedId, $value, $identifierType)
+    public function testGetFixedQueryBuilder($class, $alias, $id, $expectedId, $value, $identifierType, $distinct)
     {
         $meta = $this->createMock(ClassMetadata::class);
         $meta->expects($this->any())
@@ -132,6 +128,9 @@ class ProxyQueryTest extends TestCase
         $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$em])
             ->getMock();
+        $qb->expects($this->once())
+            ->method('distinct')
+            ->with($this->equalTo($distinct));
         $qb->expects($this->any())
             ->method('getEntityManager')
             ->willReturn($em);
@@ -166,8 +165,9 @@ class ProxyQueryTest extends TestCase
             ->setMethods(['a'])
             ->getMock();
 
-        /* Work */
+        $pq->setDistinct($distinct);
 
+        /* Work */
         $pq->execute();
     }
 


### PR DESCRIPTION
List view for big tables very slow due to DISTINCT query.
Also we should have available to enable distinct for query like with left join.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is Feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #473

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ProxyQuery::setDistinct` and `ProxyQuery::isDistinct`.

### Changed
- `Pager` use `CountWalker` for get count.
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [x] Update the documentation

<!-- Describe your Pull Request content here -->
