### PR TITLE
Added configuration for case_sensitive option in StringFilter

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -62,3 +62,7 @@ Full configuration options
                     percent:    "@SonataAdmin/CRUD/base_percent.html.twig"
                     choice:     "@SonataAdmin/CRUD/show_choice.html.twig"
                     url:        "@SonataAdmin/CRUD/show_url.html.twig"
+
+        filters:
+            string:
+                case_sensitive: true

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -41,13 +42,6 @@ class Configuration implements ConfigurationInterface
         } else {
             $rootNode = $treeBuilder->getRootNode();
         }
-
-        $caseSensitiveInfo = <<<'CASESENSITIVE'
-Whether the StringFilter should behave case sensitive or not.
-Using case-insensitivity might lead to performance issues.
-See https://use-the-index-luke.com/sql/where-clause/functions/case-insensitive-search
-for more information.
-CASESENSITIVE;
 
         $rootNode
             ->children()
@@ -83,23 +77,40 @@ CASESENSITIVE;
                         ->end()
                     ->end()
                 ->end()
-                ->arrayNode('filters')
+            ->end()
+            ->append($this->getFiltersNode())
+        ;
+
+        return $treeBuilder;
+    }
+
+    private function getFiltersNode(): ArrayNodeDefinition
+    {
+        $treeBuilder = new TreeBuilder();
+        $node = $treeBuilder->root('filters');
+
+        $caseSensitiveInfo = <<<'CASESENSITIVE'
+Whether the StringFilter should behave case sensitive or not.
+Using case-insensitivity might lead to performance issues.
+See https://use-the-index-luke.com/sql/where-clause/functions/case-insensitive-search
+for more information.
+CASESENSITIVE;
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('string')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->arrayNode('string')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->booleanNode('case_sensitive')
-                                    ->defaultTrue()
-                                    ->info($caseSensitiveInfo)
-                                ->end()
-                            ->end()
+                        ->booleanNode('case_sensitive')
+                            ->defaultTrue()
+                            ->info($caseSensitiveInfo)
                         ->end()
                     ->end()
                 ->end()
             ->end()
         ;
 
-        return $treeBuilder;
+        return $node;
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -42,6 +42,13 @@ class Configuration implements ConfigurationInterface
             $rootNode = $treeBuilder->getRootNode();
         }
 
+        $caseSensitiveInfo = <<<'CASESENSITIVE'
+Whether the StringFilter should behave case sensitive or not.
+Using case-insensitivity might lead to performance issues.
+See https://use-the-index-luke.com/sql/where-clause/functions/case-insensitive-search
+for more information.
+CASESENSITIVE;
+
         $rootNode
             ->children()
                 ->scalarNode('entity_manager')->defaultNull()->end()
@@ -71,6 +78,20 @@ class Configuration implements ConfigurationInterface
                                 ->arrayNode('show')
                                     ->useAttributeAsKey('name')
                                     ->prototype('scalar')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('filters')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('string')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('case_sensitive')
+                                    ->defaultTrue()
+                                    ->info($caseSensitiveInfo)
                                 ->end()
                             ->end()
                         ->end()

--- a/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
+++ b/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
@@ -57,5 +57,10 @@ class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
 
         $container->getDefinition('sonata.admin.builder.orm_show')
             ->replaceArgument(1, $config['templates']['types']['show']);
+
+        $container->setParameter(
+            'sonata_doctrine_orm_admin.filters.string.case_sensitive',
+            $config['filters']['string']['case_sensitive']
+        );
     }
 }

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -27,11 +27,11 @@ class StringFilter extends Filter
     /**
      * @var bool
      */
-    private $caseSensitive;
+    private $defaultCaseSensitive;
 
-    public function __construct(bool $caseSensitive = true)
+    public function __construct(bool $defaultCaseSensitive = true)
     {
-        $this->caseSensitive = $caseSensitive;
+        $this->defaultCaseSensitive = $defaultCaseSensitive;
     }
 
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
@@ -87,7 +87,7 @@ class StringFilter extends Filter
     {
         return [
             'format' => '%%%s%%',
-            'case_sensitive' => $this->caseSensitive,
+            'case_sensitive' => $this->defaultCaseSensitive,
         ];
     }
 

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -24,6 +24,19 @@ class StringFilter extends Filter
         ChoiceType::TYPE_EQUAL => '=',
     ];
 
+    /**
+     * @var bool
+     */
+    private $caseSensitive;
+
+    /**
+     * @param bool $caseSensitive
+     */
+    public function __construct($caseSensitive)
+    {
+        $this->caseSensitive = $caseSensitive;
+    }
+
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
         if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || null === $data['value']) {
@@ -77,7 +90,7 @@ class StringFilter extends Filter
     {
         return [
             'format' => '%%%s%%',
-            'case_sensitive' => true,
+            'case_sensitive' => $this->caseSensitive,
         ];
     }
 

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -29,10 +29,7 @@ class StringFilter extends Filter
      */
     private $caseSensitive;
 
-    /**
-     * @param bool $caseSensitive
-     */
-    public function __construct($caseSensitive)
+    public function __construct(bool $caseSensitive = true)
     {
         $this->caseSensitive = $caseSensitive;
     }

--- a/src/Resources/config/doctrine_orm_filter_types.xml
+++ b/src/Resources/config/doctrine_orm_filter_types.xml
@@ -17,6 +17,7 @@
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_model_autocomplete"/>
         </service>
         <service id="sonata.admin.orm.filter.type.string" class="Sonata\DoctrineORMAdminBundle\Filter\StringFilter">
+            <argument>%sonata_doctrine_orm_admin.filters.string.case_sensitive%</argument>
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_string"/>
         </service>
         <service id="sonata.admin.orm.filter.type.number" class="Sonata\DoctrineORMAdminBundle\Filter\NumberFilter">

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -140,29 +140,47 @@ class StringFilterTest extends TestCase
 
     public function testCaseSensitiveFalse(): void
     {
-        $filter = new StringFilter();
-        $filter->initialize('field_name', ['case_sensitive' => false]);
+        $caseSensitive = false;
 
-        $builder = new ProxyQuery(new QueryBuilder());
-        $this->assertSame([], $builder->query);
+        // Setting case_sensitive via constructor
+        $filter1 = new StringFilter($caseSensitive);
+        $filter1->initialize('field_name');
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'FooBar', 'type' => ChoiceType::TYPE_CONTAINS]);
-        $this->assertSame(['LOWER(alias.field) LIKE :field_name_0'], $builder->query[0]->getParts());
-        $this->assertSame(['field_name_0' => '%foobar%'], $builder->parameters);
-        $this->assertTrue($filter->isActive());
+        // Setting case_sensitive via options
+        $filter2 = new StringFilter();
+        $filter2->initialize('field_name', ['case_sensitive' => $caseSensitive]);
+
+        foreach ([$filter1, $filter2] as $filter) {
+            $builder = new ProxyQuery(new QueryBuilder());
+            $this->assertSame([], $builder->query);
+
+            $filter->filter($builder, 'alias', 'field', ['value' => 'FooBar', 'type' => ChoiceType::TYPE_CONTAINS]);
+            $this->assertSame(['LOWER(alias.field) LIKE :field_name_0'], $builder->query[0]->getParts());
+            $this->assertSame(['field_name_0' => '%foobar%'], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        }
     }
 
     public function testCaseSensitiveTrue(): void
     {
-        $filter = new StringFilter();
-        $filter->initialize('field_name', ['case_sensitive' => true]);
+        $caseSensitive = true;
 
-        $builder = new ProxyQuery(new QueryBuilder());
-        $this->assertSame([], $builder->query);
+        // Setting case_sensitive via constructor
+        $filter1 = new StringFilter($caseSensitive);
+        $filter1->initialize('field_name');
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'FooBar', 'type' => ChoiceType::TYPE_CONTAINS]);
-        $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query[0]->getParts());
-        $this->assertSame(['field_name_0' => '%FooBar%'], $builder->parameters);
-        $this->assertTrue($filter->isActive());
+        // Setting case_sensitive via options
+        $filter2 = new StringFilter();
+        $filter2->initialize('field_name', ['case_sensitive' => $caseSensitive]);
+
+        foreach ([$filter1, $filter2] as $filter) {
+            $builder = new ProxyQuery(new QueryBuilder());
+            $this->assertSame([], $builder->query);
+
+            $filter->filter($builder, 'alias', 'field', ['value' => 'FooBar', 'type' => ChoiceType::TYPE_CONTAINS]);
+            $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query[0]->getParts());
+            $this->assertSame(['field_name_0' => '%FooBar%'], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        }
     }
 }

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -142,11 +142,11 @@ class StringFilterTest extends TestCase
     {
         $caseSensitive = false;
 
-        // Setting case_sensitive via constructor
+        // Setting default case sensitive via constructor
         $filter1 = new StringFilter($caseSensitive);
         $filter1->initialize('field_name');
 
-        // Setting case_sensitive via options
+        // Setting case sensitive via options
         $filter2 = new StringFilter();
         $filter2->initialize('field_name', ['case_sensitive' => $caseSensitive]);
 
@@ -165,11 +165,11 @@ class StringFilterTest extends TestCase
     {
         $caseSensitive = true;
 
-        // Setting case_sensitive via constructor
+        // Setting default case sensitive via constructor
         $filter1 = new StringFilter($caseSensitive);
         $filter1->initialize('field_name');
 
-        // Setting case_sensitive via options
+        // Setting case sensitive via options
         $filter2 = new StringFilter();
         $filter2->initialize('field_name', ['case_sensitive' => $caseSensitive]);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I need an opportunity to set a case-insensitive search for the StringFilter through configuration.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #334

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added configuration for `case_sensitive` option in `StringFilter`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
