### PR TITLE
Steal fixture from the Doctrine bridge

### DIFF
--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -27,10 +27,10 @@ use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\DoubleNameEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Query\FooWalker;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
-use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity;
 
 class ProxyQueryTest extends TestCase
 {

--- a/tests/Fixtures/Entity/DoubleNameEntity.php
+++ b/tests/Fixtures/Entity/DoubleNameEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+/** @Entity */
+final class DoubleNameEntity
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="string") */
+    public $name;
+
+    /** @Column(type="string", nullable=true) */
+    public $name2;
+
+    public function __construct($id, $name, $name2)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->name2 = $name2;
+    }
+}


### PR DESCRIPTION
The bridge archived have recently been modified so that they no longer
contain tests. We were relying on one of the fixtures that came with
this tests. Copying the fixture to our project fixes the issue.
Fixes the build when using Symfony 4.4 or 5.0.

See https://github.com/symfony/doctrine-bridge/commit/bfe0b2925359c956da692252b9b5f38cd98ab585#diff-fc723d30b02a4cca7a534518111c1a66
