### PR TITLE
Add deprecation if callback return type is not a boolean

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,40 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter
+
+Deprecate the usage of a callback which does not return a boolean value.
+
+Previously, this was valid:
+```php
+function callback(ProxyQueryInterface $queryBuilder, string $alias, string $field, array $value)
+{
+    if (!$value['value']) {
+        return;
+    }
+
+    // ...
+
+    return true;
+}
+```
+To remove the deprecation, please update the code this way:
+```php
+function callback(ProxyQueryInterface $queryBuilder, string $alias, string $field, array $value): bool
+{
+    if (!$value['value']) {
+        return false;
+    }
+
+    // ...
+
+    return true;
+}
+```
+
 UPGRADE FROM 3.22 to 3.23
 =========================
 

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -255,9 +255,9 @@ In this example, ``getWithOpenCommentField`` and ``getWithOpenCommentFilter`` im
                 ->add('author')
                 ->add('with_open_comments', CallbackFilter::class, [
     //                'callback'   => [$this, 'getWithOpenCommentFilter'],
-                    'callback' => function($queryBuilder, $alias, $field, $value) {
+                    'callback' => static function(ProxyQueryInterface $queryBuilder, string $alias, string $field, array $value): bool {
                         if (!$value['value']) {
-                            return;
+                            return false;
                         }
 
                         $queryBuilder
@@ -274,7 +274,7 @@ In this example, ``getWithOpenCommentField`` and ``getWithOpenCommentFilter`` im
         public function getWithOpenCommentFilter($queryBuilder, $alias, $field, $value)
         {
             if (!$value['value']) {
-                return;
+                return false;
             }
 
             $queryBuilder

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -29,7 +29,22 @@ class CallbackFilter extends Filter
             throw new \RuntimeException(sprintf('Please provide a valid callback option "filter" for field "%s"', $this->getName()));
         }
 
-        $this->active = \call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $value);
+        $isActive = \call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $value);
+        if (!\is_bool($isActive)) {
+            @trigger_error(
+                'Using another return type than boolean for the callback option is deprecated'
+                .' since sonata-project/doctrine-orm-admin-bundle 3.x and will throw an exception in version 4.0.',
+                E_USER_DEPRECATED
+            );
+
+            // NEXT_MAJOR: Uncomment the following code instead of the deprecation.
+//            throw new \UnexpectedValueException(sprintf(
+//                'The callback should return a boolean, %s returned',
+//                \is_object($isActive) ? 'instance of "'.\get_class($isActive).'"' : '"'.\gettype($isActive).'"'
+//            ));
+        }
+
+        $this->active = $isActive;
     }
 
     public function getDefaultOptions()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Using a callback filter with a callback option which does not return a boolean
```