### PR TITLE
allow null selection in ChoiceFilter

### DIFF
--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -87,7 +87,7 @@ class ChoiceFilter extends Filter
         }
     }
 
-    private function filterWithSingleValue(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
+    private function filterWithSingleValue(ProxyQueryInterface $queryBuilder, string $alias, string $field, array $data = []): void
     {
         if ('' === $data['value'] || false === $data['value'] || 'all' === $data['value']) {
             return;

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -52,7 +52,7 @@ class ChoiceFilter extends Filter
         ]];
     }
 
-    private function filterWithMultipleValues(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
+    private function filterWithMultipleValues(ProxyQueryInterface $queryBuilder, string $alias, string $field, array $data = []): void
     {
         if (0 === \count($data['value'])) {
             return;

--- a/tests/Filter/QueryBuilder.php
+++ b/tests/Filter/QueryBuilder.php
@@ -120,10 +120,7 @@ class QueryBuilder
         return $queryPart.' IS NULL';
     }
 
-    /**
-     * @param string $queryPart
-     */
-    public function isNotNull($queryPart): string
+    public function isNotNull(string $queryPart): string
     {
         return $queryPart.' IS NOT NULL';
     }

--- a/tests/Filter/QueryBuilder.php
+++ b/tests/Filter/QueryBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
+use Doctrine\ORM\Query\Expr\Andx;
 use Doctrine\ORM\Query\Expr\Orx;
 
 class QueryBuilder
@@ -93,6 +94,11 @@ class QueryBuilder
         return new Orx(\func_get_args());
     }
 
+    public function andX($x = null): Andx
+    {
+        return new Andx(\func_get_args());
+    }
+
     /**
      * @param string $alias
      * @param string $parameter
@@ -112,6 +118,14 @@ class QueryBuilder
     public function isNull($queryPart)
     {
         return $queryPart.' IS NULL';
+    }
+
+    /**
+     * @param string $queryPart
+     */
+    public function isNotNull($queryPart): string
+    {
+        return $queryPart.' IS NOT NULL';
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #991

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- allow null to be selected in ChoiceFilter
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
