### PR TITLE
Add support for SonataBlockBundle 4.x

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,13 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =========================
 
+### Compatibility with SonataBlockBundle 4.0
+
+We added compatibility with SonataBlockBundle 4.0, make sure you are explicitly declaring your dependency
+with `sonata-project/block-bundle` in your composer.json in order to avoid unwanted upgrades.
+
+There is a minimal BC Break on `AuditBlockService`. If you are extending this class (keep in mind that it will become final on 4.0) you should add return type hints to `execute()` and `configureSettings()`.
+
 ### Sonata\DoctrineORMAdminBundle\Model\ModelManager
 
 Deprecated `camelize()` method with no replacement.

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "require-dev": {
         "simplethings/entity-audit-bundle": "^0.9 || ^1.0",
-        "sonata-project/block-bundle": "^3.17",
+        "sonata-project/block-bundle": "^3.17 || ^4.0",
         "symfony/phpunit-bridge": "^5.0"
     },
     "suggest": {

--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -24,6 +24,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Twig\Environment;
 
 /**
+ * @final since sonata-project/doctrine-orm-admin-bundle 3.x
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AuditBlockService extends AbstractBlockService
@@ -92,7 +94,7 @@ class AuditBlockService extends AbstractBlockService
         }
     }
 
-    public function execute(BlockContextInterface $blockContext, ?Response $response = null)
+    public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {
         $revisions = [];
 
@@ -119,7 +121,7 @@ class AuditBlockService extends AbstractBlockService
         return 'Audit List';
     }
 
-    public function configureSettings(OptionsResolver $resolver)
+    public function configureSettings(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'limit' => 10,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change have to be in 3.x - see https://github.com/sonata-project/SonataAdminBundle/pull/6212.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add support for SonataBlockBundle 4.0
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
