### PR TITLE
Add StringFilter support for START_WITH and END_WITH operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4",
-        "sonata-project/admin-bundle": "^3.68",
+        "sonata-project/admin-bundle": "^3.71",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -15,14 +15,16 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
-use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
+use Sonata\AdminBundle\Form\Type\Operator\StringOperatorType;
 
 class StringFilter extends Filter
 {
     public const CHOICES = [
-        ContainsOperatorType::TYPE_CONTAINS => 'LIKE',
-        ContainsOperatorType::TYPE_NOT_CONTAINS => 'NOT LIKE',
-        ContainsOperatorType::TYPE_EQUAL => '=',
+        StringOperatorType::TYPE_CONTAINS => 'LIKE',
+        StringOperatorType::TYPE_STARTS_WITH => 'LIKE',
+        StringOperatorType::TYPE_ENDS_WITH => 'LIKE',
+        StringOperatorType::TYPE_NOT_CONTAINS => 'NOT LIKE',
+        StringOperatorType::TYPE_EQUAL => '=',
     ];
 
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
@@ -37,7 +39,7 @@ class StringFilter extends Filter
             return;
         }
 
-        $data['type'] = !isset($data['type']) ? ContainsOperatorType::TYPE_CONTAINS : $data['type'];
+        $data['type'] = !isset($data['type']) ? StringOperatorType::TYPE_CONTAINS : $data['type'];
 
         $operator = $this->getOperator((int) $data['type']);
 
@@ -56,22 +58,33 @@ class StringFilter extends Filter
             $or->add(sprintf('LOWER(%s.%s) %s :%s', $alias, $field, $operator, $parameterName));
         }
 
-        if (ContainsOperatorType::TYPE_NOT_CONTAINS === $data['type']) {
+        if (StringOperatorType::TYPE_NOT_CONTAINS === $data['type']) {
             $or->add($queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $field)));
         }
 
         $this->applyWhere($queryBuilder, $or);
 
-        if (ContainsOperatorType::TYPE_EQUAL === $data['type']) {
+        if (StringOperatorType::TYPE_EQUAL === $data['type']) {
             $queryBuilder->setParameter(
                 $parameterName,
                 $this->getOption('case_sensitive') ? $data['value'] : mb_strtolower($data['value'])
             );
         } else {
+            switch ($data['type']) {
+                case StringOperatorType::TYPE_STARTS_WITH:
+                    $format = '%s%%';
+                    break;
+                case StringOperatorType::TYPE_ENDS_WITH:
+                    $format = '%%%s';
+                    break;
+                default:
+                    $format = $this->getOption('format');
+            }
+
             $queryBuilder->setParameter(
                 $parameterName,
                 sprintf(
-                    $this->getOption('format'),
+                    $format,
                     $this->getOption('case_sensitive') ? $data['value'] : mb_strtolower($data['value'])
                 )
             );

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -15,6 +15,7 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
+use Sonata\AdminBundle\Form\Type\Operator\StringOperatorType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
 
@@ -65,6 +66,32 @@ class StringFilterTest extends TestCase
         $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
         $this->assertSame(['field_name_0' => 'asd'], $builder->parameters);
         $this->assertTrue($filter->isActive());
+    }
+
+    public function testStartsWith(): void
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['format' => '%s']);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $this->assertSame([], $builder->query);
+
+        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_STARTS_WITH]);
+        $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
+        $this->assertSame(['field_name_0' => 'asd%'], $builder->parameters);
+    }
+
+    public function testEndsWith(): void
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['format' => '%s']);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $this->assertSame([], $builder->query);
+
+        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_ENDS_WITH]);
+        $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
+        $this->assertSame(['field_name_0' => '%asd'], $builder->parameters);
     }
 
     public function testNotContains(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Provides fix for:
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/943#issuecomment-641258617
<!-- Describe your Pull Request content here -->

I am targeting this branch, because its a new feature.

Provides fix for:
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/943#issuecomment-641258617

## Changelog
```markdown
### Added
- Add `StringFilter` support for `START_WITH` and `END_WITH` operator
```