### PR TITLE
Fix exception on composite keys #834

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -89,7 +89,7 @@ class Pager extends BasePager
         }
 
         $columns = implode(",'-',", array_map(function ($column) use ($rootAlias) {
-            return "$rootAlias.$column";
+            return "IDENTITY($rootAlias.$column)";
         }, $countColumns));
 
         return "concat($columns)";

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -14,13 +14,39 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Tests\Datagrid;
 
 use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Tests\Filter\QueryBuilder;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\Product;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\Store;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\StoreProduct;
+use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 
 class PagerTest extends TestCase
 {
+    public function testComputeNbResultFoCompositeId()
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+        $classes = [
+            $em->getClassMetadata(Product::class),
+            $em->getClassMetadata(StoreProduct::class),
+            $em->getClassMetadata(Store::class),
+        ];
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->createSchema($classes);
+
+        $qb = $em->createQueryBuilder()
+            ->select('o')
+            ->from(StoreProduct::class, 'o');
+        $pq = new ProxyQuery($qb);
+        $pager = new Pager();
+        $pager->setCountColumn($em->getClassMetadata(StoreProduct::class)->getIdentifierFieldNames());
+        $pager->setQuery($pq);
+        $this->assertEquals(0, $pager->computeNbResult());
+    }
+
     public function dataGetComputeNbResult()
     {
         return [


### PR DESCRIPTION
Added IDENITIY for composite keys for Pager::computeNbResult()

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Does not work: Admin for entity with a composite keys


Closes #834

## Changelog
```markdown
### Fixed
- Added IDENTITY when CONCAT composite keys
```