### PR TITLE
Stop using default _sort_by

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -528,8 +528,6 @@ class ModelManager implements ModelManagerInterface, LockInterface
     public function getDefaultSortValues($class)
     {
         return [
-            '_sort_order' => 'ASC',
-            '_sort_by' => implode(',', $this->getModelIdentifier($class)),
             '_page' => 1,
             '_per_page' => 25,
         ];


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC-break.

Related to https://github.com/sonata-project/SonataAdminBundle/issues/5929#issuecomment-599215849

## Changelog

```markdown
### Removed
- The modelManager getDefaultSortValues does not have default _sort_by value anymore.
```