### PR TITLE
Add deprecations for ModelManager methods

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -569,8 +569,18 @@ class ModelManager implements ModelManagerInterface, LockInterface
         return new $class();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getSortParameters(FieldDescriptionInterface $fieldDescription, DatagridInterface $datagrid)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $values = $datagrid->getValues();
 
         if ($this->isFieldAlreadySorted($fieldDescription, $datagrid)) {
@@ -588,8 +598,18 @@ class ModelManager implements ModelManagerInterface, LockInterface
         return ['filter' => $values];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getPaginationParameters(DatagridInterface $datagrid, $page)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $values = $datagrid->getValues();
 
         if (isset($values['_sort_by']) && $values['_sort_by'] instanceof FieldDescriptionInterface) {
@@ -633,28 +653,78 @@ class ModelManager implements ModelManagerInterface, LockInterface
         return $instance;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getModelCollectionInstance($class)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return new \Doctrine\Common\Collections\ArrayCollection();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function collectionClear(&$collection)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $collection->clear();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function collectionHasElement(&$collection, &$element)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $collection->contains($element);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function collectionAddElement(&$collection, &$element)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $collection->add($element);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function collectionRemoveElement(&$collection, &$element)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $collection->removeElement($element);
     }
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -59,10 +59,13 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidBinaryEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\UuidEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\VersionedEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class ModelManagerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var ManagerRegistry|MockObject
      */
@@ -143,6 +146,11 @@ class ModelManagerTest extends TestCase
         $this->assertSame($em, $this->modelManager->getEntityManager('x'));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testSortParameters(): void
     {
         $datagrid1 = $this->createMock(Datagrid::class);
@@ -174,6 +182,7 @@ class ModelManagerTest extends TestCase
                 '_sort_order' => 'ASC',
             ]);
 
+        $this->expectDeprecation('Method Sonata\DoctrineORMAdminBundle\Model\ModelManager::getSortParameters() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.');
         $parameters = $this->modelManager->getSortParameters($field1, $datagrid1);
 
         $this->assertSame('DESC', $parameters['filter']['_sort_order']);
@@ -742,8 +751,14 @@ class ModelManagerTest extends TestCase
         $this->assertSame('hello', $object->getMultiWordProperty());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testCollections(): void
     {
+        $this->expectDeprecation('Method Sonata\DoctrineORMAdminBundle\Model\ModelManager::getModelCollectionInstance() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.');
         $collection = $this->modelManager->getModelCollectionInstance('whyDoWeEvenHaveThisParameter');
         $this->assertInstanceOf(ArrayCollection::class, $collection);
 
@@ -770,6 +785,11 @@ class ModelManagerTest extends TestCase
         $this->assertSame('doWeNeedThisMethod', $result);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetPaginationParameters(): void
     {
         $datagrid = $this->createMock(DatagridInterface::class);
@@ -783,6 +803,7 @@ class ModelManagerTest extends TestCase
             ->method('getName')
             ->willReturn($name = 'test');
 
+        $this->expectDeprecation('Method Sonata\DoctrineORMAdminBundle\Model\ModelManager::getPaginationParameters() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.');
         $result = $this->modelManager->getPaginationParameters($datagrid, $page = 5);
 
         $this->assertSame($page, $result['filter']['_page']);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

These methods are deprecated in Sonata Admin.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate ModelManager collections methods.
- Deprecate ModelManager::getPaginationParameters().
- Deprecate ModelManager::getSortParameters().
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
