### PR TITLE
Remove Twig deprecated syntax `for..if`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
         "symfony/options-resolver": "^4.4",
-        "symfony/security-acl": "^3.0"
+        "symfony/security-acl": "^3.0",
+        "twig/twig": "^1.41 || ^2.10"
     },
     "conflict": {
         "simplethings/entity-audit-bundle": ">=2.0",

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
                         >
                             <fieldset>
                                 <div class="sonata-ba-collapsed-fields">
-                                    {% for field_name in form_group.fields if nested_group_field.children[field_name] is defined %}
+                                    {% for field_name in form_group.fields|filter(v => nested_group_field.children[v] is defined) %}
                                         {% set nested_field = nested_group_field.children[field_name] %}
                                         <div class="sonata-ba-field-{{ id }}-{{ field_name }}">
                                             {% if associationAdmin.formfielddescriptions[field_name] is defined %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Remove Twig deprecated syntax `for..if`.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added direct dependency against "twig/twig".
### Fixed
- Fixed usage of deprecated Twig syntax `for..if`.

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
