### PR TITLE
Fixes #846

### DIFF
--- a/src/Resources/config/security.xml
+++ b/src/Resources/config/security.xml
@@ -4,6 +4,6 @@
         <parameter key="sonata.admin.manipulator.acl.object.orm.class">Sonata\DoctrineORMAdminBundle\Util\ObjectAclManipulator</parameter>
     </parameters>
     <services>
-        <service id="sonata.admin.manipulator.acl.object.orm" class="%sonata.admin.manipulator.acl.object.orm.class%"/>
+        <service id="sonata.admin.manipulator.acl.object.orm" class="%sonata.admin.manipulator.acl.object.orm.class%" public="true"/>
     </services>
 </container>


### PR DESCRIPTION
Services are private by default since Symfony 3.4.
I am targeting this branch, because there is no BC-Break.

Closes #846

## Changelog

```markdown
### Fixed
- sonata.admin.manipulator.acl.object.orm is now public
```
