### PR TITLE
Breaks if entity has many identifiers and one of the not last identifiers is an entity

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -348,9 +348,9 @@ class ModelManager implements ModelManagerInterface, LockInterface
                 continue;
             }
 
-            $metadata = $this->getMetadata(ClassUtils::getClass($value));
+            $identifierMetadata = $this->getMetadata(ClassUtils::getClass($value));
 
-            foreach ($metadata->getIdentifierValues($value) as $value) {
+            foreach ($identifierMetadata->getIdentifierValues($value) as $value) {
                 $identifiers[] = $value;
             }
         }


### PR DESCRIPTION
Not overwrite the entity metadata on get the identifier metadata in `ModelManager::getIdentifierValues()`

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
Critical error here:
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Model/ModelManager.php#L351

You overwrite the entity metadata variable on get the identifier metadata and in the next itarations we tring get metadata from previous identifier, not a entity metadata.

```php
public function getIdentifierValues($entity)
{
    $class = ClassUtils::getClass($entity);
    // Entity metadata!!!
    $metadata = $this->getMetadata($class);
    $platform = $this->getEntityManager($class)->getConnection()->getDatabasePlatform();

    $identifiers = [];

    foreach ($metadata->getIdentifierValues($entity) as $name => $value) {
        if (!\is_object($value)) {
            $identifiers[] = $value;

            continue;
        }

        $fieldType = $metadata->getTypeOfField($name);
        $type = $fieldType && Type::hasType($fieldType) ? Type::getType($fieldType) : null;
        if ($type) {
            $identifiers[] = $this->getValueFromType($value, $type, $fieldType, $platform);

            continue;
        }

        // Entity metadata overwritten to identifier metadata!!!
        $metadata = $this->getMetadata(ClassUtils::getClass($value));

        foreach ($metadata->getIdentifierValues($value) as $value) {
            $identifiers[] = $value;
        }
    }

    return $identifiers;
}
```

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
Entity for reproduce bug

```php
/**
 * @ORM\Entity(readOnly=true)
 * @ORM\Table(name="billing__transaction")
 */
class TransactionAdminView
{
    /**
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="NONE")
     * @ORM\OneToOne(targetEntity="AccountAdminView", fetch="EAGER")
     * @ORM\JoinColumn(name="account_holder", referencedColumnName="id", nullable=false)
     *
     * @var AccountAdminView
     */
    public $account;

    /**
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="NONE")
     * @ORM\Column(name="transaction", type="BillingTransactionType", nullable=false)
     *
     * @var TransactionType
     */
    public $transaction;
}
```

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed

 * Breaks if entity has many identifiers and one of the not last identifiers is an entity.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
