### PR TITLE
Add deprecation for StringFilter format option

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\DoctrineORMAdminBundle\Filter\StringFilter
+
+Deprecated `format` option with no replacement.
+
 ### Sonata\DoctrineORMAdminBundle\Admin\FieldDescription
 
 Deprecated `getTargetEntity()`, use `getTargetModel()` instead.

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -79,6 +79,13 @@ class StringFilter extends Filter
                     break;
                 default:
                     $format = $this->getOption('format');
+
+                    if ('%%%s%%' !== $format) {
+                        @trigger_error(
+                            'The "format" option is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+                            E_USER_DEPRECATED
+                        );
+                    }
             }
 
             $queryBuilder->setParameter(
@@ -94,6 +101,7 @@ class StringFilter extends Filter
     public function getDefaultOptions()
     {
         return [
+            // NEXT_MAJOR: Remove the format option.
             'format' => '%%%s%%',
             'case_sensitive' => true,
         ];

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -38,7 +38,7 @@ class StringFilterTest extends TestCase
     public function testNullValue(): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name', ['format' => '%s']);
+        $filter->initialize('field_name');
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
@@ -50,28 +50,28 @@ class StringFilterTest extends TestCase
     public function testContains(): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name', ['format' => '%s']);
+        $filter->initialize('field_name');
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
         $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_CONTAINS]);
         $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => 'asd'], $builder->parameters);
+        $this->assertSame(['field_name_0' => '%asd%'], $builder->parameters);
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
         $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => null]);
         $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => 'asd'], $builder->parameters);
+        $this->assertSame(['field_name_0' => '%asd%'], $builder->parameters);
         $this->assertTrue($filter->isActive());
     }
 
     public function testStartsWith(): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name', ['format' => '%s']);
+        $filter->initialize('field_name');
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
@@ -84,7 +84,7 @@ class StringFilterTest extends TestCase
     public function testEndsWith(): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name', ['format' => '%s']);
+        $filter->initialize('field_name');
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
@@ -97,21 +97,21 @@ class StringFilterTest extends TestCase
     public function testNotContains(): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name', ['format' => '%s']);
+        $filter->initialize('field_name');
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
         $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_NOT_CONTAINS]);
         $this->assertSame(['alias.field NOT LIKE :field_name_0 OR alias.field IS NULL'], $builder->query);
-        $this->assertSame(['field_name_0' => 'asd'], $builder->parameters);
+        $this->assertSame(['field_name_0' => '%asd%'], $builder->parameters);
         $this->assertTrue($filter->isActive());
     }
 
     public function testEquals(): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name', ['format' => '%s']);
+        $filter->initialize('field_name');
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
@@ -126,7 +126,6 @@ class StringFilterTest extends TestCase
     {
         $filter = new StringFilter();
         $filter->initialize('field_name', [
-            'format' => '%s',
             'field_name' => 'field_name',
             'parent_association_mappings' => [
                 [
@@ -194,5 +193,25 @@ class StringFilterTest extends TestCase
             [true, ContainsOperatorType::TYPE_EQUAL, 'alias.field = :field_name_0', 'FooBar'],
 
         ];
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation The "format" option is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
+    public function testFormatOption(): void
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['format' => '%s']);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $this->assertSame([], $builder->query);
+
+        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_CONTAINS]);
+        $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
+        $this->assertSame(['field_name_0' => 'asd'], $builder->parameters);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I am targeting this branch, because BC.

I already found weird the `format` option of the `StringFilter`.
If I look for something containing `foo`, there is IMHO no multiple way to check for this. It always `LIKE %foo%`.

Now, this option is weirder since we have the `START WITH` and an `END WITH` checks.
Why would these checks be made with `%foo` and `foo%` but the CONTAINS one could use another format than `%foo%` ?

That's why I think we should deprecate the `format` option and remove it in the next major.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `format` option of the `StringFilter`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
