### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4",
-        "sonata-project/admin-bundle": "^3.61",
-        "sonata-project/core-bundle": "^3.14",
+        "sonata-project/admin-bundle": "^3.63 || ^4.0",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "symfony/config": "^4.4",
         "symfony/console": "^4.4",
@@ -50,7 +49,7 @@
     },
     "require-dev": {
         "simplethings/entity-audit-bundle": "^0.9 || ^1.0",
-        "sonata-project/block-bundle": "^3.17",
+        "sonata-project/block-bundle": "^3.18 || ^4.0",
         "symfony/phpunit-bridge": "^5.0"
     },
     "suggest": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Allow using SonataAdminBundle 4.x

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because SonataAdminBundlle 4.x is in dev.

Or should I add it in 3.x branch? SonataCoreBundle should avoid install this bundle 4.x (next major) with SonataAdminBundle 3.x.