### PR TITLE
Symfony 5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ matrix:
     - php: '7.3'
       env: SYMFONY='dev-master as 4.4.x-dev'
     - php: '7.3'
-      env: SONATA_ADMIN=3.*
-    - php: '7.3'
       env: SONATA_ADMIN='dev-master as 3.x-dev'
     - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
 language: php
 
 php:
-  - '7.2'
   - '7.3'
   - '7.4'
   - nightly
@@ -30,8 +29,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: '7.2'
-      env: COMPOSER_FLAGS="--prefer-lowest"
     - php: '7.3'
       env: SYMFONY=4.4.*
     - php: '7.3'

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,6 @@
             "homepage": "https://github.com/sonata-project/SonataDoctrineORMAdminBundle/contributors"
         }
     ],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/mathieupetrini/SonataAdminBundle.git"
-        }
-    ],
     "require": {
         "php": "^7.2",
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
@@ -50,6 +44,12 @@
         "symfony/options-resolver": "^4.4 || ^5.0",
         "symfony/security-acl": "^3.0"
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/mathieupetrini/SonataAdminBundle.git"
+        }
+    ],
     "conflict": {
         "simplethings/entity-audit-bundle": ">=2.0",
         "sonata-project/block-bundle": "<3.11"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^7.3,
+        "php": "^7.3",
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3,
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4",

--- a/composer.json
+++ b/composer.json
@@ -22,23 +22,32 @@
             "homepage": "https://github.com/sonata-project/SonataDoctrineORMAdminBundle/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/mathieupetrini/SonataAdminBundle.git"
+        }
+    ],
     "require": {
         "php": "^7.2",
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4",
-        "sonata-project/admin-bundle": "^3.63",
-        "sonata-project/core-bundle": "^3.14",
+        "sonata-project/admin-bundle": "dev-master",
+        "sonata-project/block-bundle": "^4.2",
+        "sonata-project/doctrine-extensions": "^1.6",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
-        "symfony/config": "^4.4",
-        "symfony/console": "^4.4",
-        "symfony/dependency-injection": "^4.4",
-        "symfony/doctrine-bridge": "^4.4",
-        "symfony/form": "^4.4",
-        "symfony/framework-bundle": "^4.4",
-        "symfony/http-foundation": "^4.4",
-        "symfony/http-kernel": "^4.4",
-        "symfony/options-resolver": "^4.4",
+        "sonata-project/form-extensions": "^1.3",
+        "sonata-project/twig-extensions": "^1.2",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/console": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/doctrine-bridge": "^4.4 || ^5.0",
+        "symfony/form": "^4.4 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/http-foundation": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/options-resolver": "^4.4 || ^5.0",
         "symfony/security-acl": "^3.0"
     },
     "conflict": {
@@ -50,7 +59,6 @@
     },
     "require-dev": {
         "simplethings/entity-audit-bundle": "^0.9 || ^1.0",
-        "sonata-project/block-bundle": "^3.17",
         "symfony/phpunit-bridge": "^5.0"
     },
     "suggest": {

--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -18,9 +18,10 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -32,17 +33,14 @@ class AuditBlockService extends AbstractBlockService
      */
     protected $auditReader;
 
-    /**
-     * @param string $name
-     */
-    public function __construct($name, EngineInterface $templating, AuditReader $auditReader)
+    public function __construct(Environment $templating, AuditReader $auditReader)
     {
-        parent::__construct($name, $templating);
+        parent::__construct($templating);
 
         $this->auditReader = $auditReader;
     }
 
-    public function execute(BlockContextInterface $blockContext, ?Response $response = null)
+    public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {
         $revisions = [];
 

--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -20,7 +20,6 @@ use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Templating\EngineInterface;
 use Twig\Environment;
 
 /**

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -22,8 +22,6 @@ use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
-use Sonata\AdminBundle\Form\Type\ModelTypeList;
-use Sonata\CoreBundle\Form\Type\CollectionType as DeprecatedCollectionType;
 use Sonata\Form\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -101,7 +99,6 @@ class FormContractor implements FormContractorInterface
 
         if ($this->checkFormClass($type, [
             ModelType::class,
-            ModelTypeList::class,
             ModelListType::class,
             ModelHiddenType::class,
             ModelAutocompleteType::class,
@@ -159,7 +156,7 @@ class FormContractor implements FormContractorInterface
                 return $fieldDescription->getAssociationAdmin()->getNewInstance();
             };
             $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
-        } elseif ($this->checkFormClass($type, [CollectionType::class, DeprecatedCollectionType::class])) {
+        } elseif ($this->checkFormClass($type, [CollectionType::class])) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf(
                     'The current field `%s` is not linked to an admin.'

--- a/tests/Block/AuditBlockServiceTest.php
+++ b/tests/Block/AuditBlockServiceTest.php
@@ -13,18 +13,14 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Block;
 
-use Prophecy\Argument;
 use SimpleThings\EntityAudit\AuditReader as SimpleThingsAuditReader;
-use SimpleThings\EntityAudit\Revision;
-use Sonata\BlockBundle\Block\BlockContext;
-use Sonata\BlockBundle\Model\Block;
-use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\DoctrineORMAdminBundle\Block\AuditBlockService;
 
 /**
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */
-class AuditBlockServiceTest extends AbstractBlockServiceTestCase
+class AuditBlockServiceTest extends BlockServiceTestCase
 {
     private $simpleThingsAuditReader;
     private $blockService;
@@ -35,39 +31,9 @@ class AuditBlockServiceTest extends AbstractBlockServiceTestCase
         $this->simpleThingsAuditReader = $this->prophesize(SimpleThingsAuditReader::class);
 
         $this->blockService = new AuditBlockService(
-            'block.service',
-            $this->templating,
+            $this->twig,
             $this->simpleThingsAuditReader->reveal()
         );
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testExecute(): void
-    {
-        $blockContext = $this->prophesize(BlockContext::class);
-
-        $blockContext->getBlock()->willReturn($block = new Block())->shouldBeCalledTimes(1);
-        $blockContext->getSetting('limit')->willReturn($limit = 10)->shouldBeCalledTimes(1);
-
-        $this->simpleThingsAuditReader->findRevisionHistory($limit, 0)
-            ->willReturn([$revision = new Revision('test', '123', 'test')])
-            ->shouldBeCalledTimes(1);
-
-        $this->simpleThingsAuditReader->findEntitiesChangedAtRevision(Argument::cetera())
-            ->willReturn([])
-            ->shouldBeCalledTimes(1);
-
-        $blockContext->getTemplate()->willReturn('template')->shouldBeCalledTimes(1);
-        $blockContext->getSettings()->willReturn([])->shouldBeCalledTimes(1);
-
-        $this->blockService->execute($blockContext->reveal());
-
-        $this->assertSame('template', $this->templating->view);
-        $this->assertIsArray($this->templating->parameters['settings']);
-        $this->assertSame($revision, $this->templating->parameters['revisions'][0]['revision']);
-        $this->assertSame($block, $this->templating->parameters['block']);
     }
 
     public function testDefaultSettings(): void

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -67,8 +67,8 @@ final class DatagridBuilderTest extends TestCase
 
         $this->admin->getClass()->willReturn('FakeClass');
         $this->admin->getModelManager()->willReturn($this->modelManager->reveal());
-        $this->admin->attachAdminClass(Argument::cetera())->willReturn();
-        $this->admin->addFilterFieldDescription(Argument::cetera())->willReturn();
+        $this->admin->attachAdminClass(Argument::cetera());
+        $this->admin->addFilterFieldDescription(Argument::cetera());
     }
 
     /**

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -24,7 +24,6 @@ use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\CoreBundle\Form\Type\CollectionType as DeprecatedCollectionType;
 use Sonata\DoctrineORMAdminBundle\Builder\FormContractor;
 use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Sonata\Form\Type\CollectionType;

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -90,7 +90,6 @@ final class FormContractorTest extends TestCase
             AdminType::class,
         ];
         $collectionTypes = [
-            DeprecatedCollectionType::class,
             CollectionType::class,
         ];
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -107,7 +107,7 @@ class ModelManagerTest extends TestCase
         $entityManager->method('getMetadataFactory')->willReturn($classMetadataFactory);
         $entityManager->method('getConnection')->willReturn($connection);
 
-        $registry = $this->createMock(RegistryInterface::class);
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->method('getManagerForClass')->willReturn($entityManager);
 
         $manager = new ModelManager($registry);
@@ -116,20 +116,6 @@ class ModelManagerTest extends TestCase
             ['a7ef873a-e7b5-11e9-81b4-2a2ae2dbcce4'],
             $manager->getIdentifierValues($entity)
         );
-    }
-
-    public function testInstantiateWithDeprecatedRegistryInterface(): void
-    {
-        $registry = $this->createMock(RegistryInterface::class);
-        $manager = new ModelManager($registry);
-        $em = $this->createMock(EntityManagerInterface::class);
-
-        $registry->expects($this->once())
-            ->method('getManagerForClass')
-            ->with('x')
-            ->willReturn($em)
-        ;
-        $this->assertSame($em, $manager->getEntityManager('x'));
     }
 
     public function testSortParameters(): void
@@ -646,7 +632,7 @@ class ModelManagerTest extends TestCase
             ->method('getQuery')
             ->willReturn($proxyQuery);
 
-        $registry = $this->getMockBuilder(RegistryInterface::class)->getMock();
+        $registry = $this->getMockBuilder(ManagerRegistry::class)->getMock();
         $manager = new ModelManager($registry);
         $manager->getDataSourceIterator($datagrid, []);
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -21,7 +21,6 @@ use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -59,7 +58,6 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidBinaryEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\VersionedEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class ModelManagerTest extends TestCase
 {


### PR DESCRIPTION
## Subject

Symfony 5.0 Compatibility

I am targeting this branch, because Symfony 5.0 BC.

## Changelog

```markdown
### Added
- Symfony 5.0 compatiblity

### Changed
- Bump to PHP 7.3

### Removed
- SonataAdminBundle 3.0 support
```