### PR TITLE
Revert support for composite key in Pager

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -39,9 +39,10 @@ class Pager extends BasePager
         }
 
         $countQuery->select(sprintf(
-            'count(%s %s) as cnt',
+            'count(%s %s.%s) as cnt',
             $countQuery instanceof ProxyQuery && !$countQuery->isDistinct() ? null : 'DISTINCT',
-            $this->getColumnsForQuery(current($countQuery->getRootAliases()))
+            current($countQuery->getRootAliases()),
+            current($this->getCountColumn())
         ));
 
         return $countQuery->resetDQLPart('orderBy')->getQuery()->getSingleScalarResult();
@@ -80,18 +81,5 @@ class Pager extends BasePager
             $this->getQuery()->setFirstResult($offset);
             $this->getQuery()->setMaxResults($this->getMaxPerPage());
         }
-    }
-
-    private function getColumnsForQuery($rootAlias)
-    {
-        if (1 === \count($countColumns = $this->getCountColumn())) {
-            return $rootAlias.'.'.current($countColumns);
-        }
-
-        $columns = implode(",'-',", array_map(function ($column) use ($rootAlias) {
-            return "$rootAlias.$column";
-        }, $countColumns));
-
-        return "concat($columns)";
     }
 }

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -14,13 +14,37 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Tests\Datagrid;
 
 use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Tests\Filter\QueryBuilder;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\User;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\UserBrowser;
+use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 
 class PagerTest extends TestCase
 {
+    public function testComputeNbResultFoCompositeId()
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+        $classes = [
+            $em->getClassMetadata(User::class),
+            $em->getClassMetadata(UserBrowser::class),
+        ];
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->createSchema($classes);
+
+        $qb = $em->createQueryBuilder()
+            ->select('ub')
+            ->from(UserBrowser::class, 'ub');
+        $pq = new ProxyQuery($qb);
+        $pager = new Pager();
+        $pager->setCountColumn($em->getClassMetadata(UserBrowser::class)->getIdentifierFieldNames());
+        $pager->setQuery($pq);
+        $this->assertEquals(0, $pager->computeNbResult());
+    }
+
     public function dataGetComputeNbResult()
     {
         return [

--- a/tests/Fixtures/Entity/ORM/User.php
+++ b/tests/Fixtures/Entity/ORM/User.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class User
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+}

--- a/tests/Fixtures/Entity/ORM/UserBrowser.php
+++ b/tests/Fixtures/Entity/ORM/UserBrowser.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class UserBrowser
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="User")
+     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
+     * @ORM\Id()
+     * @ORM\GeneratedValue("NONE")
+     */
+    private $user;
+
+    /**
+     * @var string
+     *
+     * @ORM\Id
+     * @ORM\Column(type="string", length=64)
+     */
+    private $browserId;
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
I am targeting this branch, because this is BC.
To preserve the feature from #827 but still revert to the old way for count calculate.

Closes #834 

## Changelog
```markdown
### Fixed
- Composite key pagination throwing exception
```
