### PR TITLE
Cast the value as string before calling `explode()` at `ModelManager::addIdentifiersToQuery()`

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -502,7 +502,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     }
 
     /**
-     * @phpstan-param non-empty-array<string> $idx
+     * @phpstan-param non-empty-array<string|int> $idx
      *
      * @throws \InvalidArgumentException if value passed as argument 3 is an empty array
      */
@@ -521,7 +521,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $prefix = uniqid();
         $sqls = [];
         foreach ($idx as $pos => $id) {
-            $ids = explode(self::ID_SEPARATOR, $id);
+            $ids = explode(self::ID_SEPARATOR, (string) $id);
 
             $ands = [];
             foreach ($fieldNames as $posName => $name) {

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -1030,6 +1030,7 @@ final class ModelManagerTest extends TestCase
 
     public function addIdentifiersToQueryProvider(): iterable
     {
+        yield [['1', '2'], ['id'], [1, 2]];
         yield [['112', '2020'], ['id'], ['112', '2020']];
         yield [['1', '42', '2', '256'], ['id', 'foreignId'], ['1~42', '2~256']];
         yield [['a', '4', 'b', '52'], ['id', 'foreignId'], ['a~4', 'b~52']];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Cast the value as string before calling `explode()` at `ModelManager::addIdentifiersToQuery()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `TypeError` thrown by `explode()` when receiving non string values as argument 2 from argument 3 at `ModelManager::addIdentifiersToQuery()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
