### PR TITLE
include string cast to avoid typeError with explode function

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -243,7 +243,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
             return;
         }
 
-        $values = array_combine($this->getIdentifierFieldNames($class), explode(self::ID_SEPARATOR, $id));
+        $values = array_combine($this->getIdentifierFieldNames($class), explode(self::ID_SEPARATOR, (string)$id));
 
         return $this->getEntityManager($class)->getRepository($class)->find($values);
     }

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -243,7 +243,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
             return;
         }
 
-        $values = array_combine($this->getIdentifierFieldNames($class), explode(self::ID_SEPARATOR, (string)$id));
+        $values = array_combine($this->getIdentifierFieldNames($class), explode(self::ID_SEPARATOR, (string) $id));
 
         return $this->getEntityManager($class)->getRepository($class)->find($values);
     }


### PR DESCRIPTION
## Subject

I opened an issue in SonataAdminBundle with the problem, you can see from this link:

https://github.com/sonata-project/SonataAdminBundle/issues/5448

In this pull request I include (string) cast to avoid TypeError with explode function.

I am targeting this branch, because in this branch is included strict_types.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/5448

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
TypeError with explode in ModelManager
```
