### PR TITLE
Remove call to `call_user_func_array()` at `ProxyQuery::__call()`

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -75,7 +75,7 @@ class ProxyQuery implements ProxyQueryInterface
 
     public function __call($name, $args)
     {
-        return \call_user_func_array([$this->queryBuilder, $name], $args);
+        return $this->queryBuilder->$name(...$args);
     }
 
     public function __get($name)


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |