### PR TITLE
Avoid to call not accessible `toString()` methods

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -640,12 +640,12 @@ class ModelManager implements ModelManagerInterface, LockInterface
             return (string) $type->convertToPHPValue($value, $platform);
         }
 
-        // some libraries may have `toString` implementation
-        if (method_exists($value, 'toString')) {
+        // some libraries may have `toString()` implementation
+        if (\is_callable([$value, 'toString'])) {
             return $value->toString();
         }
 
-        // final fallback to magic __toString which it may throw an exception in 7.4
+        // final fallback to magic `__toString()` which may throw an exception in 7.4
         if (method_exists($value, '__toString')) {
             return $value->__toString();
         }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -75,7 +75,7 @@ class ModelManagerTest extends TestCase
         }
     }
 
-    public function valueObjectDataProvider()
+    public function valueObjectDataProvider(): array
     {
         return [
             'value object with toString implementation' => [ValueObjectWithToStringImpl::class],
@@ -86,7 +86,7 @@ class ModelManagerTest extends TestCase
     /**
      * @dataProvider valueObjectDataProvider
      */
-    public function testGetIdentifierValuesWhenIdentifierIsValueObjectWithToStringMethod($vbClassName)
+    public function testGetIdentifierValuesWhenIdentifierIsValueObjectWithToStringMethod(string $vbClassName): void
     {
         $entity = new UuidBinaryEntity(new $vbClassName('a7ef873a-e7b5-11e9-81b4-2a2ae2dbcce4'));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Avoid to call not accessible `toString()` methods.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #937.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Avoid to call not accessible `toString()` methods.
```