### PR TITLE
Remove choice filter 'all' special case

### DIFF
--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -57,10 +57,6 @@ class ChoiceFilter extends Filter
             return;
         }
 
-        if (\in_array('all', $data['value'], true)) {
-            return;
-        }
-
         $isNullSelected = \in_array(null, $data['value'], true);
         $data['value'] = array_filter($data['value'], static function ($value): bool {
             return null !== $value;
@@ -88,7 +84,7 @@ class ChoiceFilter extends Filter
 
     private function filterWithSingleValue(ProxyQueryInterface $queryBuilder, string $alias, string $field, array $data = []): void
     {
-        if ('' === $data['value'] || false === $data['value'] || 'all' === $data['value']) {
+        if ('' === $data['value'] || false === $data['value']) {
             return;
         }
 

--- a/tests/Filter/ChoiceFilterTest.php
+++ b/tests/Filter/ChoiceFilterTest.php
@@ -38,7 +38,6 @@ class ChoiceFilterTest extends TestCase
         $builder = new ProxyQuery(new QueryBuilder());
 
         $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', 'all');
         $filter->filter($builder, 'alias', 'field', []);
 
         $this->assertSame([], $builder->query);


### PR DESCRIPTION
## Subject

I am targeting this branch, because unfortunally this is a BC-break.

The `all` special case make no sens to me.
- It's not documented
- I can't filter by the `all` value if I have the `all` value in database.
- It does nothing, it's the same than an empty input.

## Changelog

```markdown
### Removed
- Special case for the `all` value in ChoiceFilter
```

If accepted, I'll make the PR for the other ORM bundle.