### PR TITLE
Add typehint for private methods and improve tests

### DIFF
--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -183,10 +183,7 @@ class FormContractor implements FormContractorInterface
         return $options;
     }
 
-    /**
-     * @return bool
-     */
-    private function hasAssociation(FieldDescriptionInterface $fieldDescription)
+    private function hasAssociation(FieldDescriptionInterface $fieldDescription): bool
     {
         return \in_array($fieldDescription->getMappingType(), [
             ClassMetadata::ONE_TO_MANY,
@@ -196,13 +193,7 @@ class FormContractor implements FormContractorInterface
         ], true);
     }
 
-    /**
-     * @param string $type
-     * @param array  $classes
-     *
-     * @return array
-     */
-    private function checkFormClass($type, $classes)
+    private function checkFormClass(string $type, array $classes): array
     {
         return array_filter($classes, static function ($subclass) use ($type) {
             return is_a($type, $subclass, true);

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -98,7 +98,7 @@ class FormContractor implements FormContractorInterface
         $options = [];
         $options['sonata_field_description'] = $fieldDescription;
 
-        if ($this->checkFormClass($type, [
+        if ($this->isAnyInstanceOf($type, [
             ModelType::class,
             ModelTypeList::class,
             ModelListType::class,
@@ -116,7 +116,7 @@ class FormContractor implements FormContractorInterface
             $options['class'] = $fieldDescription->getTargetModel();
             $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
 
-            if ($this->checkFormClass($type, [ModelAutocompleteType::class])) {
+            if ($this->isAnyInstanceOf($type, [ModelAutocompleteType::class])) {
                 if (!$fieldDescription->getAssociationAdmin()) {
                     throw new \RuntimeException(sprintf(
                         'The current field `%s` is not linked to an admin.'
@@ -126,7 +126,7 @@ class FormContractor implements FormContractorInterface
                     ));
                 }
             }
-        } elseif ($this->checkFormClass($type, [AdminType::class])) {
+        } elseif ($this->isAnyInstanceOf($type, [AdminType::class])) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf(
                     'The current field `%s` is not linked to an admin.'
@@ -159,7 +159,7 @@ class FormContractor implements FormContractorInterface
             };
             $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
         // NEXT_MAJOR: remove 'Sonata\CoreBundle\Form\Type\CollectionType'
-        } elseif ($this->checkFormClass($type, [CollectionType::class, 'Sonata\CoreBundle\Form\Type\CollectionType'])) {
+        } elseif ($this->isAnyInstanceOf($type, [CollectionType::class, 'Sonata\CoreBundle\Form\Type\CollectionType'])) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf(
                     'The current field `%s` is not linked to an admin.'
@@ -193,10 +193,17 @@ class FormContractor implements FormContractorInterface
         ], true);
     }
 
-    private function checkFormClass(string $type, array $classes): array
+    /**
+     * @param string[] $classes
+     */
+    private function isAnyInstanceOf(string $type, array $classes): bool
     {
-        return array_filter($classes, static function ($subclass) use ($type) {
-            return is_a($type, $subclass, true);
-        });
+        foreach ($classes as $class) {
+            if (is_a($type, $class, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -190,12 +190,7 @@ class ListBuilder implements ListBuilderInterface
         return $fieldDescription;
     }
 
-    /**
-     * @param string $type
-     *
-     * @return string|null
-     */
-    private function getTemplate($type)
+    private function getTemplate(string $type): ?string
     {
         if (!isset($this->templates[$type])) {
             // NEXT_MAJOR: Remove the check for deprecated type and always return null.

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -103,12 +103,7 @@ class ShowBuilder implements ShowBuilderInterface
         }
     }
 
-    /**
-     * @param string $type
-     *
-     * @return string|null
-     */
-    private function getTemplate($type)
+    private function getTemplate(string $type): ?string
     {
         if (!isset($this->templates[$type])) {
             // NEXT_MAJOR: Remove the check for deprecated type and always return null.

--- a/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -55,12 +55,7 @@ class AddAuditEntityCompilerPass implements CompilerPassInterface
         $auditManager->addMethodCall('setReader', ['sonata.admin.audit.orm.reader', $auditedEntities]);
     }
 
-    /**
-     * @param string $name
-     *
-     * @return string
-     */
-    private function getModelName(ContainerBuilder $container, $name)
+    private function getModelName(ContainerBuilder $container, string $name): string
     {
         if ('%' === $name[0]) {
             return $container->getParameter(substr($name, 1, -1));

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -180,6 +180,8 @@ abstract class AbstractDateFilter extends Filter
     }
 
     /**
+     * NEXT_MAJOR: Change the visibility for private.
+     *
      * Resolves DateOperatorType:: constants to SQL operators.
      *
      * @param int $type
@@ -190,6 +192,6 @@ abstract class AbstractDateFilter extends Filter
     {
         $type = (int) $type;
 
-        return self::CHOICES[$type] ?? '=';
+        return self::CHOICES[$type] ?? self::CHOICES[DateOperatorType::TYPE_EQUAL];
     }
 }

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -35,13 +35,8 @@ class ClassFilter extends Filter
             return;
         }
 
-        $data['type'] = !isset($data['type']) ? EqualOperatorType::TYPE_EQUAL : $data['type'];
-
-        $operator = $this->getOperator((int) $data['type']);
-
-        if (!$operator) {
-            $operator = 'INSTANCE OF';
-        }
+        $type = $data['type'] ?? EqualOperatorType::TYPE_EQUAL;
+        $operator = $this->getOperator((int) $type);
 
         $this->applyWhere($queryBuilder, sprintf('%s %s %s', $alias, $operator, $data['value']));
     }
@@ -80,11 +75,8 @@ class ClassFilter extends Filter
         ]];
     }
 
-    /**
-     * @return string|false
-     */
-    private function getOperator(int $type)
+    private function getOperator(int $type): string
     {
-        return self::CHOICES[$type] ?? false;
+        return self::CHOICES[$type] ?? self::CHOICES[EqualOperatorType::TYPE_EQUAL];
     }
 }

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -81,11 +81,9 @@ class ClassFilter extends Filter
     }
 
     /**
-     * @param int $type
-     *
-     * @return mixed
+     * @return string|false
      */
-    private function getOperator($type)
+    private function getOperator(int $type)
     {
         return self::CHOICES[$type] ?? false;
     }

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -125,12 +125,8 @@ class ModelFilter extends Filter
     /**
      * Retrieve the parent alias for given alias.
      * Root alias for direct association or entity joined alias for association depth >= 2.
-     *
-     * @param string $alias
-     *
-     * @return string
      */
-    private function getParentAlias(ProxyQueryInterface $queryBuilder, $alias)
+    private function getParentAlias(ProxyQueryInterface $queryBuilder, string $alias): string
     {
         $parentAlias = $rootAlias = current($queryBuilder->getRootAliases());
         $joins = $queryBuilder->getDQLPart('join');

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -34,12 +34,7 @@ class NumberFilter extends Filter
         }
 
         $type = $data['type'] ?? NumberOperatorType::TYPE_EQUAL;
-
         $operator = $this->getOperator((int) $type);
-
-        if (!$operator) {
-            $operator = '=';
-        }
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($queryBuilder);
@@ -61,11 +56,8 @@ class NumberFilter extends Filter
         ]];
     }
 
-    /**
-     * @return string|false
-     */
-    private function getOperator(int $type)
+    private function getOperator(int $type): string
     {
-        return self::CHOICES[$type] ?? false;
+        return self::CHOICES[$type] ?? self::CHOICES[NumberOperatorType::TYPE_EQUAL];
     }
 }

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -33,9 +33,9 @@ class NumberFilter extends Filter
             return;
         }
 
-        $type = $data['type'] ?? false;
+        $type = $data['type'] ?? NumberOperatorType::TYPE_EQUAL;
 
-        $operator = $this->getOperator($type);
+        $operator = $this->getOperator((int) $type);
 
         if (!$operator) {
             $operator = '=';
@@ -62,11 +62,9 @@ class NumberFilter extends Filter
     }
 
     /**
-     * @param string $type
-     *
-     * @return bool
+     * @return string|false
      */
-    private function getOperator($type)
+    private function getOperator(int $type)
     {
         return self::CHOICES[$type] ?? false;
     }

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -109,11 +109,9 @@ class StringFilter extends Filter
     }
 
     /**
-     * @param string $type
-     *
-     * @return bool
+     * @return string|false
      */
-    private function getOperator($type)
+    private function getOperator(int $type)
     {
         return self::CHOICES[$type] ?? false;
     }

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -39,13 +39,8 @@ class StringFilter extends Filter
             return;
         }
 
-        $data['type'] = !isset($data['type']) ? StringOperatorType::TYPE_CONTAINS : $data['type'];
-
-        $operator = $this->getOperator((int) $data['type']);
-
-        if (!$operator) {
-            $operator = 'LIKE';
-        }
+        $type = $data['type'] ?? StringOperatorType::TYPE_CONTAINS;
+        $operator = $this->getOperator((int) $type);
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($queryBuilder);
@@ -58,19 +53,19 @@ class StringFilter extends Filter
             $or->add(sprintf('LOWER(%s.%s) %s :%s', $alias, $field, $operator, $parameterName));
         }
 
-        if (StringOperatorType::TYPE_NOT_CONTAINS === $data['type']) {
+        if (StringOperatorType::TYPE_NOT_CONTAINS === $type) {
             $or->add($queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $field)));
         }
 
         $this->applyWhere($queryBuilder, $or);
 
-        if (StringOperatorType::TYPE_EQUAL === $data['type']) {
+        if (StringOperatorType::TYPE_EQUAL === $type) {
             $queryBuilder->setParameter(
                 $parameterName,
                 $this->getOption('case_sensitive') ? $data['value'] : mb_strtolower($data['value'])
             );
         } else {
-            switch ($data['type']) {
+            switch ($type) {
                 case StringOperatorType::TYPE_STARTS_WITH:
                     $format = '%s%%';
                     break;
@@ -108,11 +103,8 @@ class StringFilter extends Filter
         ]];
     }
 
-    /**
-     * @return string|false
-     */
-    private function getOperator(int $type)
+    private function getOperator(int $type): string
     {
-        return self::CHOICES[$type] ?? false;
+        return self::CHOICES[$type] ?? self::CHOICES[StringOperatorType::TYPE_CONTAINS];
     }
 }

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -67,8 +67,6 @@ final class DatagridBuilderTest extends TestCase
 
         $this->admin->getClass()->willReturn('FakeClass');
         $this->admin->getModelManager()->willReturn($this->modelManager->reveal());
-        $this->admin->attachAdminClass(Argument::cetera())->willReturn();
-        $this->admin->addFilterFieldDescription(Argument::cetera())->willReturn();
     }
 
     /**
@@ -126,6 +124,8 @@ final class DatagridBuilderTest extends TestCase
         $fieldDescription->setName('test');
         $fieldDescription->setMappingType(ClassMetadata::ONE_TO_MANY);
 
+        $this->admin->attachAdminClass(Argument::cetera())->shouldBeCalled();
+
         $this->modelManager->hasMetadata(Argument::any())->willReturn(true);
 
         $this->modelManager->getParentMetadataForProperty(Argument::cetera())
@@ -147,6 +147,8 @@ final class DatagridBuilderTest extends TestCase
 
     public function testAddFilterNoType(): void
     {
+        $this->admin->addFilterFieldDescription(Argument::cetera())->shouldBeCalled();
+
         $datagrid = $this->prophesize(DatagridInterface::class);
         $guessType = $this->prophesize(TypeGuess::class);
 

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -44,13 +44,14 @@ class ListBuilderTest extends TestCase
         $this->admin = $this->prophesize(AdminInterface::class);
         $this->admin->getClass()->willReturn('Foo');
         $this->admin->getModelManager()->willReturn($this->modelManager);
-        $this->admin->addListFieldDescription(Argument::cetera())->willReturn();
 
         $this->listBuilder = new ListBuilder($this->typeGuesser->reveal());
     }
 
     public function testAddListActionField(): void
     {
+        $this->admin->addListFieldDescription(Argument::cetera())->shouldBeCalled();
+
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('foo');
         $list = $this->listBuilder->getBaseList();
@@ -66,6 +67,8 @@ class ListBuilderTest extends TestCase
 
     public function testCorrectFixedActionsFieldType(): void
     {
+        $this->admin->addListFieldDescription(Argument::cetera())->shouldBeCalled();
+
         $this->typeGuesser->guessType(Argument::cetera())
             ->willReturn(new TypeGuess('_action', [], Guess::LOW_CONFIDENCE));
 

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -55,8 +55,6 @@ class ShowBuilderTest extends TestCase
 
         $this->admin->getClass()->willReturn('FakeClass');
         $this->admin->getModelManager()->willReturn($this->modelManager->reveal());
-        $this->admin->attachAdminClass(Argument::cetera())->willReturn();
-        $this->admin->addShowFieldDescription(Argument::cetera())->willReturn();
     }
 
     public function testGetBaseList(): void
@@ -74,6 +72,9 @@ class ShowBuilderTest extends TestCase
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('FakeName');
         $fieldDescription->setMappingType(ClassMetadata::MANY_TO_ONE);
+
+        $this->admin->attachAdminClass(Argument::cetera())->shouldBeCalled();
+        $this->admin->addShowFieldDescription(Argument::cetera())->shouldBeCalled();
 
         $typeGuess->getType()->willReturn($typeGuessReturn = 'fakeType');
 
@@ -97,6 +98,8 @@ class ShowBuilderTest extends TestCase
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('FakeName');
 
+        $this->admin->addShowFieldDescription(Argument::cetera())->shouldBeCalled();
+
         $this->modelManager->hasMetadata(Argument::any())->willReturn(false);
 
         $this->showBuilder->addField(
@@ -119,6 +122,8 @@ class ShowBuilderTest extends TestCase
         $fieldDescription->setName('FakeName');
         $fieldDescription->setType($type);
         $fieldDescription->setMappingType($mappingType);
+
+        $this->admin->attachAdminClass(Argument::cetera())->shouldBeCalled();
 
         $this->modelManager->hasMetadata(Argument::any())->willReturn(true);
 


### PR DESCRIPTION
## Subject

I wanted to add typehint on the master branch, but some can be added on 3.x.
Plus, `willReturn()` throw an error when the return typehint is `void`. So I modified the tests to prevent this issue.

I am targeting this branch, because pedantic.