### PR TITLE
Fix type check at `ModelManager::getNormalizedIdentifier()`

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -370,12 +370,12 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
     public function getNormalizedIdentifier($entity)
     {
-        if (is_scalar($entity)) {
-            throw new \RuntimeException('Invalid argument, object or null required');
+        if (null === $entity) {
+            return null;
         }
 
-        if (!$entity) {
-            return null;
+        if (!\is_object($entity)) {
+            throw new \RuntimeException('Invalid argument, object or null required');
         }
 
         if (\in_array($this->getEntityManager($entity)->getUnitOfWork()->getEntityState($entity), [

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -946,7 +946,12 @@ class ModelManagerTest extends TestCase
         $this->assertNull($model->find('notImportant', null));
     }
 
-    public function testGetUrlsafeIdentifierException(): void
+    /**
+     * @dataProvider getWrongEntities
+     *
+     * @param mixed $entity
+     */
+    public function testNormalizedIdentifierException($entity): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
 
@@ -954,7 +959,18 @@ class ModelManagerTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
 
-        $model->getNormalizedIdentifier('test');
+        $model->getNormalizedIdentifier($entity);
+    }
+
+    public function getWrongEntities(): iterable
+    {
+        yield [0];
+        yield [1];
+        yield [false];
+        yield [true];
+        yield [[]];
+        yield [''];
+        yield ['sonata-project'];
     }
 
     public function testGetUrlsafeIdentifierNull(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix type check at `ModelManager::getNormalizedIdentifier()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed weak check at `ModelManager::getNormalizedIdentifier()`.
```