### PR TITLE
Deprecate getModelIdentifier

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -314,6 +314,11 @@ class ModelManager implements ModelManagerInterface, LockInterface
         return $query->execute();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this function.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x. To be removed in 4.0.
+     */
     public function getModelIdentifier($class)
     {
         return $this->getMetadata($class)->identifier;


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog

```markdown
### Deprecated
- Deprecate `getModelIdentifier` from `ModelManager`
```