### PR TITLE
Handle case without sort_by value

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -500,10 +500,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     {
         $values = $datagrid->getValues();
 
-        if (isset($values['_sort_by'])
-            && ($values['_sort_by']->getName() === $fieldDescription->getName()
-                || $values['_sort_by']->getName() === $fieldDescription->getOption('sortable'))
-        ) {
+        if ($this->isFieldAlreadySorted($fieldDescription, $datagrid)) {
             if ('ASC' === $values['_sort_order']) {
                 $values['_sort_order'] = 'DESC';
             } else {
@@ -632,6 +629,18 @@ class ModelManager implements ModelManagerInterface, LockInterface
     protected function camelize($property)
     {
         return str_replace(' ', '', ucwords(str_replace('_', ' ', $property)));
+    }
+
+    private function isFieldAlreadySorted(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid): bool
+    {
+        $values = $datagrid->getValues();
+
+        if (!isset($values['_sort_by'])) {
+            return false;
+        }
+
+        return $values['_sort_by']->getName() === $fieldDescription->getName()
+            || $values['_sort_by']->getName() === $fieldDescription->getOption('sortable');
     }
 
     /**

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -500,7 +500,10 @@ class ModelManager implements ModelManagerInterface, LockInterface
     {
         $values = $datagrid->getValues();
 
-        if ($fieldDescription->getName() === $values['_sort_by']->getName() || $values['_sort_by']->getName() === $fieldDescription->getOption('sortable')) {
+        if (isset($values['_sort_by'])
+            && ($values['_sort_by']->getName() === $fieldDescription->getName()
+                || $values['_sort_by']->getName() === $fieldDescription->getOption('sortable'))
+        ) {
             if ('ASC' === $values['_sort_order']) {
                 $values['_sort_order'] = 'DESC';
             } else {
@@ -519,7 +522,9 @@ class ModelManager implements ModelManagerInterface, LockInterface
     {
         $values = $datagrid->getValues();
 
-        $values['_sort_by'] = $values['_sort_by']->getName();
+        if (isset($values['_sort_by'])) {
+            $values['_sort_by'] = $values['_sort_by']->getName();
+        }
         $values['_page'] = $page;
 
         return ['filter' => $values];

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -519,7 +519,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     {
         $values = $datagrid->getValues();
 
-        if (isset($values['_sort_by'])) {
+        if (isset($values['_sort_by']) && $values['_sort_by'] instanceof FieldDescriptionInterface) {
             $values['_sort_by'] = $values['_sort_by']->getName();
         }
         $values['_page'] = $page;
@@ -635,7 +635,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     {
         $values = $datagrid->getValues();
 
-        if (!isset($values['_sort_by'])) {
+        if (!isset($values['_sort_by']) || !$values['_sort_by'] instanceof FieldDescriptionInterface) {
             return false;
         }
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -31,11 +31,11 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
-use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineORMAdminBundle\Datagrid\OrderByToSelectWalker;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
@@ -782,14 +782,14 @@ class ModelManagerTest extends TestCase
     public function testGetPaginationParameters(): void
     {
         $datagrid = $this->createMock(DatagridInterface::class);
-        $filter = $this->createMock(FilterInterface::class);
+        $field = $this->createMock(FieldDescriptionInterface::class);
         $registry = $this->createMock(ManagerRegistry::class);
 
         $datagrid->expects($this->once())
             ->method('getValues')
-            ->willReturn(['_sort_by' => $filter]);
+            ->willReturn(['_sort_by' => $field]);
 
-        $filter->expects($this->once())
+        $field->expects($this->once())
             ->method('getName')
             ->willReturn($name = 'test');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Following https://github.com/sonata-project/SonataAdminBundle/issues/5929, I want to introduce the ability of using `sortable => true` without a default column to sort the list.
This means that `$value['_sort_by']` can be 'not set'. 

## Changelog

```markdown
### Added
Allow `_sort_by` filter to not be initially defined. 
```