### PR TITLE
Remove sonata_help block

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -131,7 +131,7 @@ file that was distributed with this source code.
             {{ form_widget(form, {'required':false}) }}
         </span>
 
-        {{ block('sonata_help') }}
+        {{ form_help(form) }}
 
         <div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-lg">


### PR DESCRIPTION
## Subject

**Fix for the Exception:**
Block "sonata_help" on template "form_div_layout.html.twig" does not exist.

**Deprecation message:**
The "sonata_help" option is deprecated since sonata-project/admin-bundle 3.60, to be removed in 4.0. Use "help" instead.

I am targeting this branch, because this branch gives an exception.

## Changelog

```markdown
### Changed
- Changed `{{ block('sonata_help') }}` to `{{ form_help(form) }}` in `form_admin_fields.html.twig`.
```
