### PR TITLE
Add support for simple_array type to TypeGuesser

### DIFF
--- a/src/Guesser/TypeGuesser.php
+++ b/src/Guesser/TypeGuesser.php
@@ -48,6 +48,7 @@ class TypeGuesser extends AbstractTypeGuesser
 
         switch ($metadata->getTypeOfField($propertyName)) {
             case 'array':
+            case 'simple_array':
             case 'json':
             case 'json_array':
                 return new TypeGuess('array', [], Guess::HIGH_CONFIDENCE);

--- a/tests/Guesser/TypeGuesserTest.php
+++ b/tests/Guesser/TypeGuesserTest.php
@@ -120,6 +120,11 @@ class TypeGuesserTest extends TestCase
                 $array,
                 Guess::HIGH_CONFIDENCE,
             ],
+            'simple_array' => [
+                'simple_array',
+                $array,
+                Guess::HIGH_CONFIDENCE,
+            ],
             'json_array' => [
                 'json_array',
                 $array,


### PR DESCRIPTION
## Subject

Doctrine has 4 array types: array, simple_array, json and json_array (see https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/reference/types.html).

TypeGuesser currently only supports array, json and json_array.

This PR adds support for simple_array.

I am targeting this branch, because there is no backwards compatibility issue.

## Changelog

```markdown
### Added
- Added support for guessing the show type of `simple_array` fields.
```
