### PR TITLE
Add new filter for empty fields

### DIFF
--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -44,6 +44,7 @@ For now, only `Doctrine ORM` filters are available:
 * ``Sonata\DoctrineORMAdminBundle\Filter\DateTimeFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DateTimeType`` Form Type, renders a datetime field,
 * ``Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType`` Form Type, renders a 2 datetime fields,
 * ``Sonata\DoctrineORMAdminBundle\Filter\ClassFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DefaultType`` Form type, renders a choice list field.
+* ``Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DefaultType`` Form type, renders a choice list field.
 
 Example
 -------
@@ -159,6 +160,26 @@ ClassFilter
         {
             $datagridMapper
                 ->add('type', ClassFilter::class, ['sub_classes' => $this->getSubClasses()]);
+        }
+    }
+
+Empty
+-----
+
+``Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter`` supports filtering for empty (null) entity fields::
+
+    namespace Sonata\NewsBundle\Admin;
+
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminBundle\Filter\EmptyFilter;
+
+    final class PostAdmin extends AbstractAdmin
+    {
+        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+        {
+            $datagridMapper
+                ->add('deleted', EmptyFilter::class, ['field_name' => 'deletedAt']);
         }
     }
 

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Filter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+
+final class EmptyFilter extends Filter
+{
+    /**
+     * @param string       $alias
+     * @param string       $field
+     * @param mixed[]|null $data
+     */
+    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data): void
+    {
+        if (null === $data || !\is_array($data) || !\array_key_exists('value', $data)) {
+            return;
+        }
+
+        if (BooleanType::TYPE_YES === (int) $data['value']) {
+            $this->applyWhere(
+                $queryBuilder,
+                $queryBuilder
+                ->expr()
+                ->isNull(sprintf('%s.%s', $alias, $field))
+            );
+        } elseif (BooleanType::TYPE_NO === (int) $data['value']) {
+            $this->applyWhere(
+                $queryBuilder,
+                $queryBuilder
+                ->expr()
+                ->isNotNull(sprintf('%s.%s', $alias, $field))
+            );
+        }
+    }
+
+    public function getDefaultOptions()
+    {
+        return [
+            'field_type' => BooleanType::class,
+            'operator_type' => HiddenType::class,
+            'operator_options' => [],
+        ];
+    }
+
+    public function getRenderSettings()
+    {
+        return [DefaultType::class, [
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
+            'label' => $this->getLabel(),
+        ]];
+    }
+}

--- a/src/Resources/config/doctrine_orm_filter_types.xml
+++ b/src/Resources/config/doctrine_orm_filter_types.xml
@@ -40,5 +40,8 @@
         <service id="sonata.admin.orm.filter.type.class" class="Sonata\DoctrineORMAdminBundle\Filter\ClassFilter">
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_class"/>
         </service>
+        <service id="Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter">
+            <tag name="sonata.admin.filter.type" alias="doctrine_orm_empty"/>
+        </service>
     </services>
 </container>

--- a/tests/Filter/EmptyFilterTest.php
+++ b/tests/Filter/EmptyFilterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter;
+use Sonata\Form\Type\BooleanType;
+
+final class EmptyFilterTest extends TestCase
+{
+    public function testEmpty(): void
+    {
+        $filter = new EmptyFilter();
+        $filter->initialize('field_name', [
+            'field_options' => ['class' => 'FooBar'],
+        ]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $filter->filter($builder, 'alias', 'field', null);
+
+        $this->assertSame([], $builder->query);
+        $this->assertFalse($filter->isActive());
+    }
+
+    /**
+     * @dataProvider valueDataProvider
+     */
+    public function testValue(int $value, string $expectedQuery): void
+    {
+        $filter = new EmptyFilter();
+        $filter->initialize('field_name', [
+            'field_options' => ['class' => 'FooBar'],
+        ]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $this->assertSame([], $builder->query);
+
+        $filter->filter($builder, 'alias', 'field', ['value' => $value]);
+
+        $this->assertSame([$expectedQuery], $builder->query);
+        $this->assertTrue($filter->isActive());
+    }
+
+    public function testRenderSettings(): void
+    {
+        $filter = new EmptyFilter();
+        $filter->initialize('field_name', [
+            'field_options' => ['class' => 'FooBar'],
+        ]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(BooleanType::class, $options['field_type']);
+    }
+
+    public function valueDataProvider(): array
+    {
+        return [
+            [BooleanType::TYPE_YES, 'alias.field IS NULL'],
+            [BooleanType::TYPE_NO, 'alias.field IS NOT NULL'],
+        ];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This filter allows filtering for (non-)nullable fields.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
-  Add new filter for empty fields
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
