### PR TITLE
Deprecate getParentFieldDescription

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -312,8 +312,18 @@ class ModelManager implements ModelManagerInterface, LockInterface
         return $this->cache[$class];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0
+     */
     public function getParentFieldDescription($parentAssociationMapping, $class)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in 4.0',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $fieldName = $parentAssociationMapping['fieldName'];
 
         $metadata = $this->getMetadata($class);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Related to https://github.com/sonata-project/SonataAdminBundle/pull/6234
The method wasn't even working so there is no real need for an upgrade note.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate ModelManager::getParentFieldDescription with no replacement
```