### PR TITLE
Remove references to deprecated help option

### DIFF
--- a/docs/reference/form_field_definition.rst
+++ b/docs/reference/form_field_definition.rst
@@ -24,14 +24,10 @@ Example
             $formMapper
                 ->add('author', ModelListType::class, [])
                 ->add('enabled')
-                ->add('title')
+                // you can define help messages using Symfony help option
+                ->add('title', null, ['help' => 'help_post_title'])
                 ->add('abstract', null, ['required' => false])
-                ->add('content')
-
-                // you can define help messages like this
-                ->setHelps([
-                   'title' => $this->trans('help_post_title')
-                ]);
+                ->add('content');
         }
 
         public function validate(ErrorElement $errorElement, $object)

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -146,14 +146,6 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame($adminMock, $field->getParent());
     }
 
-    public function testGetHelp(): void
-    {
-        $field = new FieldDescription();
-        $field->setHelp('help message');
-
-        $this->assertSame($field->getHelp(), 'help message');
-    }
-
     public function testGetAdmin(): void
     {
         $adminMock = $this->createMock(AdminInterface::class);


### PR DESCRIPTION
Those methods are from `Sonata\AdminBundle\Admin\BaseFieldDescription`, we shouldn't test them here.