### PR TITLE
Resolve error in entities with composite ID

### DIFF
--- a/tests/Fixtures/DoctrineType/UuidBinaryType.php
+++ b/tests/Fixtures/DoctrineType/UuidBinaryType.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\StringType;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
+
+/**
+ * Mock for a custom doctrine type used in the ModelManagerTest suite.
+ *
+ * @author Jorge Garces <jgarces@iberdat.com>
+ */
+final class UuidBinaryType extends StringType
+{
+    const NAME = 'uuid_binary';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return !empty($value) ? new NonIntegerIdentifierTestClass($value->toString()) : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return $value->toString();
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Solution for [#923](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/923).

While a more elegant solution is found for this case, this PR would fix the errors when generating URLs in Sonata Admin when using entities with composite and foreign keys. See manual of doctrine: [Link](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/tutorials/composite-primary-keys.html)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #923 

## Changelog
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

```markdown
### Fixed
- Fix "Resolve string value of is with __toString cause trouble with composite key" (#923)
```
<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->
