### PR TITLE
Change default route name for association links to show.

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,2 +1,16 @@
 UPGRADE FROM 3.X to 3.0
 =======================
+
+## Deprecations
+
+All the deprecated code introduced on 3.x is removed on 4.0.
+
+Please read [3.x](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/tree/3.x) upgrade guides for more information.
+
+See also the [diff code](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/compare/3.x...4.0.0).
+
+## ModelManager
+
+The default route name for association links is `show` instead of `edit`.
+
+If you want to keep the old behaviour, you SHOULD override the `getNewFieldDescriptionInstance()` method.

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -143,12 +143,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
     public function getNewFieldDescriptionInstance(string $class, string $name, array $options = []): FieldDescriptionInterface
     {
-        if (!\is_string($name)) {
-            throw new \RuntimeException('The name argument must be a string');
-        }
-
         if (!isset($options['route']['name'])) {
-            $options['route']['name'] = 'edit';
+            $options['route']['name'] = 'show';
         }
 
         if (!isset($options['route']['parameters'])) {

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -724,6 +724,54 @@ class ModelManagerTest extends TestCase
         $this->modelManager->getEntityManager(VersionedEntity::class);
     }
 
+    public function testGetNewFieldDescriptionInstance(): void
+    {
+        $modelManager = $this->getMockBuilder(ModelManager::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getParentMetadataForProperty'])
+            ->getMock();
+
+        $modelManager->method('getParentMetadataForProperty')->willReturn([
+            $classMetadata = new ClassMetadata(\stdClass::class),
+            'property',
+            [],
+        ]);
+
+        $fieldDescription = $modelManager->getNewFieldDescriptionInstance(\stdClass::class, 'name', []);
+        $options = $fieldDescription->getOptions();
+
+        $this->assertSame([
+            'route' => ['name' => 'show', 'parameters' => []],
+            'placeholder' => 'short_object_description_placeholder',
+            'link_parameters' => [],
+        ], $options);
+    }
+
+    public function testGetNewFieldDescriptionInstanceWithOptions(): void
+    {
+        $modelManager = $this->getMockBuilder(ModelManager::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getParentMetadataForProperty'])
+            ->getMock();
+
+        $modelManager->method('getParentMetadataForProperty')->willReturn([
+            $classMetadata = new ClassMetadata(\stdClass::class),
+            'property',
+            [],
+        ]);
+
+        $fieldDescription = $modelManager->getNewFieldDescriptionInstance(\stdClass::class, 'name', [
+            'route' => ['name' => 'edit', 'parameters' => ['foo' => 'bar']],
+        ]);
+        $options = $fieldDescription->getOptions();
+
+        $this->assertSame([
+            'route' => ['name' => 'edit', 'parameters' => ['foo' => 'bar']],
+            'placeholder' => 'short_object_description_placeholder',
+            'link_parameters' => [],
+        ], $options);
+    }
+
     /**
      * @dataProvider createUpdateRemoveData
      */


### PR DESCRIPTION
Related to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1160

A global option can still be implemented, but IMHO `show` has more sens than `edit` for the default route name.

If accepted, the same PR should be done to https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle