### PR TITLE
Fix StringFilter with equal operator and case sensitive false

### DIFF
--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -63,7 +63,10 @@ class StringFilter extends Filter
         $this->applyWhere($queryBuilder, $or);
 
         if (ContainsOperatorType::TYPE_EQUAL === $data['type']) {
-            $queryBuilder->setParameter($parameterName, $data['value']);
+            $queryBuilder->setParameter(
+                $parameterName,
+                $this->getOption('case_sensitive') ? $data['value'] : mb_strtolower($data['value'])
+            );
         } else {
             $queryBuilder->setParameter(
                 $parameterName,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- StringFilter now correctly takes the `case_sensitive` option into account when the operator is `=`.
```
