### PR TITLE
Use deprecated tag instead of sonata_template_deprecate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/http-kernel": "^4.4",
         "symfony/options-resolver": "^4.4",
         "symfony/security-acl": "^3.0",
-        "twig/twig": "^1.41 || ^2.10"
+        "twig/twig": "^2.10"
     },
     "conflict": {
         "simplethings/entity-audit-bundle": ">=2.0",

--- a/src/Resources/views/CRUD/edit_modal.html.twig
+++ b/src/Resources/views/CRUD/edit_modal.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+{% deprecated 'The "edit_modal.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_modal.html.twig" instead.' %}
 
 <div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">

--- a/src/Resources/views/CRUD/edit_orm_many_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_many_association_script.html.twig
@@ -16,7 +16,7 @@ This code manage the many-to-[one|many] association field popup
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
+{% deprecated 'The "edit_orm_many_association_script.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_many_script.html.twig" instead.' %}
 
 {% autoescape false %}
 

--- a/src/Resources/views/CRUD/edit_orm_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_many_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_many_to_many.html.twig' %}
+{% deprecated 'The "edit_orm_many_to_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_many_to_many.html.twig" instead.' %}
 
 {% if sonata_admin.field_description.hasassociationadmin %}
     <div id="field_container_{{ id }}" class="field-container">

--- a/src/Resources/views/CRUD/edit_orm_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_many_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_many_to_one.html.twig' %}
+{% deprecated 'The "edit_orm_many_to_one.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_many_to_one.html.twig" instead.' %}
 
 {% if not sonata_admin.field_description.hasassociationadmin%}
     {{ value|render_relation_element(sonata_admin.field_description) }}

--- a/src/Resources/views/CRUD/edit_orm_one_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_association_script.html.twig
@@ -16,7 +16,7 @@ This code manage the one-to-many association field popup
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_one_script.html.twig' %}
+{% deprecated 'The "edit_orm_one_association_script.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_one_script.html.twig" instead.' %}
 
 {% autoescape false %}
 

--- a/src/Resources/views/CRUD/edit_orm_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_one_to_many.html.twig' %}
+{% deprecated 'The "edit_orm_one_to_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_one_to_many.html.twig" instead.' %}
 
 {% if not sonata_admin.field_description.hasassociationadmin %}
     {% for element in value %}

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_table.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_one_to_many_inline_table.html.twig' %}
+{% deprecated 'The "edit_orm_one_to_many_inline_table.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_one_to_many_inline_table.html.twig" instead.' %}
 
 <table class="table table-bordered">
     <thead>

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_inline_tabs.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_one_to_many_inline_tabs.html.twig' %}
+{% deprecated 'The "edit_orm_one_to_many_inline_tabs.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_one_to_many_inline_tabs.html.twig" instead.' %}
 
 <div class="sonata-ba-tabs">
     {% for nested_group_field in form.children %}

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_table.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_table.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig' %}
+{% deprecated 'The "edit_orm_one_to_many_sortable_script_table.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig" instead.' %}
 
 <script type="text/javascript">
     jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody').first().sortable({

--- a/src/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_tabs.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_many_sortable_script_tabs.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_one_to_many_sortable_script_tabs.html.twig' %}
+{% deprecated 'The "edit_orm_one_to_many_sortable_script_tabs.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_one_to_many_sortable_script_tabs.html.twig" instead.' %}
 
 <script type="text/javascript">
     jQuery('div#field_container_{{ id }} .sonata-ba-tabs').sortable({

--- a/src/Resources/views/CRUD/edit_orm_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/edit_orm_one_to_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_one_to_one.html.twig' %}
+{% deprecated 'The "edit_orm_one_to_one.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_one_to_one.html.twig" instead.' %}
 
 {% if not sonata_admin.field_description.hasassociationadmin%}
     {{ value|render_relation_element(sonata_admin.field_description) }}

--- a/src/Resources/views/CRUD/list_orm_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/list_orm_many_to_many.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/list_many_to_many.html.twig' %}
+{% deprecated 'The "list_orm_many_to_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/list_many_to_many.html.twig" instead.' %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/list_orm_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/list_orm_many_to_one.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/list_many_to_one.html.twig' %}
+{% deprecated 'The "list_orm_many_to_one.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/list_many_to_one.html.twig" instead.' %}
 
 {% block field %}
     {% if value %}

--- a/src/Resources/views/CRUD/list_orm_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/list_orm_one_to_many.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/list_one_to_many.html.twig' %}
+{% deprecated 'The "list_orm_one_to_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/list_one_to_many.html.twig" instead.' %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/list_orm_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/list_orm_one_to_one.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/list_one_to_one.html.twig' %}
+{% deprecated 'The "list_orm_one_to_one.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/list_one_to_one.html.twig" instead.' %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}

--- a/src/Resources/views/CRUD/show_orm_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/show_orm_many_to_many.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig' %}
+{% deprecated 'The "show_orm_many_to_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/show_many_to_many.html.twig" instead.' %}
 
 {% block field %}
     <ul class="sonata-ba-show-many-to-many">

--- a/src/Resources/views/CRUD/show_orm_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/show_orm_many_to_one.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig' %}
+{% deprecated 'The "show_orm_many_to_one.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/show_many_to_one.html.twig" instead.' %}
 
 {% block field %}
     {% if value %}

--- a/src/Resources/views/CRUD/show_orm_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/show_orm_one_to_many.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig' %}
+{% deprecated 'The "show_orm_one_to_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/show_one_to_many.html.twig" instead.' %}
 
 {% block field %}
     <ul class="sonata-ba-show-one-to-many">

--- a/src/Resources/views/CRUD/show_orm_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/show_orm_one_to_one.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig' %}
+{% deprecated 'The "show_orm_one_to_one.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/show_one_to_one.html.twig" instead.' %}
 
 {% block field %}
     {% set route_name = field_description.options.route.name %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/373

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Use `deprecated` tag instead of `sonata_template_deprecate` to not throw unwanted deprecation notices.
### Removed
- Support for Twig 1.x
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
