### PR TITLE
Filters must respect `createQuery()` clauses

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -30,8 +30,10 @@ abstract class Filter extends BaseFilter
         if (\is_array($value) && \array_key_exists('value', $value)) {
             list($alias, $field) = $this->association($queryBuilder, $value);
 
-            $this->filter($queryBuilder, $alias, $field, $value);
+            return $this->filter($queryBuilder, $alias, $field, $value);
         }
+
+        return null;
     }
 
     public function isActive()
@@ -52,12 +54,6 @@ abstract class Filter extends BaseFilter
      */
     protected function applyWhere(ProxyQueryInterface $queryBuilder, $parameter)
     {
-        if (self::CONDITION_OR === $this->getCondition()) {
-            $queryBuilder->orWhere($parameter);
-        } else {
-            $queryBuilder->andWhere($parameter);
-        }
-
         // filter is active since it's added to the queryBuilder
         $this->active = true;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Filters must respect `createQuery()` clauses.

I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to sonata-project/SonataAdminBundle#5569.

## Changelog

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Clauses provided by `createQuery()` method being not respected with filters using "OR" condition.
```
    
## To do
    
- [ ] Update tests;
- [ ] Validate that `FilterInterface::apply()` and `FilterInterface::filter()` can return values or find other approach; 