### PR TITLE
Prepare support for BlockBundle 4

### DIFF
--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -21,6 +21,7 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -33,13 +34,60 @@ class AuditBlockService extends AbstractBlockService
     protected $auditReader;
 
     /**
-     * @param string $name
+     * NEXT_MAJOR: Allow only Environment|EngineInterface for argument 1 and AuditReader for argument 2.
+     *
+     * @param Environment|EngineInterface|string $templatingOrDeprecatedName
+     * @param EngineInterface|AuditReader        $templatingOrAuditReader
      */
-    public function __construct($name, EngineInterface $templating, AuditReader $auditReader)
+    public function __construct($templatingOrDeprecatedName, object $templatingOrAuditReader, ?AuditReader $auditReader = null)
     {
-        parent::__construct($name, $templating);
+        if ($templatingOrAuditReader instanceof EngineInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 2 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError in version 4.0. You must pass an instance of %s instead.',
+                EngineInterface::class,
+                __METHOD__,
+                AuditReader::class
+            ), E_USER_DEPRECATED);
 
-        $this->auditReader = $auditReader;
+            if (null === $auditReader) {
+                throw new \TypeError(sprintf(
+                    'Passing null as argument 3 to %s() is not allowed when %s is passed as argument 2.'
+                    .' You must pass an instance of %s instead.',
+                    __METHOD__,
+                    EngineInterface::class,
+                    AuditReader::class
+                ));
+            }
+
+            parent::__construct($templatingOrDeprecatedName, $templatingOrAuditReader);
+
+            $this->auditReader = $auditReader;
+        } elseif ($templatingOrAuditReader instanceof AuditReader) {
+            if (!$templatingOrDeprecatedName instanceof Environment
+                && !$templatingOrDeprecatedName instanceof EngineInterface
+            ) {
+                throw new \TypeError(sprintf(
+                    'Argument 1 passed to %s() must be either an instance of %s or preferably %s, %s given.',
+                    __METHOD__,
+                    EngineInterface::class,
+                    Environment::class,
+                    \is_object($templatingOrDeprecatedName) ? \get_class($templatingOrDeprecatedName) : \gettype($templatingOrDeprecatedName)
+                ));
+            }
+
+            parent::__construct($templatingOrDeprecatedName);
+
+            $this->auditReader = $templatingOrAuditReader;
+        } else {
+            throw new \TypeError(sprintf(
+                'Argument 2 passed to %s() must be either an instance of %s or preferably %s, %s given.',
+                __METHOD__,
+                EngineInterface::class,
+                AuditReader::class,
+                \get_class($templatingOrAuditReader)
+            ));
+        }
     }
 
     public function execute(BlockContextInterface $blockContext, ?Response $response = null)

--- a/src/Resources/config/audit.xml
+++ b/src/Resources/config/audit.xml
@@ -6,8 +6,7 @@
         </service>
         <service id="sonata.admin_doctrine_orm.block.audit" class="Sonata\DoctrineORMAdminBundle\Block\AuditBlockService">
             <tag name="sonata.block"/>
-            <argument>sonata.admin_doctrine_orm.block.audit</argument>
-            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="simplethings_entityaudit.reader" on-invalid="ignore"/>
         </service>
     </services>

--- a/tests/Block/DeprecatedAuditBlockServiceTest.php
+++ b/tests/Block/DeprecatedAuditBlockServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Block;
+
+use Prophecy\Argument;
+use SimpleThings\EntityAudit\AuditReader as SimpleThingsAuditReader;
+use SimpleThings\EntityAudit\Revision;
+use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Model\Block;
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
+use Sonata\DoctrineORMAdminBundle\Block\AuditBlockService;
+
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @group legacy
+ *
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+class DeprecatedAuditBlockServiceTest extends BlockServiceTestCase
+{
+    private $simpleThingsAuditReader;
+    private $blockService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->simpleThingsAuditReader = $this->prophesize(SimpleThingsAuditReader::class);
+
+        $this->blockService = new AuditBlockService(
+            'block.service',
+            $this->templating,
+            $this->simpleThingsAuditReader->reveal()
+        );
+    }
+
+    /**
+     * @expectedDeprecation Passing Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as argument 2 to Sonata\DoctrineORMAdminBundle\Block\AuditBlockService::__construct() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will throw a \TypeError in version 4.0. You must pass an instance of SimpleThings\EntityAudit\AuditReader instead.
+     */
+    public function testExecute(): void
+    {
+        $blockContext = $this->prophesize(BlockContext::class);
+
+        $blockContext->getBlock()->willReturn($block = new Block())->shouldBeCalledTimes(1);
+        $blockContext->getSetting('limit')->willReturn($limit = 10)->shouldBeCalledTimes(1);
+
+        $this->simpleThingsAuditReader->findRevisionHistory($limit, 0)
+            ->willReturn([$revision = new Revision('test', '123', 'test')])
+            ->shouldBeCalledTimes(1);
+
+        $this->simpleThingsAuditReader->findEntitiesChangedAtRevision(Argument::cetera())
+            ->willReturn([])
+            ->shouldBeCalledTimes(1);
+
+        $blockContext->getTemplate()->willReturn('template')->shouldBeCalledTimes(1);
+        $blockContext->getSettings()->willReturn([])->shouldBeCalledTimes(1);
+
+        $this->blockService->execute($blockContext->reveal());
+
+        $this->assertSame('template', $this->templating->view);
+        $this->assertIsArray($this->templating->parameters['settings']);
+        $this->assertSame($revision, $this->templating->parameters['revisions'][0]['revision']);
+        $this->assertSame($block, $this->templating->parameters['block']);
+    }
+
+    /**
+     * @expectedDeprecation Passing Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as argument 2 to Sonata\DoctrineORMAdminBundle\Block\AuditBlockService::__construct() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will throw a \TypeError in version 4.0. You must pass an instance of SimpleThings\EntityAudit\AuditReader instead.
+     */
+    public function testDefaultSettings(): void
+    {
+        $blockContext = $this->getBlockContext($this->blockService);
+
+        $this->assertSettings([
+            'attr' => [],
+            'extra_cache_keys' => [],
+            'limit' => 10,
+            'template' => '@SonataDoctrineORMAdmin/Block/block_audit.html.twig',
+            'ttl' => 0,
+            'use_cache' => true,
+        ], $blockContext);
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\DoctrineORMAdminBundle\Tests;
+namespace Sonata\DoctrineORMAdminBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\Configuration;

--- a/tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+namespace Sonata\DoctrineORMAdminBundle\Tests\DependencyInjection;
+
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\SonataDoctrineORMAdminExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog

```markdown
### Deprecated
- Passing a string as argument 1 when instantiating Sonata\DoctrineORMAdminBundle\Block\AuditBlockService 
```
