### PR TITLE
Add supportQuery

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -344,11 +344,29 @@ class ModelManager implements ModelManagerInterface, LockInterface
         return new ProxyQuery($repository->createQueryBuilder($alias));
     }
 
+    public function supportsQuery(object $query): bool
+    {
+        return $query instanceof ProxyQuery || $query instanceof QueryBuilder;
+    }
+
     public function executeQuery($query)
     {
         if ($query instanceof QueryBuilder) {
             return $query->getQuery()->execute();
         }
+
+        if ($query instanceof ProxyQuery) {
+            return $query->execute();
+        }
+
+        // NEXT_MAJOR: Throw an InvalidArgumentException instead.
+        @trigger_error(sprintf(
+            'Not passing an instance of %s or %s as param 1 of %s() is deprecated since'
+            .' sonata-project/doctrine-orm-admin-bundle 3.x and will throw an exception in 4.0.',
+            QueryBuilder::class,
+            ProxyQuery::class,
+            __METHOD__
+        ), E_USER_DEPRECATED);
 
         return $query->execute();
     }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -147,6 +147,21 @@ class ModelManagerTest extends TestCase
     }
 
     /**
+     * @dataProvider supportsQueryDataProvider
+     */
+    public function testSupportsQuery(bool $expected, object $object): void
+    {
+        $this->assertSame($expected, $this->modelManager->supportsQuery($object));
+    }
+
+    public function supportsQueryDataProvider(): iterable
+    {
+        yield [true, $this->createMock(ProxyQuery::class)];
+        yield [true, $this->createMock(QueryBuilder::class)];
+        yield [false, new \stdClass()];
+    }
+
+    /**
      * NEXT_MAJOR: Remove this test.
      *
      * @group legacy


### PR DESCRIPTION
## Subject

Related to https://github.com/sonata-project/SonataAdminBundle/issues/6273
I am targeting this branch, because BC.

## Changelog

```markdown
### Added
- `ModelManager::supportsQuery()` method

### Deprecated
- Calling `executeQuery` on something else than an instance of `Doctrine\ORM\QueryBuilder` or `Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery`.
```
