### PR TITLE
Fix typo in AbstractDateFilter which can lead to exceptions

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -131,7 +131,7 @@ abstract class AbstractDateFilter extends Filter
             $parameterName = $this->getNewParameterName($queryBuilder);
 
             // date filter should filter records for the whole day
-            if (false === $this->time && DateRangeOperatorType::TYPE_EQUAL === $data['type']) {
+            if (false === $this->time && DateOperatorType::TYPE_EQUAL === $data['type']) {
                 $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, '>=', $parameterName));
                 $queryBuilder->setParameter($parameterName, $data['value']);
 

--- a/tests/Filter/DateFilterTest.php
+++ b/tests/Filter/DateFilterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Filter\DateFilter;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+
+/**
+ * @author Ennio Wolsink <ennio@rimote.nl>
+ */
+class DateFilterTest extends TestCase
+{
+    public function testEmpty(): void
+    {
+        $filter = new DateFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $filter->filter($builder, 'alias', 'field', null);
+        $filter->filter($builder, 'alias', 'field', '');
+
+        $this->assertSame([], $builder->query);
+        $this->assertFalse($filter->isActive());
+    }
+
+    public function testGetType(): void
+    {
+        $this->assertSame(DateType::class, (new DateFilter())->getFieldType());
+    }
+
+    public function testFilterRecordsWholeDay(): void
+    {
+        $filter = new DateFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $filter->filter($builder, 'alias', 'field', ['value' => new \DateTime()]);
+
+        $this->assertCount(2, $builder->parameters);
+        $this->assertCount(2, $builder->query);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Fix typo in AbstractDateFilter which can lead to exceptions

v3.15 introduced a bug because of a typo in AbstractDateFilter, referencing Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType::TYPE_EQUAL, where it should have been Sonata\AdminBundle\Form\Type\Operator\DateOperatorType::TYPE_EQUAL.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this bug has been recently introduced in 3.15 and affects everyone downloading the latest version of Sonata.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Typo in AbstractDateFilter, DateRangeOperatorType::TYPE_EQUAL should have been DateOperatorType::TYPE_EQUAL.

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
