### PR TITLE
Add explicit `null` return values at `ModelManager::getNormalizedIdentifier()`

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -216,7 +216,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $metadata = $this->getMetadata(ClassUtils::getClass($object));
 
         if (!$metadata->isVersioned) {
-            return;
+            return null;
         }
 
         return $metadata->reflFields[$metadata->versionField]->getValue($object);
@@ -241,7 +241,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     public function find($class, $id)
     {
         if (!isset($id)) {
-            return;
+            return null;
         }
 
         $values = array_combine($this->getIdentifierFieldNames($class), explode(self::ID_SEPARATOR, (string) $id));
@@ -370,20 +370,20 @@ class ModelManager implements ModelManagerInterface, LockInterface
         }
 
         if (!$entity) {
-            return;
+            return null;
         }
 
         if (\in_array($this->getEntityManager($entity)->getUnitOfWork()->getEntityState($entity), [
             UnitOfWork::STATE_NEW,
             UnitOfWork::STATE_REMOVED,
         ], true)) {
-            return;
+            return null;
         }
 
         $values = $this->getIdentifierValues($entity);
 
         if (0 === \count($values)) {
-            return;
+            return null;
         }
 
         return implode(self::ID_SEPARATOR, $values);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add explicit `null` return values at `ModelManager::getNormalizedIdentifier()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed returning `void` in `ModelManager::getNormalizedIdentifier()`, which is intended to return a value or `null`.
```