### PR TITLE
Avoid exception when no result

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -45,7 +45,7 @@ class Pager extends BasePager
             current($this->getCountColumn())
         ));
 
-        return (int) ($countQuery->resetDQLPart('orderBy')->getQuery()->getSingleScalarResult());
+        return (int) ($countQuery->resetDQLPart('orderBy')->getQuery()->getOneOrNullResult(Query::HYDRATE_SINGLE_SCALAR));
     }
 
     public function getResults($hydrationMode = Query::HYDRATE_OBJECT)

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -62,11 +62,11 @@ class PagerTest extends TestCase
     {
         $query = $this->getMockBuilder(AbstractQuery::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getSingleScalarResult'])
+            ->setMethods(['getOneOrNullResult'])
             ->getMockForAbstractClass();
 
         $query->expects($this->once())
-            ->method('getSingleScalarResult');
+            ->method('getOneOrNullResult');
 
         $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
# Subject

I wrote a custom filter with Having/groupBy condition and got an exception when no result was found.

This was the query
```
SELECT count(DISTINCT a0_.id) AS sclr_0 FROM asv_contract a0_ LEFT JOIN asv_relaunch a1_ ON a0_.id = a1_.contract_id LEFT JOIN asv_client_role a2_ ON a0_.id = a2_.contract_id LEFT JOIN asv_external_client_id a3_ ON a2_.external_client_id = a3_.id LEFT JOIN asv_client a4_ ON a3_.client_id = a4_.id WHERE a4_.usagename LIKE ? GROUP BY a0_.id, a0_.admin_comment, a0_.external_contract_id, a0_.effective_date, a0_.end_date, a0_.updated_date, a0_.sent_to_partner_date, a0_.created_by_grc_date, a0_.completed_by_grc_date, a0_.pledge, a0_.management_mandate, a0_.contract_status, a0_.buy_worth, a0_.initial_amount, a0_.current_advances, a0_.is_investor_profile_ignored, a0_.investor_profile_ignored_date, a0_.is_complete, a0_.has_been_matched_with_created_contract, a0_.is_transferred, a0_.distribution_in_progress, a0_.cash_amount, a0_.initial_management_type, a0_.initial_management_profile, a0_.manual_input, a0_.bank_account_number, a0_.received_at, a0_.current_management_type, a0_.current_management_type_for_partner, a0_.current_management_profile, a0_.management_mode_change_date, a0_.business_identifier_code, a0_.origin, a0_.contract_type_id, a0_.initial_management_mode_id, a0_.bank_details_file_id, a0_.signed_subscription_document_file_id, a0_.webservice_response_id, a0_.mobile_invoice_file_id, a0_.proof_of_payment_origin_file_id, a0_.specific_terms_file_id HAVING COUNT(DISTINCT a1_.id) = ?
```

I think `getOneOrNullResult' is safer than `getSingleScalarResult`.
I am targeting this branch, because it's a bug fix.

### Fixed
Do not return exception if Pager->computeNbResult has no result 