### PR TITLE
Remove some NEXT_MAJOR in stable branch !

### DIFF
--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -99,13 +99,7 @@ class FormContractor implements FormContractorInterface
         $options = [];
         $options['sonata_field_description'] = $fieldDescription;
 
-        // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony 2.8
-        if (\in_array($type, [
-            'sonata_type_model',
-            'sonata_type_model_list',
-            'sonata_type_model_hidden',
-            'sonata_type_model_autocomplete',
-        ], true) || $this->checkFormClass($type, [
+        if ($this->checkFormClass($type, [
             ModelType::class,
             ModelTypeList::class,
             ModelListType::class,
@@ -123,8 +117,7 @@ class FormContractor implements FormContractorInterface
             $options['class'] = $fieldDescription->getTargetEntity();
             $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
 
-            // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony 2.8
-            if ('sonata_type_model_autocomplete' === $type || $this->checkFormClass($type, [ModelAutocompleteType::class])) {
+            if ($this->checkFormClass($type, [ModelAutocompleteType::class])) {
                 if (!$fieldDescription->getAssociationAdmin()) {
                     throw new \RuntimeException(sprintf(
                         'The current field `%s` is not linked to an admin.'
@@ -134,8 +127,7 @@ class FormContractor implements FormContractorInterface
                     ));
                 }
             }
-            // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony 2.8
-        } elseif ('sonata_type_admin' === $type || $this->checkFormClass($type, [AdminType::class])) {
+        } elseif ($this->checkFormClass($type, [AdminType::class])) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf(
                     'The current field `%s` is not linked to an admin.'
@@ -167,8 +159,7 @@ class FormContractor implements FormContractorInterface
                 return $fieldDescription->getAssociationAdmin()->getNewInstance();
             };
             $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
-        // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony 2.8
-        } elseif ('sonata_type_collection' === $type || $this->checkFormClass($type, [CollectionType::class, DeprecatedCollectionType::class])) {
+        } elseif ($this->checkFormClass($type, [CollectionType::class, DeprecatedCollectionType::class])) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf(
                     'The current field `%s` is not linked to an admin.'

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -36,7 +37,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 final class FormContractorTest extends TestCase
 {
     /**
-     * @var FormFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var FormFactoryInterface|MockObject
      */
     private $formFactory;
 
@@ -80,21 +81,15 @@ final class FormContractorTest extends TestCase
         $admin->method('getNewInstance')->willReturn($model);
 
         $modelTypes = [
-            'sonata_type_model',
-            'sonata_type_model_list',
-            'sonata_type_model_hidden',
-            'sonata_type_model_autocomplete',
             ModelType::class,
             ModelListType::class,
             ModelHiddenType::class,
             ModelAutocompleteType::class,
         ];
         $adminTypes = [
-            'sonata_type_admin',
             AdminType::class,
         ];
         $collectionTypes = [
-            'sonata_type_collection',
             DeprecatedCollectionType::class,
             CollectionType::class,
         ];

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -30,6 +30,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\Datagrid;
@@ -281,7 +282,7 @@ class ModelManagerTest extends TestCase
 
         $em = $this->createMock(EntityManager::class);
 
-        /** @var \PHPUnit_Framework_MockObject_MockObject|ModelManager $modelManager */
+        /** @var MockObject|ModelManager $modelManager */
         $modelManager = $this->getMockBuilder($modelManagerClass)
             ->disableOriginalConstructor()
             ->setMethods(['getMetadata', 'getEntityManager'])


### PR DESCRIPTION
## Subject

I am targeting this branch, because since Sf2.8 is dropped, it's BC.

## Changelog

```markdown
### Removed
Code used for 2.8 symfony support
```