### PR TITLE
added case_sensitive option to StringFilter

### DIFF
--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -41,7 +41,11 @@ class StringFilter extends Filter
 
         $or = $queryBuilder->expr()->orX();
 
-        $or->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
+        if ($this->getOption('case_sensitive')) {
+            $or->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
+        } else {
+            $or->add(sprintf('LOWER(%s.%s) %s :%s', $alias, $field, $operator, $parameterName));
+        }
 
         if (ChoiceType::TYPE_NOT_CONTAINS == $data['type']) {
             $or->add($queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $field)));
@@ -52,7 +56,12 @@ class StringFilter extends Filter
         if (ChoiceType::TYPE_EQUAL == $data['type']) {
             $queryBuilder->setParameter($parameterName, $data['value']);
         } else {
-            $queryBuilder->setParameter($parameterName, sprintf($this->getOption('format'), $data['value']));
+            $queryBuilder->setParameter($parameterName,
+                sprintf(
+                    $this->getOption('format'),
+                    $this->getOption('case_sensitive') ? $data['value'] : mb_strtolower($data['value'])
+                )
+            );
         }
     }
 
@@ -60,6 +69,7 @@ class StringFilter extends Filter
     {
         return [
             'format' => '%%%s%%',
+            'case_sensitive' => true,
         ];
     }
 

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -114,4 +114,32 @@ class StringFilterTest extends TestCase
         $this->assertEquals(['field_name_0' => 'asd'], $builder->parameters);
         $this->assertTrue($filter->isActive());
     }
+
+    public function testCaseSensitiveFalse()
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['case_sensitive' => false]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $this->assertEquals([], $builder->query);
+
+        $filter->filter($builder, 'alias', 'field', ['value' => 'FooBar', 'type' => ChoiceType::TYPE_CONTAINS]);
+        $this->assertEquals(['LOWER(alias.field) LIKE :field_name_0'], $builder->query);
+        $this->assertEquals(['field_name_0' => '%foobar%'], $builder->parameters);
+        $this->assertTrue($filter->isActive());
+    }
+
+    public function testCaseSensitiveTrue()
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['case_sensitive' => true]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $this->assertEquals([], $builder->query);
+
+        $filter->filter($builder, 'alias', 'field', ['value' => 'FooBar', 'type' => ChoiceType::TYPE_CONTAINS]);
+        $this->assertEquals(['alias.field LIKE :field_name_0'], $builder->query);
+        $this->assertEquals(['field_name_0' => '%FooBar%'], $builder->parameters);
+        $this->assertTrue($filter->isActive());
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because this is BC.

this change is needed to make a filter `case-insensitive` instead of `case-sensitive`

Refs https://github.com/sonata-project/SonataAdminBundle/pull/5353

## Changelog

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added possibility to make `StringFilter` case-insensitive
```
    
## To do
    
- [x] Update the tests
