### PR TITLE
Use propertyAccessor and deprecate camelize

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,13 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=========================
+
+### Sonata\DoctrineORMAdminBundle\Model\ModelManager
+
+Deprecated `camelize()` method with no replacement.
+
 UPGRADE FROM 3.20 to 3.21
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
         "symfony/options-resolver": "^4.4",
+        "symfony/property-access": "^4.4",
         "symfony/security-acl": "^3.0",
         "twig/twig": "^2.10"
     },

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -19,12 +19,12 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -616,15 +616,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $metadata = $this->getMetadata($class);
 
         foreach ($array as $name => $value) {
-            // property or association ?
-            if (\array_key_exists($name, $metadata->fieldMappings)) {
-                $property = $metadata->fieldMappings[$name]['fieldName'];
-            } elseif (\array_key_exists($name, $metadata->associationMappings)) {
-                $property = $metadata->associationMappings[$name]['fieldName'];
-            } else {
-                $property = $name;
-            }
-
+            $property = $this->getFieldName($metadata, $name);
             $this->propertyAccessor->setValue($instance, $property, $value);
         }
 
@@ -671,6 +663,19 @@ class ModelManager implements ModelManagerInterface, LockInterface
         ), E_USER_DEPRECATED);
 
         return str_replace(' ', '', ucwords(str_replace('_', ' ', $property)));
+    }
+
+    private function getFieldName(ClassMetadata $metadata, string $name): string
+    {
+        if (\array_key_exists($name, $metadata->fieldMappings)) {
+            return $metadata->fieldMappings[$name]['fieldName'];
+        }
+
+        if (\array_key_exists($name, $metadata->associationMappings)) {
+            return $metadata->associationMappings[$name]['fieldName'];
+        }
+
+        return $name;
     }
 
     private function isFieldAlreadySorted(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid): bool

--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -7,6 +7,7 @@
         </service>
         <service id="sonata.admin.manager.orm" class="Sonata\DoctrineORMAdminBundle\Model\ModelManager" public="true">
             <argument type="service" id="doctrine"/>
+            <argument type="service" id="property_accessor"/>
             <tag name="sonata.admin.manager"/>
         </service>
         <!-- FormBuilder -->

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -59,10 +59,20 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidBinaryEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\VersionedEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class ModelManagerTest extends TestCase
 {
+    /**
+     * @var ManagerRegistry|MockObject
+     */
+    private $registry;
+
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+
     public static function setUpBeforeClass(): void
     {
         if (!Type::hasType(UuidType::NAME)) {
@@ -74,6 +84,12 @@ class ModelManagerTest extends TestCase
         if (!Type::hasType(ProductIdType::NAME)) {
             Type::addType(ProductIdType::NAME, ProductIdType::class);
         }
+    }
+
+    protected function setup(): void
+    {
+        $this->registry = $this->createMock(ManagerRegistry::class);
+        $this->modelManager = new ModelManager($this->registry, PropertyAccess::createPropertyAccessor());
     }
 
     public function valueObjectDataProvider(): array
@@ -107,37 +123,28 @@ class ModelManagerTest extends TestCase
         $entityManager->method('getMetadataFactory')->willReturn($classMetadataFactory);
         $entityManager->method('getConnection')->willReturn($connection);
 
-        $registry = $this->createMock(RegistryInterface::class);
-        $registry->method('getManagerForClass')->willReturn($entityManager);
-
-        $manager = new ModelManager($registry);
+        $this->registry->method('getManagerForClass')->willReturn($entityManager);
 
         $this->assertSame(
             ['a7ef873a-e7b5-11e9-81b4-2a2ae2dbcce4'],
-            $manager->getIdentifierValues($entity)
+            $this->modelManager->getIdentifierValues($entity)
         );
     }
 
     public function testInstantiateWithDeprecatedRegistryInterface(): void
     {
-        $registry = $this->createMock(RegistryInterface::class);
-        $manager = new ModelManager($registry);
         $em = $this->createMock(EntityManagerInterface::class);
 
-        $registry->expects($this->once())
+        $this->registry->expects($this->once())
             ->method('getManagerForClass')
             ->with('x')
             ->willReturn($em)
         ;
-        $this->assertSame($em, $manager->getEntityManager('x'));
+        $this->assertSame($em, $this->modelManager->getEntityManager('x'));
     }
 
     public function testSortParameters(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $manager = new ModelManager($registry);
-
         $datagrid1 = $this->createMock(Datagrid::class);
         $datagrid2 = $this->createMock(Datagrid::class);
 
@@ -167,22 +174,22 @@ class ModelManagerTest extends TestCase
                 '_sort_order' => 'ASC',
             ]);
 
-        $parameters = $manager->getSortParameters($field1, $datagrid1);
+        $parameters = $this->modelManager->getSortParameters($field1, $datagrid1);
 
         $this->assertSame('DESC', $parameters['filter']['_sort_order']);
         $this->assertSame('field1', $parameters['filter']['_sort_by']);
 
-        $parameters = $manager->getSortParameters($field2, $datagrid1);
+        $parameters = $this->modelManager->getSortParameters($field2, $datagrid1);
 
         $this->assertSame('ASC', $parameters['filter']['_sort_order']);
         $this->assertSame('field2', $parameters['filter']['_sort_by']);
 
-        $parameters = $manager->getSortParameters($field3, $datagrid1);
+        $parameters = $this->modelManager->getSortParameters($field3, $datagrid1);
 
         $this->assertSame('ASC', $parameters['filter']['_sort_order']);
         $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
 
-        $parameters = $manager->getSortParameters($field3, $datagrid2);
+        $parameters = $this->modelManager->getSortParameters($field3, $datagrid2);
 
         $this->assertSame('DESC', $parameters['filter']['_sort_order']);
         $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
@@ -474,13 +481,11 @@ class ModelManagerTest extends TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())
+        $this->registry->expects($this->any())
             ->method('getManagerForClass')
             ->willReturn($em);
 
-        $manager = new ModelManager($registry);
-        $result = $manager->getIdentifierValues($entity);
+        $result = $this->modelManager->getIdentifierValues($entity);
 
         $this->assertSame($entity->getId()->toString(), $result[0]);
     }
@@ -524,13 +529,11 @@ class ModelManagerTest extends TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())
+        $this->registry->expects($this->any())
             ->method('getManagerForClass')
             ->willReturn($em);
 
-        $manager = new ModelManager($registry);
-        $result = $manager->getIdentifierValues($entity);
+        $result = $this->modelManager->getIdentifierValues($entity);
 
         $this->assertSame($entity->getId()->toString(), $result[0]);
     }
@@ -574,13 +577,11 @@ class ModelManagerTest extends TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())
+        $this->registry->expects($this->any())
             ->method('getManagerForClass')
             ->willReturn($em);
 
-        $manager = new ModelManager($registry);
-        $result = $manager->getIdentifierValues($entity);
+        $result = $this->modelManager->getIdentifierValues($entity);
 
         $this->assertSame((string) $entity->getId()->getId(), $result[0]);
     }
@@ -619,13 +620,11 @@ class ModelManagerTest extends TestCase
             ->method('getConnection')
             ->willReturn($conn);
 
-        $registry = $this->createMock(ManagerRegistry::class);
-        $registry->expects($this->any())
+        $this->registry->expects($this->any())
             ->method('getManagerForClass')
             ->willReturn($em);
 
-        $manager = new ModelManager($registry);
-        $result = $manager->getIdentifierValues($entity);
+        $result = $this->modelManager->getIdentifierValues($entity);
 
         $this->assertSame(42, $result[0]);
     }
@@ -701,9 +700,7 @@ class ModelManagerTest extends TestCase
             ->method('getQuery')
             ->willReturn($proxyQuery);
 
-        $registry = $this->getMockBuilder(RegistryInterface::class)->getMock();
-        $manager = new ModelManager($registry);
-        $manager->getDataSourceIterator($datagrid, []);
+        $this->modelManager->getDataSourceIterator($datagrid, []);
 
         if ($isAddOrderBy) {
             $this->assertArrayHasKey($key = 'doctrine.customTreeWalkers', $hints = $query->getHints());
@@ -716,26 +713,25 @@ class ModelManagerTest extends TestCase
         $class = SimpleEntity::class;
 
         $metadataFactory = $this->createMock(ClassMetadataFactory::class);
-        $modelManager = $this->createMock(ObjectManager::class);
+        $objectManager = $this->createMock(ObjectManager::class);
         $registry = $this->createMock(ManagerRegistry::class);
 
         $classMetadata = new ClassMetadata($class);
         $classMetadata->reflClass = new \ReflectionClass($class);
 
-        $modelManager->expects($this->once())
+        $objectManager->expects($this->once())
             ->method('getMetadataFactory')
             ->willReturn($metadataFactory);
         $metadataFactory->expects($this->once())
             ->method('getMetadataFor')
             ->with($class)
             ->willReturn($classMetadata);
-        $registry->expects($this->once())
+        $this->registry->expects($this->once())
             ->method('getManagerForClass')
             ->with($class)
-            ->willReturn($modelManager);
+            ->willReturn($objectManager);
 
-        $manager = new ModelManager($registry);
-        $this->assertInstanceOf($class, $object = $manager->modelReverseTransform(
+        $this->assertInstanceOf($class, $object = $this->modelManager->modelReverseTransform(
             $class,
             [
                 'schmeckles' => 42,
@@ -748,34 +744,28 @@ class ModelManagerTest extends TestCase
 
     public function testCollections(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-        $model = new ModelManager($registry);
-
-        $collection = $model->getModelCollectionInstance('whyDoWeEvenHaveThisParameter');
+        $collection = $this->modelManager->getModelCollectionInstance('whyDoWeEvenHaveThisParameter');
         $this->assertInstanceOf(ArrayCollection::class, $collection);
 
         $item1 = 'item1';
         $item2 = 'item2';
-        $model->collectionAddElement($collection, $item1);
-        $model->collectionAddElement($collection, $item2);
+        $this->modelManager->collectionAddElement($collection, $item1);
+        $this->modelManager->collectionAddElement($collection, $item2);
 
-        $this->assertTrue($model->collectionHasElement($collection, $item1));
+        $this->assertTrue($this->modelManager->collectionHasElement($collection, $item1));
 
-        $model->collectionRemoveElement($collection, $item1);
+        $this->modelManager->collectionRemoveElement($collection, $item1);
 
-        $this->assertFalse($model->collectionHasElement($collection, $item1));
+        $this->assertFalse($this->modelManager->collectionHasElement($collection, $item1));
 
-        $model->collectionClear($collection);
+        $this->modelManager->collectionClear($collection);
 
         $this->assertTrue($collection->isEmpty());
     }
 
     public function testModelTransform(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-        $model = new ModelManager($registry);
-
-        $result = $model->modelTransform('thisIsNotUsed', 'doWeNeedThisMethod');
+        $result = $this->modelManager->modelTransform('thisIsNotUsed', 'doWeNeedThisMethod');
 
         $this->assertSame('doWeNeedThisMethod', $result);
     }
@@ -784,7 +774,6 @@ class ModelManagerTest extends TestCase
     {
         $datagrid = $this->createMock(DatagridInterface::class);
         $field = $this->createMock(FieldDescriptionInterface::class);
-        $registry = $this->createMock(ManagerRegistry::class);
 
         $datagrid->expects($this->once())
             ->method('getValues')
@@ -794,9 +783,7 @@ class ModelManagerTest extends TestCase
             ->method('getName')
             ->willReturn($name = 'test');
 
-        $model = new ModelManager($registry);
-
-        $result = $model->getPaginationParameters($datagrid, $page = 5);
+        $result = $this->modelManager->getPaginationParameters($datagrid, $page = 5);
 
         $this->assertSame($page, $result['filter']['_page']);
         $this->assertSame($name, $result['filter']['_sort_by']);
@@ -804,44 +791,28 @@ class ModelManagerTest extends TestCase
 
     public function testGetModelInstanceException(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $model = new ModelManager($registry);
-
         $this->expectException(\RuntimeException::class);
 
-        $model->getModelInstance(AbstractEntity::class);
+        $this->modelManager->getModelInstance(AbstractEntity::class);
     }
 
     public function testGetModelInstanceForProtectedEntity(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $model = new ModelManager($registry);
-
-        $this->assertInstanceOf(ProtectedEntity::class, $model->getModelInstance(ProtectedEntity::class));
+        $this->assertInstanceOf(ProtectedEntity::class, $this->modelManager->getModelInstance(ProtectedEntity::class));
     }
 
     public function testGetEntityManagerException(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $model = new ModelManager($registry);
-
         $this->expectException(\RuntimeException::class);
 
-        $model->getEntityManager(VersionedEntity::class);
+        $this->modelManager->getEntityManager(VersionedEntity::class);
     }
 
     public function testGetNewFieldDescriptionInstanceException(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $model = new ModelManager($registry);
-
         $this->expectException(\RuntimeException::class);
 
-        $model->getNewFieldDescriptionInstance(VersionedEntity::class, [], []);
+        $this->modelManager->getNewFieldDescriptionInstance(VersionedEntity::class, [], []);
     }
 
     /**
@@ -849,11 +820,9 @@ class ModelManagerTest extends TestCase
      */
     public function testCreate($exception): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
         $entityManger = $this->createMock(EntityManager::class);
 
-        $registry->expects($this->once())
+        $this->registry->expects($this->once())
             ->method('getManagerForClass')
             ->willReturn($entityManger);
 
@@ -864,11 +833,9 @@ class ModelManagerTest extends TestCase
             ->method('flush')
             ->willThrowException($exception);
 
-        $model = new ModelManager($registry);
-
         $this->expectException(ModelManagerException::class);
 
-        $model->create(new VersionedEntity());
+        $this->modelManager->create(new VersionedEntity());
     }
 
     public function createUpdateRemoveData()
@@ -888,11 +855,9 @@ class ModelManagerTest extends TestCase
      */
     public function testUpdate($exception): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
         $entityManger = $this->createMock(EntityManager::class);
 
-        $registry->expects($this->once())
+        $this->registry->expects($this->once())
             ->method('getManagerForClass')
             ->willReturn($entityManger);
 
@@ -903,11 +868,9 @@ class ModelManagerTest extends TestCase
             ->method('flush')
             ->willThrowException($exception);
 
-        $model = new ModelManager($registry);
-
         $this->expectException(ModelManagerException::class);
 
-        $model->update(new VersionedEntity());
+        $this->modelManager->update(new VersionedEntity());
     }
 
     /**
@@ -915,11 +878,9 @@ class ModelManagerTest extends TestCase
      */
     public function testRemove($exception): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
         $entityManger = $this->createMock(EntityManager::class);
 
-        $registry->expects($this->once())
+        $this->registry->expects($this->once())
             ->method('getManagerForClass')
             ->willReturn($entityManger);
 
@@ -930,11 +891,9 @@ class ModelManagerTest extends TestCase
             ->method('flush')
             ->willThrowException($exception);
 
-        $model = new ModelManager($registry);
-
         $this->expectException(ModelManagerException::class);
 
-        $model->delete(new VersionedEntity());
+        $this->modelManager->delete(new VersionedEntity());
     }
 
     /**
@@ -946,11 +905,7 @@ class ModelManagerTest extends TestCase
      */
     public function testFindBadId(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $model = new ModelManager($registry);
-
-        $this->assertNull($model->find('notImportant', null));
+        $this->assertNull($this->modelManager->find('notImportant', null));
     }
 
     /**
@@ -960,13 +915,9 @@ class ModelManagerTest extends TestCase
      */
     public function testNormalizedIdentifierException($entity): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $model = new ModelManager($registry);
-
         $this->expectException(\RuntimeException::class);
 
-        $model->getNormalizedIdentifier($entity);
+        $this->modelManager->getNormalizedIdentifier($entity);
     }
 
     public function getWrongEntities(): iterable
@@ -989,11 +940,7 @@ class ModelManagerTest extends TestCase
      */
     public function testGetUrlsafeIdentifierNull(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        $model = new ModelManager($registry);
-
-        $this->assertNull($model->getNormalizedIdentifier(null));
+        $this->assertNull($this->modelManager->getNormalizedIdentifier(null));
     }
 
     private function getMetadata($class, $isVersioned)


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Related to https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/368#discussion_r460404367

## Changelog

```markdown

### Deprecated
- deprecate `ModelManager::camelize`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
