### PR TITLE
Fix computeNbResult in case of groupBy

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -45,7 +45,10 @@ class Pager extends BasePager
             current($this->getCountColumn())
         ));
 
-        return (int) ($countQuery->resetDQLPart('orderBy')->getQuery()->getOneOrNullResult(Query::HYDRATE_SINGLE_SCALAR));
+        return array_sum(array_column(
+            $countQuery->resetDQLPart('orderBy')->getQuery()->getResult(Query::HYDRATE_SCALAR),
+            'cnt'
+        ));
     }
 
     public function getResults($hydrationMode = Query::HYDRATE_OBJECT)

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -62,11 +62,12 @@ class PagerTest extends TestCase
     {
         $query = $this->getMockBuilder(AbstractQuery::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getOneOrNullResult'])
+            ->setMethods(['getResult'])
             ->getMockForAbstractClass();
 
         $query->expects($this->once())
-            ->method('getOneOrNullResult');
+            ->method('getResult')
+            ->willReturn([['cnt' => 1], ['cnt' => 2]]);
 
         $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
## Subject
Fix computeNbResult where groupBy was used

I am targeting this branch, because BC-break free.

Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/968

If this PR is merged, I would love a new release since we need this from our project.

## Changelog
```markdown
### Fixed
- Fix computeNbResult where groupBy was used
```
