### PR TITLE
Improve Template mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4",
-        "sonata-project/admin-bundle": "^3.63",
+        "sonata-project/admin-bundle": "^3.68",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\DoctrineORMAdminBundle\Guesser\TypeGuesser;
 
 class ListBuilder implements ListBuilderInterface
 {
@@ -192,12 +193,27 @@ class ListBuilder implements ListBuilderInterface
     /**
      * @param string $type
      *
-     * @return string
+     * @return string|null
      */
     private function getTemplate($type)
     {
         if (!isset($this->templates[$type])) {
-            return;
+            // NEXT_MAJOR: Remove the check for deprecated type and always return null.
+            if (isset(TypeGuesser::DEPRECATED_TYPES[$type])) {
+                return $this->getTemplate(TypeGuesser::DEPRECATED_TYPES[$type]);
+            }
+
+            return null;
+        }
+
+        // NEXT_MAJOR: Remove the deprecation.
+        if (isset(TypeGuesser::DEPRECATED_TYPES[$type])) {
+            @trigger_error(sprintf(
+                'Overriding %s list template is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x.'
+                .' You should override %s list template instead.',
+                $type,
+                TypeGuesser::DEPRECATED_TYPES[$type]
+            ), E_USER_DEPRECATED);
         }
 
         return $this->templates[$type];

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\DoctrineORMAdminBundle\Guesser\TypeGuesser;
 
 class ShowBuilder implements ShowBuilderInterface
 {
@@ -89,35 +90,6 @@ class ShowBuilder implements ShowBuilderInterface
 
         if (!$fieldDescription->getTemplate()) {
             $fieldDescription->setTemplate($this->getTemplate($fieldDescription->getType()));
-
-            if (!$fieldDescription->getTemplate()) {
-                switch ($fieldDescription->getMappingType()) {
-                    case ClassMetadata::MANY_TO_ONE:
-                        $fieldDescription->setTemplate(
-                            '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig'
-                        );
-
-                        break;
-                    case ClassMetadata::ONE_TO_ONE:
-                        $fieldDescription->setTemplate(
-                            '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig'
-                        );
-
-                        break;
-                    case ClassMetadata::ONE_TO_MANY:
-                        $fieldDescription->setTemplate(
-                            '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig'
-                        );
-
-                        break;
-                    case ClassMetadata::MANY_TO_MANY:
-                        $fieldDescription->setTemplate(
-                            '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig'
-                        );
-
-                        break;
-                }
-            }
         }
 
         switch ($fieldDescription->getMappingType()) {
@@ -134,12 +106,27 @@ class ShowBuilder implements ShowBuilderInterface
     /**
      * @param string $type
      *
-     * @return string
+     * @return string|null
      */
     private function getTemplate($type)
     {
         if (!isset($this->templates[$type])) {
-            return;
+            // NEXT_MAJOR: Remove the check for deprecated type and always return null.
+            if (isset(TypeGuesser::DEPRECATED_TYPES[$type])) {
+                return $this->getTemplate(TypeGuesser::DEPRECATED_TYPES[$type]);
+            }
+
+            return null;
+        }
+
+        // NEXT_MAJOR: Remove the deprecation.
+        if (isset(TypeGuesser::DEPRECATED_TYPES[$type])) {
+            @trigger_error(sprintf(
+                'Overriding %s show template is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x.'
+                .' You should override %s show template instead.',
+                $type,
+                TypeGuesser::DEPRECATED_TYPES[$type]
+            ), E_USER_DEPRECATED);
         }
 
         return $this->templates[$type];

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -37,6 +37,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
     public function guessType($class, $property, ModelManagerInterface $modelManager)
     {
         if (!$ret = $this->getParentMetadataForProperty($class, $property, $modelManager)) {
+            // NEXT_MAJOR: Return null.
             return false;
         }
 

--- a/src/Guesser/TypeGuesser.php
+++ b/src/Guesser/TypeGuesser.php
@@ -15,11 +15,29 @@ namespace Sonata\DoctrineORMAdminBundle\Guesser;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
 class TypeGuesser extends AbstractTypeGuesser
 {
+    /**
+     * This is a mapping between the old deprecated value we provided in the TypeGuesser
+     * and the value we should use to get the correct SonataAdminBundle template. Making the change
+     * directly in the TypeGuesser would be a BC-break if a user overrides the templates config.
+     *
+     * NEXT_MAJOR: remove this constant.
+     *
+     * @internal
+     */
+    public const DEPRECATED_TYPES = [
+        'orm_one_to_many' => TemplateRegistry::TYPE_ONE_TO_MANY,
+        'orm_many_to_many' => TemplateRegistry::TYPE_MANY_TO_MANY,
+        'orm_many_to_one' => TemplateRegistry::TYPE_MANY_TO_ONE,
+        'orm_one_to_one' => TemplateRegistry::TYPE_ONE_TO_ONE,
+        'number' => TemplateRegistry::TYPE_FLOAT,
+    ];
+
     public function guessType($class, $property, ModelManagerInterface $modelManager)
     {
         if (!$ret = $this->getParentMetadataForProperty($class, $property, $modelManager)) {
@@ -33,15 +51,19 @@ class TypeGuesser extends AbstractTypeGuesser
 
             switch ($mapping['type']) {
                 case ClassMetadata::ONE_TO_MANY:
+                    // NEXT_MAJOR: return new TypeGuess(TemplateRegistry::TYPE_ONE_TO_MANY, [], Guess::HIGH_CONFIDENCE)
                     return new TypeGuess('orm_one_to_many', [], Guess::HIGH_CONFIDENCE);
 
                 case ClassMetadata::MANY_TO_MANY:
+                    // NEXT_MAJOR: return new TypeGuess(TemplateRegistry::TYPE_MANY_TO_MANY, [], Guess::HIGH_CONFIDENCE)
                     return new TypeGuess('orm_many_to_many', [], Guess::HIGH_CONFIDENCE);
 
                 case ClassMetadata::MANY_TO_ONE:
+                    // NEXT_MAJOR: return new TypeGuess(TemplateRegistry::TYPE_MANY_TO_ONE, [], Guess::HIGH_CONFIDENCE)
                     return new TypeGuess('orm_many_to_one', [], Guess::HIGH_CONFIDENCE);
 
                 case ClassMetadata::ONE_TO_ONE:
+                    // NEXT_MAJOR: return new TypeGuess(TemplateRegistry::TYPE_ONE_TO_ONE, [], Guess::HIGH_CONFIDENCE)
                     return new TypeGuess('orm_one_to_one', [], Guess::HIGH_CONFIDENCE);
             }
         }
@@ -51,34 +73,36 @@ class TypeGuesser extends AbstractTypeGuesser
             case 'simple_array':
             case 'json':
             case 'json_array':
-                return new TypeGuess('array', [], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess(TemplateRegistry::TYPE_ARRAY, [], Guess::HIGH_CONFIDENCE);
             case 'boolean':
-                return new TypeGuess('boolean', [], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess(TemplateRegistry::TYPE_BOOLEAN, [], Guess::HIGH_CONFIDENCE);
             case 'datetime':
             case 'datetime_immutable':
             case 'vardatetime':
             case 'datetimetz':
             case 'datetimetz_immutable':
-                return new TypeGuess('datetime', [], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess(TemplateRegistry::TYPE_DATETIME, [], Guess::HIGH_CONFIDENCE);
             case 'date':
             case 'date_immutable':
-                return new TypeGuess('date', [], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess(TemplateRegistry::TYPE_DATE, [], Guess::HIGH_CONFIDENCE);
             case 'decimal':
             case 'float':
+                // NEXT_MAJOR: return new TypeGuess(TemplateRegistry::TYPE_FLOAT, [], Guess::LOW_CONFIDENCE)
                 return new TypeGuess('number', [], Guess::MEDIUM_CONFIDENCE);
             case 'integer':
             case 'bigint':
             case 'smallint':
-                return new TypeGuess('integer', [], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess(TemplateRegistry::TYPE_INTEGER, [], Guess::MEDIUM_CONFIDENCE);
             case 'string':
-                return new TypeGuess('text', [], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess(TemplateRegistry::TYPE_TEXT, [], Guess::MEDIUM_CONFIDENCE);
             case 'text':
-                return new TypeGuess('textarea', [], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess(TemplateRegistry::TYPE_TEXTAREA, [], Guess::MEDIUM_CONFIDENCE);
             case 'time':
             case 'time_immutable':
-                return new TypeGuess('time', [], Guess::HIGH_CONFIDENCE);
+                return new TypeGuess(TemplateRegistry::TYPE_TIME, [], Guess::HIGH_CONFIDENCE);
             default:
-                return new TypeGuess('text', [], Guess::LOW_CONFIDENCE);
+                // NEXT_MAJOR: return new TypeGuess(TemplateRegistry::TYPE_STRING, [], Guess::LOW_CONFIDENCE)
+                return new TypeGuess(TemplateRegistry::TYPE_TEXT, [], Guess::LOW_CONFIDENCE);
         }
     }
 }

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -19,6 +19,7 @@ use Prophecy\Argument;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineORMAdminBundle\Builder\ShowBuilder;
 use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
@@ -40,7 +41,13 @@ class ShowBuilderTest extends TestCase
 
         $this->showBuilder = new ShowBuilder(
             $this->guesser->reveal(),
-            ['fakeTemplate' => 'fake']
+            [
+                'fakeTemplate' => 'fake',
+                TemplateRegistry::TYPE_ONE_TO_ONE => '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig',
+                TemplateRegistry::TYPE_ONE_TO_MANY => '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig',
+                TemplateRegistry::TYPE_MANY_TO_ONE => '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
+                TemplateRegistry::TYPE_MANY_TO_MANY => '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
+            ]
         );
 
         $this->admin = $this->prophesize(AdminInterface::class);
@@ -102,14 +109,15 @@ class ShowBuilderTest extends TestCase
 
     /**
      * @dataProvider fixFieldDescriptionData
+     * @dataProvider fixFieldDescriptionDeprecatedData
      */
-    public function testFixFieldDescription($mappingType, $template): void
+    public function testFixFieldDescription(string $type, int $mappingType, string $template): void
     {
         $classMetadata = $this->prophesize(ClassMetadata::class);
 
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('FakeName');
-        $fieldDescription->setType('someType');
+        $fieldDescription->setType($type);
         $fieldDescription->setMappingType($mappingType);
 
         $this->modelManager->hasMetadata(Argument::any())->willReturn(true);
@@ -126,22 +134,55 @@ class ShowBuilderTest extends TestCase
         $this->assertSame($template, $fieldDescription->getTemplate());
     }
 
-    public function fixFieldDescriptionData()
+    public function fixFieldDescriptionData(): iterable
     {
         return [
             'one-to-one' => [
+                TemplateRegistry::TYPE_ONE_TO_ONE,
                 ClassMetadata::ONE_TO_ONE,
                 '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig',
             ],
             'many-to-one' => [
+                TemplateRegistry::TYPE_MANY_TO_ONE,
                 ClassMetadata::MANY_TO_ONE,
                 '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
             ],
             'one-to-many' => [
+                TemplateRegistry::TYPE_ONE_TO_MANY,
                 ClassMetadata::ONE_TO_MANY,
                 '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig',
             ],
             'many-to-many' => [
+                TemplateRegistry::TYPE_MANY_TO_MANY,
+                ClassMetadata::MANY_TO_MANY,
+                '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
+            ],
+        ];
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this dataprovider.
+     */
+    public function fixFieldDescriptionDeprecatedData(): iterable
+    {
+        return [
+            'deprecated-one-to-one' => [
+                'orm_one_to_one',
+                ClassMetadata::ONE_TO_ONE,
+                '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig',
+            ],
+            'deprecated-many-to-one' => [
+                'orm_many_to_one',
+                ClassMetadata::MANY_TO_ONE,
+                '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
+            ],
+            'deprecated-one-to-many' => [
+                'orm_one_to_many',
+                ClassMetadata::ONE_TO_MANY,
+                '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig',
+            ],
+            'deprecated-many-to-many' => [
+                'orm_many_to_many',
                 ClassMetadata::MANY_TO_MANY,
                 '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
             ],


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

There is no template for types like `number` or `orm_one_to_many`.
So I added a mapping between wrong types and right types to use, only if the developer didn't added a template.

## Changelog

```markdown
### Changed
- `decimal` and `float` type use the `float` template if no `number` template exists

### Fixed
- `one_to_one`, `one_to_many`, `many_to_one` and `many_to_many` type are correctly using the template defined in your config instead of the Sonata one.
```