### PR TITLE
Allow empty string for filtering

### DIFF
--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -67,6 +67,15 @@ Example
         }
     }
 
+StringFilter
+------------
+
+The string filter has additional options:
+
+* ``case_sensitive`` - set to ``false`` to make the search case insensitive. By default ``true`` is used;
+* ``trim`` - use one of ``Sonata\DoctrineORMAdminBundle\Filter\TRIM_*`` constants to control the clearing of blank spaces around in the value. By default ``Sonata\DoctrineORMAdminBundle\Filter\TRIM_BOTH`` is used;
+* ``allow_empty`` - set to ``true`` to enable search by empty value. By default ``false`` is used.
+
 StringListFilter
 ----------------
 

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -29,110 +29,186 @@ class StringFilterTest extends TestCase
 
         $filter->filter($builder, 'alias', 'field', null);
         $filter->filter($builder, 'alias', 'field', '');
+        $filter->filter($builder, 'alias', 'field', []);
 
         $this->assertSame([], $builder->query);
         $this->assertFalse($filter->isActive());
     }
 
-    public function testNullValue(): void
+    public function getValues(): iterable
     {
-        $filter = new StringFilter();
-        $filter->initialize('field_name');
-
-        $builder = new ProxyQuery(new QueryBuilder());
-        $this->assertSame([], $builder->query);
-
-        $filter->filter($builder, 'alias', 'field', ['value' => null, 'type' => StringOperatorType::TYPE_EQUAL]);
-        $this->assertFalse($filter->isActive());
+        return [
+            'filter by normal value' => ['asd', false],
+            'not filter by empty string' => ['', false],
+            'filter by empty string' => ['', true],
+            'not filter by null' => [null, false],
+            'filter by null' => [null, true],
+            'not filter by 0' => [0, false],
+            'filter by 0' => [0, true],
+            'not filter by \'0\'' => ['0', false],
+            'filter by \'0\'' => ['0', true],
+        ];
     }
 
-    public function testContains(): void
+    /**
+     * @dataProvider getValues
+     */
+    public function testDefaultType($value, bool $allowEmpty): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name');
+        $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_CONTAINS]);
-        $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => '%asd%'], $builder->parameters);
+        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => null]);
 
-        $builder = new ProxyQuery(new QueryBuilder());
-        $this->assertSame([], $builder->query);
-
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => null]);
-        $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => '%asd%'], $builder->parameters);
-        $this->assertTrue($filter->isActive());
+        if ('' !== (string) $value) {
+            $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
+            $this->assertSame(['field_name_0' => sprintf('%%%s%%', $value)], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        } else {
+            $this->assertSame([], $builder->query);
+            $this->assertFalse($filter->isActive());
+        }
     }
 
-    public function testStartsWith(): void
+    /**
+     * @dataProvider getValues
+     */
+    public function testContains($value, bool $allowEmpty): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name');
+        $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_STARTS_WITH]);
-        $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => 'asd%'], $builder->parameters);
+        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_CONTAINS]);
+
+        if ('' !== (string) $value) {
+            $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
+            $this->assertSame(['field_name_0' => sprintf('%%%s%%', $value)], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        } else {
+            $this->assertSame([], $builder->query);
+            $this->assertFalse($filter->isActive());
+        }
     }
 
-    public function testEndsWith(): void
+    /**
+     * @dataProvider getValues
+     */
+    public function testStartsWith($value, bool $allowEmpty): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name');
+        $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_ENDS_WITH]);
-        $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => '%asd'], $builder->parameters);
+        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_STARTS_WITH]);
+
+        if ('' !== (string) $value) {
+            $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
+            $this->assertSame(['field_name_0' => sprintf('%s%%', $value)], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        } else {
+            $this->assertSame([], $builder->query);
+            $this->assertFalse($filter->isActive());
+        }
     }
 
-    public function testNotContains(): void
+    /**
+     * @dataProvider getValues
+     */
+    public function testEndsWith($value, bool $allowEmpty): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name');
+        $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_NOT_CONTAINS]);
-        $this->assertSame(['alias.field NOT LIKE :field_name_0 OR alias.field IS NULL'], $builder->query);
-        $this->assertSame(['field_name_0' => '%asd%'], $builder->parameters);
-        $this->assertTrue($filter->isActive());
+        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_ENDS_WITH]);
+
+        if ('' !== (string) $value) {
+            $this->assertSame(['alias.field LIKE :field_name_0'], $builder->query);
+            $this->assertSame(['field_name_0' => sprintf('%%%s', $value)], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        } else {
+            $this->assertSame([], $builder->query);
+            $this->assertFalse($filter->isActive());
+        }
     }
 
-    public function testEquals(): void
+    /**
+     * @dataProvider getValues
+     */
+    public function testNotContains($value, bool $allowEmpty): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name');
+        $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_EQUAL]);
-        $this->assertSame(['alias.field = :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => 'asd'], $builder->parameters);
-        $this->assertTrue($filter->isActive());
+        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_NOT_CONTAINS]);
+
+        if ('' !== (string) $value) {
+            $this->assertSame(['alias.field NOT LIKE :field_name_0 OR alias.field IS NULL'], $builder->query);
+            $this->assertSame(['field_name_0' => sprintf('%%%s%%', $value)], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        } else {
+            $this->assertSame([], $builder->query);
+            $this->assertFalse($filter->isActive());
+        }
     }
 
-    public function testNotEquals(): void
+    /**
+     * @dataProvider getValues
+     */
+    public function testEquals($value, bool $allowEmpty): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name');
+        $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $builder = new ProxyQuery(new QueryBuilder());
         $this->assertSame([], $builder->query);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_NOT_EQUAL]);
-        $this->assertSame(['alias.field <> :field_name_0 OR alias.field IS NULL'], $builder->query);
-        $this->assertSame(['field_name_0' => 'asd'], $builder->parameters);
-        $this->assertTrue($filter->isActive());
+        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_EQUAL]);
+
+        if ('' !== (string) $value || $allowEmpty) {
+            $this->assertSame(['alias.field = :field_name_0'], $builder->query);
+            $this->assertSame(['field_name_0' => (string) ($value ?? '')], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        } else {
+            $this->assertSame([], $builder->query);
+            $this->assertFalse($filter->isActive());
+        }
+    }
+
+    /**
+     * @dataProvider getValues
+     */
+    public function testNotEquals($value, bool $allowEmpty): void
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+        $this->assertSame([], $builder->query);
+
+        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_NOT_EQUAL]);
+
+        if ('' !== (string) $value || $allowEmpty) {
+            $this->assertSame(['alias.field <> :field_name_0 OR alias.field IS NULL'], $builder->query);
+            $this->assertSame(['field_name_0' => (string) ($value ?? '')], $builder->parameters);
+            $this->assertTrue($filter->isActive());
+        } else {
+            $this->assertSame([], $builder->query);
+            $this->assertFalse($filter->isActive());
+        }
     }
 
     public function testEqualsWithValidParentAssociationMappings(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
If the filter value is empty, but the filtering type has been changed from the default value, then this is an indication that the user wants to search by empty value.
We filter by empty value if the filtering type is explicitly specified.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of fix for https://github.com/sonata-project/SonataAdminBundle/issues/3569.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Allow empty string for filtering
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
