### PR TITLE
Fix a link to Doctrine documentation site

### DIFF
--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -79,7 +79,7 @@ class FieldDescription extends BaseFieldDescription
 
         $fieldMapping = $this->getFieldMapping();
         // Support embedded object for mapping
-        // Ref: http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/tutorials/embeddables.html
+        // Ref: https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html
         if (isset($fieldMapping['declaredField'])) {
             $parentFields = explode('.', $fieldMapping['declaredField']);
             foreach ($parentFields as $parentField) {


### PR DESCRIPTION
## Subject

FieldDescription.php contained an outdated link to a Doctrine documentation page.

I am targeting this branch, because it's a comment.