### PR TITLE
use SortBy before custom orderBy

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -124,13 +124,18 @@ class ProxyQuery implements ProxyQueryInterface
 
         // todo : check how doctrine behave, potential SQL injection here ...
         if ($this->getSortBy()) {
+            $orderByDQLPart = $queryBuilder->getDQLPart('orderBy');
+            $queryBuilder->resetDQLPart('orderBy');
+
             $sortBy = $this->getSortBy();
             if (false === strpos($sortBy, '.')) { // add the current alias
                 $sortBy = $rootAlias.'.'.$sortBy;
             }
             $queryBuilder->addOrderBy($sortBy, $this->getSortOrder());
-        } else {
-            $queryBuilder->resetDQLPart('orderBy');
+
+            foreach ($orderByDQLPart as $orderBy) {
+                $queryBuilder->addOrderBy($orderBy);
+            }
         }
 
         /* By default, always add a sort on the identifier fields of the first

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -229,4 +229,44 @@ class ProxyQueryTest extends TestCase
         $query->setSortOrder($validValue);
         $this->assertSame($validValue, $query->getSortOrder());
     }
+
+    public function testExecuteWithOrderBy(): void
+    {
+        $entity1 = new DoubleNameEntity(1, 'Foo', 'Bar');
+        $entity2 = new DoubleNameEntity(2, 'Bar', 'Bar');
+        $entity3 = new DoubleNameEntity(3, 'Bar', 'Foo');
+
+        $this->em->persist($entity1);
+        $this->em->persist($entity2);
+        $this->em->persist($entity3);
+        $this->em->flush();
+
+        $query = new ProxyQuery(
+            $this->em->createQueryBuilder()->select('o.id')->from(DoubleNameEntity::class, 'o')
+        );
+        $query->setSortBy([], ['fieldName' => 'name2'])->setSortOrder('ASC');
+
+        $this->assertSame(
+            [
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+            ],
+            $query->execute()
+        );
+
+        $query2 = new ProxyQuery(
+            $this->em->createQueryBuilder()->select('o.id')->from(DoubleNameEntity::class, 'o')->addOrderBy('o.name')
+        );
+        $query2->setSortBy([], ['fieldName' => 'name2'])->setSortOrder('ASC');
+
+        $this->assertSame(
+            [
+                ['id' => 2],
+                ['id' => 1],
+                ['id' => 3],
+            ],
+            $query2->execute()
+        );
+    }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because I don't consider this like a BC-break but like a bug fix.

When adding
```
$query->addOrderBy()
```
In the `createQuery` function of an Admin class, the `orderBy` clauses was applied before the `sort_by` parameter of the datagrid value. Which break the behaviour of the list orders.
But in this situation I expect the opposite behaviour
- The list is first ordered by the selected column
- In case of row with the same values, the `orderBy` in the createQuery is used.

## Changelog
```markdown
### Fixed
The `_sort_by_ ` datagrid value is properly applied before any custom `orderBy`.
```
