### PR TITLE
Remove dependency for "sonata-project/core-bundle"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4",
         "sonata-project/admin-bundle": "^3.61",
-        "sonata-project/core-bundle": "^3.14",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "symfony/config": "^4.4",
         "symfony/console": "^4.4",

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -23,8 +23,6 @@ use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\AdminBundle\Form\Type\ModelTypeList;
-use Sonata\CoreBundle\Form\Type\CollectionType as DeprecatedCollectionType;
-use Sonata\Form\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -149,12 +147,13 @@ class FormContractor implements FormContractorInterface
                 ClassMetadata::ONE_TO_ONE,
                 ClassMetadata::MANY_TO_ONE,
             ], true)) {
+                // NEXT_MAJOR: Import the class from "sonata-project/form-extensions" and use `CollectionType::class` instead.
                 throw new \RuntimeException(sprintf(
                     'You are trying to add `%s` field `%s` which is not One-To-One or  Many-To-One.'
                     .' Maybe you want `%s` instead?',
                     AdminType::class,
                     $fieldDescription->getName(),
-                    CollectionType::class
+                    'Sonata\Form\Type\CollectionType'
                 ));
             }
 
@@ -167,8 +166,8 @@ class FormContractor implements FormContractorInterface
                 return $fieldDescription->getAssociationAdmin()->getNewInstance();
             };
             $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
-        // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony 2.8
-        } elseif ('sonata_type_collection' === $type || $this->checkFormClass($type, [CollectionType::class, DeprecatedCollectionType::class])) {
+        // NEXT_MAJOR: Import the class from "sonata-project/form-extensions" and only check against `Sonata\Form\Type\CollectionType` when dropping support for Symfony 2.8
+        } elseif ('sonata_type_collection' === $type || $this->checkFormClass($type, ['Sonata\Form\Type\CollectionType', 'Sonata\CoreBundle\Form\Type\CollectionType'])) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf(
                     'The current field `%s` is not linked to an admin.'
@@ -192,10 +191,7 @@ class FormContractor implements FormContractorInterface
         return $options;
     }
 
-    /**
-     * @return bool
-     */
-    private function hasAssociation(FieldDescriptionInterface $fieldDescription)
+    private function hasAssociation(FieldDescriptionInterface $fieldDescription): bool
     {
         return \in_array($fieldDescription->getMappingType(), [
             ClassMetadata::ONE_TO_MANY,
@@ -205,15 +201,9 @@ class FormContractor implements FormContractorInterface
         ], true);
     }
 
-    /**
-     * @param string $type
-     * @param array  $classes
-     *
-     * @return array
-     */
-    private function checkFormClass($type, $classes)
+    private function checkFormClass(string $type, array $classes): array
     {
-        return array_filter($classes, static function ($subclass) use ($type) {
+        return array_filter($classes, static function (string $subclass) use ($type): bool {
             return is_a($type, $subclass, true);
         });
     }

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -15,11 +15,21 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
-use Sonata\Form\Type\BooleanType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class BooleanFilter extends Filter
 {
+    /**
+     * NEXT_MAJOR: Remove this constant and use `Sonata\Form\Type\BooleanType::TYPE_YES`
+     * from "sonata-project/form-extensions" instead.
+     */
+    private const BOOLEAN_TYPE_YES = 1;
+    /**
+     * NEXT_MAJOR: Remove this constant and use `Sonata\Form\Type\BooleanType::TYPE_NO`
+     * from "sonata-project/form-extensions" instead.
+     */
+    private const BOOLEAN_TYPE_NO = 2;
+
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
         if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {
@@ -29,11 +39,11 @@ class BooleanFilter extends Filter
         if (\is_array($data['value'])) {
             $values = [];
             foreach ($data['value'] as $v) {
-                if (!\in_array($v, [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
+                if (!\in_array($v, [self::BOOLEAN_TYPE_NO, self::BOOLEAN_TYPE_YES], true)) {
                     continue;
                 }
 
-                $values[] = (BooleanType::TYPE_YES === $v) ? 1 : 0;
+                $values[] = (self::BOOLEAN_TYPE_YES === $v) ? 1 : 0;
             }
 
             if (0 === \count($values)) {
@@ -42,13 +52,13 @@ class BooleanFilter extends Filter
 
             $this->applyWhere($queryBuilder, $queryBuilder->expr()->in(sprintf('%s.%s', $alias, $field), $values));
         } else {
-            if (!\in_array($data['value'], [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
+            if (!\in_array($data['value'], [self::BOOLEAN_TYPE_NO, self::BOOLEAN_TYPE_YES], true)) {
                 return;
             }
 
             $parameterName = $this->getNewParameterName($queryBuilder);
             $this->applyWhere($queryBuilder, sprintf('%s.%s = :%s', $alias, $field, $parameterName));
-            $queryBuilder->setParameter($parameterName, (BooleanType::TYPE_YES === $data['value']) ? 1 : 0);
+            $queryBuilder->setParameter($parameterName, (self::BOOLEAN_TYPE_YES === $data['value']) ? 1 : 0);
         }
     }
 

--- a/src/Filter/DateRangeFilter.php
+++ b/src/Filter/DateRangeFilter.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Sonata\Form\Type\DateRangeType;
-
 class DateRangeFilter extends AbstractDateFilter
 {
     /**
@@ -33,6 +31,7 @@ class DateRangeFilter extends AbstractDateFilter
 
     public function getFieldType()
     {
-        return $this->getOption('field_type', DateRangeType::class);
+        // NEXT_MAJOR: Import the class from "sonata-project/form-extensions" and use `DateRangeType::class` instead.
+        return $this->getOption('field_type', 'Sonata\Form\Type\DateRangeType');
     }
 }

--- a/src/Filter/DateTimeRangeFilter.php
+++ b/src/Filter/DateTimeRangeFilter.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Sonata\Form\Type\DateTimeRangeType;
-
 class DateTimeRangeFilter extends AbstractDateFilter
 {
     /**
@@ -33,6 +31,7 @@ class DateTimeRangeFilter extends AbstractDateFilter
 
     public function getFieldType()
     {
-        return $this->getOption('field_type', DateTimeRangeType::class);
+        // NEXT_MAJOR: Import the class from "sonata-project/form-extensions" and use `DateTimeRangeType::class` instead.
+        return $this->getOption('field_type', 'Sonata\Form\Type\DateTimeRangeType');
     }
 }

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -24,7 +24,6 @@ use Sonata\DoctrineORMAdminBundle\Filter\NumberFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\TimeFilter;
 use Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException;
-use Sonata\Form\Type\BooleanType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
@@ -80,7 +79,8 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
         switch ($metadata->getTypeOfField($propertyName)) {
             case 'boolean':
-                $options['field_type'] = BooleanType::class;
+                // NEXT_MAJOR: Import the class from "sonata-project/form-extensions" and use `BooleanType::class` instead.
+                $options['field_type'] = 'Sonata\Form\Type\BooleanType';
 
                 return new TypeGuess(BooleanFilter::class, $options, Guess::HIGH_CONFIDENCE);
             case 'datetime':

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -23,7 +23,6 @@ use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\CoreBundle\Form\Type\CollectionType as DeprecatedCollectionType;
 use Sonata\DoctrineORMAdminBundle\Builder\FormContractor;
 use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Sonata\Form\Type\CollectionType;
@@ -93,9 +92,10 @@ final class FormContractorTest extends TestCase
             'sonata_type_admin',
             AdminType::class,
         ];
+        // NEXT_MAJOR: Import the class from "sonata-project/form-extensions" and use `CollectionType::class` instead.
         $collectionTypes = [
             'sonata_type_collection',
-            DeprecatedCollectionType::class,
+            'Sonata\CoreBundle\Form\Type\CollectionType',
             CollectionType::class,
         ];
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Remove dependency for "sonata-project/core-bundle".

Occurrences of "Sonata\\CoreBundle\\" and "Sonata\\Form\\" in this package are used just to get class names, so I've replaced them with hardcoded strings.
The dependency is yet present because "sonata-project/admin-bundle" and "sonata-project/block-bundle".
```
composer why sonata-project/core-bundle
sonata-project/admin-bundle  3.45.1  requires  sonata-project/core-bundle (^3.14.0)  
sonata-project/block-bundle  3.14.0  requires  sonata-project/core-bundle (^3.13.7)  
```

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed dependency against "sonata-project/core-bundle".
```
## To do
    
- [x] Check if there is a service or something else provided by "sonata-project/core-bundle".