### PR TITLE
remove links to obsolete google groups

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,11 +3,6 @@ Doctrine ORM Admin Bundle
 
 The ``Doctrine ORM Admin`` provides services to work with the ``Admin Bundle`` and the ``Doctrine Project``.
 
-**Google Groups**: For questions and proposals, you can post on these google groups:
-
-* `Sonata Users <https://groups.google.com/group/sonata-users>`_: For questions on how to use Sonata bundles on your project
-* `Sonata Devs <https://groups.google.com/group/sonata-devs>`_: For questions regarding the development of Sonata bundles
-
 .. toctree::
    :caption: Reference Guide
    :name: reference-guide


### PR DESCRIPTION
I am targeting this branch, because this is about the currently released versions.

same as https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/525