### PR TITLE
Pass option by_reference in case we're using AdminType

### DIFF
--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -98,6 +98,9 @@ class FormContractor implements FormContractorInterface
 
     public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription)
     {
+        // NEXT_MAJOR: Remove this line and update the function signature.
+        $formOptions = \func_get_args()[2] ?? [];
+
         $options = [];
         $options['sonata_field_description'] = $fieldDescription;
 
@@ -174,13 +177,7 @@ class FormContractor implements FormContractorInterface
 
             $options['type'] = AdminType::class;
             $options['modifiable'] = true;
-            $options['type_options'] = [
-                'sonata_field_description' => $fieldDescription,
-                'data_class' => $fieldDescription->getAssociationAdmin()->getClass(),
-                'empty_data' => static function () use ($fieldDescription) {
-                    return $fieldDescription->getAssociationAdmin()->getNewInstance();
-                },
-            ];
+            $options['type_options'] = $this->getDefaultAdminTypeOptions($fieldDescription, $formOptions);
         }
 
         return $options;
@@ -214,5 +211,22 @@ class FormContractor implements FormContractorInterface
         }
 
         return false;
+    }
+
+    private function getDefaultAdminTypeOptions(FieldDescriptionInterface $fieldDescription, array $formOptions): array
+    {
+        $typeOptions = [
+            'sonata_field_description' => $fieldDescription,
+            'data_class' => $fieldDescription->getAssociationAdmin()->getClass(),
+            'empty_data' => static function () use ($fieldDescription) {
+                return $fieldDescription->getAssociationAdmin()->getNewInstance();
+            },
+        ];
+
+        if (isset($formOptions['by_reference'])) {
+            $typeOptions['by_reference'] = $formOptions['by_reference'];
+        }
+
+        return $typeOptions;
     }
 }

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -116,13 +116,16 @@ final class FormContractorTest extends TestCase
         // collection type
         $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::ONE_TO_MANY);
         foreach ($collectionTypes as $formType) {
-            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
+            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription, [
+                'by_reference' => false,
+            ]);
             $this->assertSame($fieldDescription, $options['sonata_field_description']);
             $this->assertSame(AdminType::class, $options['type']);
             $this->assertTrue($options['modifiable']);
             $this->assertSame($fieldDescription, $options['type_options']['sonata_field_description']);
             $this->assertSame($modelClass, $options['type_options']['data_class']);
             $this->assertSame($model, $options['type_options']['empty_data']());
+            $this->assertFalse($options['type_options']['by_reference']);
         }
     }
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Related to https://github.com/sonata-project/SonataAdminBundle/pull/6438
Then I'll need a release to add a conflict on SonataAdmin.

## Changelog

```markdown
### Added
- `FormContractor::getDefaultOptions()` now pass `by_reference` from `CollectionType` to `AdminType`
```