### PR TITLE
Fix QueryBuilder build error when 2 arguments is not passed.

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -75,7 +75,22 @@ abstract class AbstractDateFilter extends Filter
             $endDateParameterName = $this->getNewParameterName($queryBuilder);
 
             if (DateRangeType::TYPE_NOT_BETWEEN === $data['type']) {
-                $this->applyWhere($queryBuilder, sprintf('%s.%s < :%s OR %s.%s > :%s', $alias, $field, $startDateParameterName, $alias, $field, $endDateParameterName));
+                if ($data['value']['start'] || $data['value']['end']) {
+                    $filterStartParameter = $filterEndParameter = null;
+
+                    if ($data['value']['start']) {
+                        $filterStartParameter = sprintf('%s.%s < :%s', $alias, $field, $startDateParameterName);
+                    }
+
+                    if ($data['value']['end']) {
+                        $filterEndParameter = sprintf('%s.%s > :%s', $alias, $field, $endDateParameterName);
+                    }
+
+                    $queryBuilder->orWhere(
+                        $filterStartParameter,
+                        $filterEndParameter
+                    );
+                }
             } else {
                 if ($data['value']['start']) {
                     $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, '>=', $startDateParameterName));

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -42,7 +42,7 @@ class PagerTest extends TestCase
         $pager = new Pager();
         $pager->setCountColumn($em->getClassMetadata(UserBrowser::class)->getIdentifierFieldNames());
         $pager->setQuery($pq);
-        $this->assertEquals(0, $pager->computeNbResult());
+        $this->assertSame(0, $pager->computeNbResult());
     }
 
     public function dataGetComputeNbResult()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I found a bug and I corrected it.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix QueryBuilder build error, when you havn't passed 2 arguments in filters form (field Date Range).

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject
Improvement of the QueryBuilder build error with only one parameter is passed to Date Range filed in filters form.
<!-- Describe your Pull Request content here -->

When you passed only one instead two arguments to field Date Range in filters form, we've got a 500 error. This PR fix this error, through added specific conditions.
