### PR TITLE
Add some deprecations about invalid values

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,11 +1,24 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Sonata\DoctrineORMAdminBundle\Admin\FieldDescription
+
+Deprecated `getTargetEntity()`, use `getTargetModel()` instead.
+
+### Sonata\DoctrineORMAdminBundle\Model\ModelManager
+
+Deprecated passing `null` as argument 2 for `find()`.
+Deprecated passing `null` or an object which is in state new or removed as argument 1 for `getNormalizedIdentifier()`.
+Deprecated passing `null` as argument 1 for `getUrlSafeIdentifier()`.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -35,11 +35,33 @@ class FieldDescription extends BaseFieldDescription
         $this->fieldName = $associationMapping['fieldName'];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0. Use FieldDescription::getTargetModel() instead.
+     */
     public function getTargetEntity()
+    {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.'
+            .' Use %s::getTargetModel() instead.',
+            __METHOD__,
+            __CLASS__
+        ), E_USER_DEPRECATED);
+
+        return $this->getTargetModel();
+    }
+
+    /**
+     * @final since sonata-project/doctrine-orm-admin-bundle 3.x.
+     */
+    public function getTargetModel(): ?string
     {
         if ($this->associationMapping) {
             return $this->associationMapping['targetEntity'];
         }
+
+        return null;
     }
 
     public function setFieldMapping($fieldMapping)

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -158,7 +158,7 @@ class DatagridBuilder implements DatagridBuilderInterface
 
         if (ModelAutocompleteFilter::class === $type) {
             $fieldDescription->mergeOption('field_options', [
-                'class' => $fieldDescription->getTargetEntity(),
+                'class' => $fieldDescription->getTargetModel(),
                 'model_manager' => $fieldDescription->getAdmin()->getModelManager(),
                 'admin_code' => $admin->getCode(),
                 'context' => 'filter',

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -113,7 +113,7 @@ class FormContractor implements FormContractorInterface
                 ));
             }
 
-            $options['class'] = $fieldDescription->getTargetEntity();
+            $options['class'] = $fieldDescription->getTargetModel();
             $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
 
             if ($this->checkFormClass($type, [ModelAutocompleteType::class])) {
@@ -122,7 +122,7 @@ class FormContractor implements FormContractorInterface
                         'The current field `%s` is not linked to an admin.'
                         .' Please create one for the target entity: `%s`',
                         $fieldDescription->getName(),
-                        $fieldDescription->getTargetEntity()
+                        $fieldDescription->getTargetModel()
                     ));
                 }
             }
@@ -132,7 +132,7 @@ class FormContractor implements FormContractorInterface
                     'The current field `%s` is not linked to an admin.'
                     .' Please create one for the target entity : `%s`',
                     $fieldDescription->getName(),
-                    $fieldDescription->getTargetEntity()
+                    $fieldDescription->getTargetModel()
                 ));
             }
 
@@ -165,7 +165,7 @@ class FormContractor implements FormContractorInterface
                     'The current field `%s` is not linked to an admin.'
                     .' Please create one for the target entity : `%s`',
                     $fieldDescription->getName(),
-                    $fieldDescription->getTargetEntity()
+                    $fieldDescription->getTargetModel()
                 ));
             }
 

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -240,7 +240,12 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
     public function find($class, $id)
     {
-        if (!isset($id)) {
+        if (null === $id) {
+            @trigger_error(sprintf(
+                'Passing null as argument 1 for %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be not allowed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
             return null;
         }
 
@@ -260,7 +265,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     }
 
     /**
-     * @param string $class
+     * @param string|object $class
      *
      * @return EntityManager
      */
@@ -370,7 +375,13 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
     public function getNormalizedIdentifier($entity)
     {
+        // NEXT_MAJOR: Remove the following 2 checks and declare "object" as type for argument 1.
         if (null === $entity) {
+            @trigger_error(sprintf(
+                'Passing null as argument 1 for %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be not allowed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
             return null;
         }
 
@@ -382,6 +393,21 @@ class ModelManager implements ModelManagerInterface, LockInterface
             UnitOfWork::STATE_NEW,
             UnitOfWork::STATE_REMOVED,
         ], true)) {
+            // NEXT_MAJOR: Uncomment the following exception, remove the deprecation and the return statement inside this conditional block.
+            // throw new \InvalidArgumentException(sprintf(
+            //    'Can not get the normalized identifier for %s since it is in state %u.',
+            //    ClassUtils::getClass($entity),
+            //    $this->getEntityManager($entity)->getUnitOfWork()->getEntityState($entity)
+            // ));
+
+            @trigger_error(sprintf(
+                'Passing an object which is in state %u (new) or %u (removed) as argument 1 for %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .'and will be not allowed in version 4.0.',
+                UnitOfWork::STATE_NEW,
+                UnitOfWork::STATE_REMOVED,
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
             return null;
         }
 
@@ -402,6 +428,16 @@ class ModelManager implements ModelManagerInterface, LockInterface
      */
     public function getUrlSafeIdentifier($entity)
     {
+        // NEXT_MAJOR: Remove the following check and declare "object" as type for argument 1.
+        if (!\is_object($entity)) {
+            @trigger_error(sprintf(
+                'Passing other type than object for argument 1 for %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be not allowed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+
+            return null;
+        }
+
         return $this->getNormalizedIdentifier($entity);
     }
 
@@ -447,9 +483,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
             $entityManager->flush();
             $entityManager->clear();
-        } catch (\PDOException $e) {
-            throw new ModelManagerException('', 0, $e);
-        } catch (DBALException $e) {
+        } catch (\PDOException | DBALException $e) {
             throw new ModelManagerException('', 0, $e);
         }
     }

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -303,11 +303,11 @@ class FieldDescriptionTest extends TestCase
 
         $field = new FieldDescription();
 
-        $this->assertNull($field->getTargetEntity());
+        $this->assertNull($field->getTargetModel());
 
         $field->setAssociationMapping($assocationMapping);
 
-        $this->assertSame('someValue', $field->getTargetEntity());
+        $this->assertSame('someValue', $field->getTargetModel());
     }
 
     public function testIsIdentifierFromFieldMapping(): void

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -24,6 +24,7 @@ use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineORMAdminBundle\Builder\FormContractor;
 use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Sonata\Form\Type\CollectionType;
@@ -73,9 +74,10 @@ final class FormContractorTest extends TestCase
         $admin->method('getModelManager')->willReturn($modelManager);
         $admin->method('getClass')->willReturn($modelClass);
 
-        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        // NEXT_MAJOR: Mock `FieldDescriptionInterface` instead and replace `getTargetEntity()` with `getTargetModel().
+        $fieldDescription = $this->createMock(FieldDescription::class);
         $fieldDescription->method('getAdmin')->willReturn($admin);
-        $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
+        $fieldDescription->method('getTargetModel')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
         $admin->method('getNewInstance')->willReturn($model);
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -937,6 +937,13 @@ class ModelManagerTest extends TestCase
         $model->delete(new VersionedEntity());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation Passing null as argument 1 for Sonata\DoctrineORMAdminBundle\Model\ModelManager::find() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be not allowed in version 4.0.
+     */
     public function testFindBadId(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
@@ -973,6 +980,13 @@ class ModelManagerTest extends TestCase
         yield ['sonata-project'];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation Passing null as argument 1 for Sonata\DoctrineORMAdminBundle\Model\ModelManager::getNormalizedIdentifier() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be not allowed in version 4.0.
+     */
     public function testGetUrlsafeIdentifierNull(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add some deprecations at `ModelManager` and `FieldDescription` in order to be prepared for the next major.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `FieldDescription::getTargetModel()`.

### Deprecated
- Deprecated passing `null` as argument 2 for `ModelManager::find()`;
- Deprecated passing `null` as argument 1 for `ModelManager::getNormalizedIdentifier()`;
- Deprecated passing objects which are in state 2 (new) or 4 (removed) as argument 1 for `ModelManager::getNormalizedIdentifier()`;
- Deprecated passing other type than `object` as argument 1 for `ModelManager::getUrlSafeIdentifier()`;
- Deprecated `FieldDescription::getTargetEntity()` in favor of `FieldDescription::getTargetModel()`.
```

## To do
    
- [x] Update the tests.