### PR TITLE
Address PHPUnit's warnings

### DIFF
--- a/tests/Block/AuditBlockServiceTest.php
+++ b/tests/Block/AuditBlockServiceTest.php
@@ -65,7 +65,7 @@ class AuditBlockServiceTest extends AbstractBlockServiceTestCase
         $this->blockService->execute($blockContext->reveal());
 
         $this->assertSame('template', $this->templating->view);
-        $this->assertInternalType('array', $this->templating->parameters['settings']);
+        $this->assertIsArray($this->templating->parameters['settings']);
         $this->assertSame($revision, $this->templating->parameters['revisions'][0]['revision']);
         $this->assertSame($block, $this->templating->parameters['block']);
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -27,8 +27,14 @@ class ConfigurationTest extends TestCase
 
         $this->assertNull($config['entity_manager']);
         $this->assertTrue($config['audit']['force']);
-        $this->assertArraySubset(['@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig'], $config['templates']['form']);
-        $this->assertArraySubset(['@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig'], $config['templates']['filter']);
+        $this->assertContains(
+            '@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig',
+            $config['templates']['form']
+        );
+        $this->assertContains(
+            '@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig',
+            $config['templates']['filter']
+        );
         $this->assertArrayNotHasKey('types', $config['templates']);
     }
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because it is a BC.

I tried using Rector, by using
```
composer require rector/rector-prefixed phpunit/phpunit --dev
vendor/bin/rector process tests --set phpunit90 --dry-run
```

You can see the output here: [rector_output.txt](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/files/4232688/rector_output.txt)

Then I had a look and saw why it does not help: https://github.com/rectorphp/rector/blob/master/config/set/phpunit/phpunit90.yaml

So I ended up doing the changes manually.