### PR TITLE
Fix ProxyQuery::getQueryBuilder() return type

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -211,7 +211,7 @@ class ProxyQuery implements ProxyQueryInterface
     }
 
     /**
-     * @return mixed
+     * @return QueryBuilder
      */
     public function getQueryBuilder()
     {


### PR DESCRIPTION
## Subject

Query builder is annotated as QueryBuilder in all other places, except here. This will help developers when altering queries (e.g. in filters), because the IDE will autocomplete properly and also static analysers like PHPStan will not complain (correctly).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a fix, should be BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

```markdown
### Fixed
- Fix ProxyQuery::getQueryBuilder() return type.
```
