### PR TITLE
marked sonata.admin.manager.orm as public

### DIFF
--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -5,7 +5,7 @@
             <factory service="doctrine" method="getManager"/>
             <argument>%sonata_doctrine_orm_admin.entity_manager%</argument>
         </service>
-        <service id="sonata.admin.manager.orm" class="Sonata\DoctrineORMAdminBundle\Model\ModelManager">
+        <service id="sonata.admin.manager.orm" class="Sonata\DoctrineORMAdminBundle\Model\ModelManager" public="true">
             <argument type="service" id="doctrine"/>
         </service>
         <!-- FormBuilder -->


### PR DESCRIPTION
I am targeting this branch, because change is backwards compatible and allows using the bundle with sf4

## Changelog

```markdown
### Changed
marked sonata.admin.manager.orm as public service
```
