### PR TITLE
Add getDefaultPerPageOptions

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -542,6 +542,11 @@ class ModelManager implements ModelManagerInterface, LockInterface
         ];
     }
 
+    public function getDefaultPerPageOptions(string $class): array
+    {
+        return [10, 25, 50, 100, 250];
+    }
+
     public function modelTransform($class, $instance)
     {
         return $instance;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Related to https://github.com/sonata-project/SonataAdminBundle/pull/6069

This will allow the ModelManager to respect the 4.0 interface.

I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ModelManager::getDefaultPerPageOptions`
```