### PR TITLE
Allow to override Operator option

### DIFF
--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -56,6 +56,8 @@ class BooleanFilter extends Filter
     {
         return [
             'field_type' => BooleanType::class,
+            'operator_type' => HiddenType::class,
+            'operator_options' => [],
         ];
     }
 
@@ -64,8 +66,8 @@ class BooleanFilter extends Filter
         return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
-            'operator_type' => HiddenType::class,
-            'operator_options' => [],
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
             'label' => $this->getLabel(),
         ]];
     }

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -63,13 +63,17 @@ class ChoiceFilter extends Filter
 
     public function getDefaultOptions()
     {
-        return [];
+        return [
+            'operator_type' => EqualType::class,
+            'operator_options' => [],
+        ];
     }
 
     public function getRenderSettings()
     {
         return [DefaultType::class, [
-            'operator_type' => EqualType::class,
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -49,7 +49,10 @@ class ClassFilter extends Filter
 
     public function getDefaultOptions()
     {
-        return [];
+        return [
+            'operator_type' => EqualType::class,
+            'operator_options' => [],
+        ];
     }
 
     public function getFieldType()
@@ -74,7 +77,8 @@ class ClassFilter extends Filter
     public function getRenderSettings()
     {
         return [DefaultType::class, [
-            'operator_type' => EqualType::class,
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/tests/Filter/BooleanFilterTest.php
+++ b/tests/Filter/BooleanFilterTest.php
@@ -17,9 +17,20 @@ use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\BooleanFilter;
 use Sonata\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class BooleanFilterTest extends TestCase
 {
+    public function testRenderSettings(): void
+    {
+        $filter = new BooleanFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(HiddenType::class, $options['operator_type']);
+        $this->assertSame([], $options['operator_options']);
+    }
+
     public function testFilterEmpty(): void
     {
         $filter = new BooleanFilter();

--- a/tests/Filter/CallbackFilterTest.php
+++ b/tests/Filter/CallbackFilterTest.php
@@ -16,9 +16,20 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class CallbackFilterTest extends TestCase
 {
+    public function testRenderSettings(): void
+    {
+        $filter = new CallbackFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(HiddenType::class, $options['operator_type']);
+        $this->assertSame([], $options['operator_options']);
+    }
+
     public function testFilterClosure(): void
     {
         $builder = new ProxyQuery(new QueryBuilder());

--- a/tests/Filter/ChoiceFilterTest.php
+++ b/tests/Filter/ChoiceFilterTest.php
@@ -17,9 +17,20 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter;
+use Sonata\Form\Type\EqualType;
 
 class ChoiceFilterTest extends TestCase
 {
+    public function testRenderSettings(): void
+    {
+        $filter = new ChoiceFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(EqualType::class, $options['operator_type']);
+        $this->assertSame([], $options['operator_options']);
+    }
+
     public function testFilterEmpty(): void
     {
         $filter = new ChoiceFilter();

--- a/tests/Filter/ClassFilterTest.php
+++ b/tests/Filter/ClassFilterTest.php
@@ -20,6 +20,16 @@ use Sonata\Form\Type\EqualType;
 
 class ClassFilterTest extends TestCase
 {
+    public function testRenderSettings(): void
+    {
+        $filter = new ClassFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(EqualType::class, $options['operator_type']);
+        $this->assertSame([], $options['operator_options']);
+    }
+
     public function testFilterEmpty(): void
     {
         $filter = new ClassFilter();


### PR DESCRIPTION
## Subject

I am targeting this branch, because there is no breaking changes.

## Changelog

```markdown
### Changed
`operator_type` and `operator_options` are overridable for the provided Filters
```
