### PR TITLE
Concat value of complex primary key for correct calculate total pages in Datagrid

### DIFF
--- a/tests/Fixtures/Entity/ORM/User.php
+++ b/tests/Fixtures/Entity/ORM/User.php
@@ -19,9 +19,11 @@ use Doctrine\ORM\Mapping as ORM;
 class User
 {
     /**
-     * @ORM\Column(name="id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(name="id", type="integer")
+     *
+     * @var int
      */
     private $id;
 }

--- a/tests/Fixtures/Entity/ORM/UserBrowser.php
+++ b/tests/Fixtures/Entity/ORM/UserBrowser.php
@@ -19,18 +19,20 @@ use Doctrine\ORM\Mapping as ORM;
 class UserBrowser
 {
     /**
-     * @ORM\ManyToOne(targetEntity="User")
-     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
-     * @ORM\Id()
-     * @ORM\GeneratedValue("NONE")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="NONE")
+     * @ORM\Column(type="integer")
+     *
+     * @var int
      */
-    private $user;
+    private $userId;
 
     /**
-     * @var string
-     *
      * @ORM\Id
-     * @ORM\Column(type="string", length=64)
+     * @ORM\GeneratedValue(strategy="NONE")
+     * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     private $browserId;
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #497

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Concat value of complex primary key for correct calculate total pages in Datagrid
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
