### PR TITLE
Fix Twig_Error_Runtime  "Key "associationAdmin" for array with keys translationDomain, associationadmin, options" does not exist."

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -100,7 +100,7 @@ file that was distributed with this source code.
                     and btn_edit
                     and sonata_admin.value != null
                 %}
-                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('edit', {'id' : sonata_admin.field_description.associationAdmin.normalizedIdentifier(sonata_admin.value)}) }}"
+                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('edit', {'id' : sonata_admin.field_description.associationadmin.normalizedIdentifier(sonata_admin.value)}) }}"
                         onclick="return start_field_dialog_form_edit_{{ id }}(this);"
                         class="btn btn-warning btn-sm sonata-ba-action"
                         title="{{ btn_edit|trans({}, btn_catalogue) }}"


### PR DESCRIPTION
…

I am targeting this branch, because I use this version and there is a bug.

Closes issues. I am not aware of any such issues. 

## Changelog

```markdown
### Fixed
- FIx Twig_Error_Runtime  "Key "associationAdmin" for array with keys translationDomain, associationadmin, options" does not exist."
```

## Subject

Fix Twig_Error_Runtime  "Key "associationAdmin" for array with keys translationDomain, associationadmin, options" does not exist."
