### PR TITLE
Prevent trim function to be executed with null value on StringFilter

### DIFF
--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -20,7 +20,7 @@ class StringFilter extends Filter
 {
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !\is_array($data) || !\array_key_exists('value', $data)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || null === $data['value']) {
             return;
         }
 

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -34,6 +34,18 @@ class StringFilterTest extends TestCase
         $this->assertFalse($filter->isActive());
     }
 
+    public function testNullValue()
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['format' => '%s']);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $this->assertSame([], $builder->query);
+
+        $filter->filter($builder, 'alias', 'field', ['value' => null, 'type' => ChoiceType::TYPE_EQUAL]);
+        $this->assertFalse($filter->isActive());
+    }
+
     public function testContains()
     {
         $filter = new StringFilter();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Since the project is now using strict_types send null value to the trim function would cause an exception. To fix that a check for null value inside  was added.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the strict types are not being used in 2.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #900

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added check for null value to prevent exception on StringFilter
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
