### PR TITLE
Add phpstan to CI

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+name: Quality assurance
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: PHPStan
+        uses: "docker://oskarstark/phpstan-ga"
+        env:
+          REQUIRE_DEV: true
+        with:
+          args: analyse -c .phpstan/phpstan.neon.dist

--- a/.phpstan/phpstan-baseline.neon
+++ b/.phpstan/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Class Symfony\\\\Component\\\\Templating\\\\EngineInterface not found\\.$#"
+			count: 3
+			path: ../src/Block/AuditBlockService.php
+

--- a/.phpstan/phpstan.neon.dist
+++ b/.phpstan/phpstan.neon.dist
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 1
+    paths:
+        - ../src

--- a/src/Util/ObjectAclManipulator.php
+++ b/src/Util/ObjectAclManipulator.php
@@ -50,7 +50,6 @@ class ObjectAclManipulator extends BaseObjectAclManipulator
 
             foreach ($qb->getQuery()->iterate() as $row) {
                 $objectIds[] = ObjectIdentity::fromDomainObject($row[0]);
-                $objectIdIterator = new \ArrayIterator($objectIds);
 
                 // detach from Doctrine, so that it can be Garbage-Collected immediately
                 $em->detach($row[0]);
@@ -58,7 +57,7 @@ class ObjectAclManipulator extends BaseObjectAclManipulator
                 ++$count;
 
                 if (0 === ($count % $batchSize)) {
-                    list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, $objectIdIterator, $securityIdentity);
+                    list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, new \ArrayIterator($objectIds), $securityIdentity);
                     $countAdded += $batchAdded;
                     $countUpdated += $batchUpdated;
                     $objectIds = [];
@@ -70,7 +69,7 @@ class ObjectAclManipulator extends BaseObjectAclManipulator
             }
 
             if (\count($objectIds) > 0) {
-                list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, $objectIdIterator, $securityIdentity);
+                list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, new \ArrayIterator($objectIds), $securityIdentity);
                 $countAdded += $batchAdded;
                 $countUpdated += $batchUpdated;
             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When adding phpstan, I also discovered a `Variable $objectIdIterator might not be defined.` error.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix null error in `ObjectAclManipulator`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
