### PR TITLE
Save extra processing at `Pager::countCompositePrimaryKey()`

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -95,20 +95,13 @@ class Pager extends BasePager
     {
         $rootAliases = current($countQuery->getRootAliases());
         $countQuery->setParameter('concat_separator', self::CONCAT_SEPARATOR);
-        $columns = [];
 
-        foreach ($this->getCountColumn() as $column) {
-            if ($columns) {
-                $columns[] = ':concat_separator';
-            }
-
-            $columns[] = sprintf('%s.%s', $rootAliases, $column);
-        }
+        $columns = $rootAliases.'.'.implode(', :concat_separator, '.$rootAliases.'.', $this->getCountColumn());
 
         $countQuery->select(sprintf(
             'count(%s concat(%s)) as cnt',
             $countQuery instanceof ProxyQuery && !$countQuery->isDistinct() ? null : 'DISTINCT',
-            implode(', ', $columns)
+            $columns
         ));
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Save extra processing at `Pager::countCompositePrimaryKey()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #996.