### PR TITLE
Applied fixes from FlintCI

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -45,7 +45,7 @@ class Pager extends BasePager
             current($this->getCountColumn())
         ));
 
-        return $countQuery->resetDQLPart('orderBy')->getQuery()->getSingleScalarResult();
+        return (int) ($countQuery->resetDQLPart('orderBy')->getQuery()->getSingleScalarResult());
     }
 
     public function getResults($hydrationMode = Query::HYDRATE_OBJECT)

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -42,7 +42,7 @@ class PagerTest extends TestCase
         $pager = new Pager();
         $pager->setCountColumn($em->getClassMetadata(UserBrowser::class)->getIdentifierFieldNames());
         $pager->setQuery($pq);
-        $this->assertEquals(0, $pager->computeNbResult());
+        $this->assertSame(0, $pager->computeNbResult());
     }
 
     public function dataGetComputeNbResult()


### PR DESCRIPTION
```markdown
# Fixed
- `Sonata\DoctrineORMAdminBundle\Datagrid\Pager::computeNbResult()` now returns an integer, not a string
```