### PR TITLE
Throw exception if array passed as argument 3 to `ModelManager::addIdentifiersToQuery()` is empty

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -501,8 +501,20 @@ class ModelManager implements ModelManagerInterface, LockInterface
         return $this->getNormalizedIdentifier($entity);
     }
 
+    /**
+     * @phpstan-param non-empty-array<string> $idx
+     *
+     * @throws \InvalidArgumentException if value passed as argument 3 is an empty array
+     */
     public function addIdentifiersToQuery($class, ProxyQueryInterface $query, array $idx)
     {
+        if ([] === $idx) {
+            throw new \InvalidArgumentException(sprintf(
+                'Array passed as argument 3 to "%s()" must not be empty.',
+                __METHOD__
+            ));
+        }
+
         $fieldNames = $this->getIdentifierFieldNames($class);
         $qb = $query->getQueryBuilder();
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -35,6 +35,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
@@ -62,7 +63,7 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestCl
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
-class ModelManagerTest extends TestCase
+final class ModelManagerTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
@@ -979,7 +980,98 @@ class ModelManagerTest extends TestCase
         $this->assertNull($this->modelManager->getNormalizedIdentifier(null));
     }
 
-    private function getMetadata($class, $isVersioned)
+    /**
+     * @dataProvider addIdentifiersToQueryProvider
+     */
+    public function testAddIdentifiersToQuery(array $expectedParameters, array $identifierFieldNames, array $ids): void
+    {
+        $modelManager = $this->getMockBuilder(ModelManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIdentifierFieldNames'])
+            ->getMock();
+
+        $modelManager
+            ->expects($this->once())
+            ->method('getIdentifierFieldNames')
+            ->willReturn($identifierFieldNames);
+
+        $em = $this->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
+            ->setConstructorArgs([$em])
+            ->setMethodsExcept(['getParameters', 'setParameter'])
+            ->getMock();
+
+        $queryBuilder
+            ->expects($this->exactly(\count($expectedParameters)))
+            ->method('getRootAliases')
+            ->willReturn(['p']);
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('andWhere')
+            ->with($this->stringContains(sprintf('( p.%s = :field_', $identifierFieldNames[0])));
+
+        $proxyQuery = $this->getMockBuilder(ProxyQuery::class)
+            ->setConstructorArgs([$queryBuilder])
+            ->setMethods(['getSortBy'])
+            ->getMock();
+
+        $modelManager->addIdentifiersToQuery(Product::class, $proxyQuery, $ids);
+
+        $this->assertCount(\count($expectedParameters), $proxyQuery->getParameters());
+
+        foreach ($proxyQuery->getParameters() as $offset => $parameter) {
+            $this->assertSame($expectedParameters[$offset], $parameter->getValue());
+        }
+    }
+
+    public function addIdentifiersToQueryProvider(): iterable
+    {
+        yield [['112', '2020'], ['id'], ['112', '2020']];
+        yield [['1', '42', '2', '256'], ['id', 'foreignId'], ['1~42', '2~256']];
+        yield [['a', '4', 'b', '52'], ['id', 'foreignId'], ['a~4', 'b~52']];
+        yield [['048b78d8-eced-47bb-8dff-31d7d32352a0', '1986'], ['mixed'], ['048b78d8-eced-47bb-8dff-31d7d32352a0', '1986']];
+        yield [
+            [
+                '048b78d8-eced-47bb-8dff-31d7d32352a0',
+                '3d6e98f5-8e43-4a81-b39b-3303c0aa5841',
+            ], [
+                'guid',
+            ], [
+                '048b78d8-eced-47bb-8dff-31d7d32352a0',
+                '3d6e98f5-8e43-4a81-b39b-3303c0aa5841',
+            ],
+        ];
+        yield [
+            [
+                '048b78d8-eced-47bb-8dff-31d7d32352a0',
+                '3d6e98f5-8e43-4a81-b39b-3303c0aa5841',
+                'dfc1c309-8628-4e1a-8ce3-d3727dedaac6',
+                'f31b0cb3-a7a5-4297-ba3d-d810b286b002',
+            ], [
+                'guid',
+                'foreingGuid',
+            ], [
+                '048b78d8-eced-47bb-8dff-31d7d32352a0~3d6e98f5-8e43-4a81-b39b-3303c0aa5841',
+                'dfc1c309-8628-4e1a-8ce3-d3727dedaac6~f31b0cb3-a7a5-4297-ba3d-d810b286b002',
+            ],
+        ];
+    }
+
+    public function testAddIdentifiersToQueryWithEmptyIdentifiers(): void
+    {
+        $datagrid = $this->createStub(ProxyQueryInterface::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Array passed as argument 3 to "Sonata\DoctrineORMAdminBundle\Model\ModelManager::addIdentifiersToQuery()" must not be empty.');
+
+        $this->modelManager->addIdentifiersToQuery(\stdClass::class, $datagrid, []);
+    }
+
+    private function getMetadata(string $class, bool $isVersioned = false): ClassMetadata
     {
         $metadata = new ClassMetadata($class);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Throw exception if array passed as argument 3 to `ModelManager::addIdentifiersToQuery()` is empty.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because if the query produced by this method is executed, an exception is already thrown.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to sonata-project/SonataAdminBundle#6508.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Check to guarantee that argument 3 passed to `ModelManager::addIdentifiersToQuery()` is not an empty array.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
