### PR TITLE
Default to lastPage when pager is looking for a non-existent page

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -72,19 +72,20 @@ class Pager extends BasePager
 
         $this->setNbResults($this->computeNbResult());
 
-        $this->getQuery()->setFirstResult(null);
-        $this->getQuery()->setMaxResults(null);
-
         if (\count($this->getParameters()) > 0) {
             $this->getQuery()->setParameters($this->getParameters());
         }
 
         if (0 === $this->getPage() || 0 === $this->getMaxPerPage() || 0 === $this->getNbResults()) {
             $this->setLastPage(0);
+            $this->getQuery()->setFirstResult(null);
+            $this->getQuery()->setMaxResults(null);
         } else {
-            $offset = ($this->getPage() - 1) * $this->getMaxPerPage();
-
             $this->setLastPage((int) ceil($this->getNbResults() / $this->getMaxPerPage()));
+
+            // Offset should be computed after we set the last page
+            // because the setLastPage method can modify the getPage return value
+            $offset = ($this->getPage() - 1) * $this->getMaxPerPage();
 
             $this->getQuery()->setFirstResult($offset);
             $this->getQuery()->setMaxResults($this->getMaxPerPage());

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -100,4 +100,34 @@ class PagerTest extends TestCase
         $pager->setQuery($proxyQuery);
         $pager->computeNbResult();
     }
+
+    /**
+     * @dataProvider initDataProvider
+     */
+    public function testInit(int $computedNbResult, int $page, int $expectedFirstResult): void
+    {
+        $query = $this->createMock(ProxyQuery::class);
+        $pager = $this->createPartialMock(Pager::class, ['computeNbResult']);
+
+        $pager->method('computeNbResult')->willReturn($computedNbResult);
+
+        $pager->setMaxPerPage(10);
+        $pager->setPage($page);
+        $pager->setQuery($query);
+
+        $query->expects($this->once())->method('setFirstResult')->with($expectedFirstResult);
+        $query->expects($this->once())->method('setMaxResults')->with(10);
+
+        $pager->init();
+    }
+
+    public function initDataProvider(): iterable
+    {
+        return [
+            [50, 3, 20],
+            [50, 10, 40],
+            [15, 3, 10],
+            [15, 1, 0],
+        ];
+    }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Closes https://github.com/sonata-project/SonataAdminBundle/issues/6090

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- When looking for a non-existent page in the listAdmin, the datagrid is now displaying the last page instead of displaying a "No result found".
```