### PR TITLE
Resolve error in entities with composite ID

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -339,6 +339,12 @@ class ModelManager implements ModelManagerInterface, LockInterface
                 continue;
             }
 
+            if (method_exists($value, 'getId')) {
+                $identifiers[] = (string) $value->getId();
+
+                continue;
+            }
+            
             if (method_exists($value, '__toString')) {
                 $identifiers[] = (string) $value;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Solution for [#923](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/923).

While a more elegant solution is found for this case, this PR would fix the errors when generating URLs in Sonata Admin when using entities with composite and foreign keys. See manual of doctrine: [Link](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/tutorials/composite-primary-keys.html)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #923 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->
- Fix "Resolve string value of is with __toString cause trouble with composite key" (#923)
<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

