### PR TITLE
Remove fieldDescription deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.71",
+        "sonata-project/admin-bundle": "^3.78.1",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -20,11 +20,6 @@ use Sonata\AdminBundle\Admin\BaseFieldDescription;
  */
 class FieldDescription extends BaseFieldDescription
 {
-    public function __construct()
-    {
-        $this->parentAssociationMappings = [];
-    }
-
     public function setAssociationMapping($associationMapping)
     {
         if (!\is_array($associationMapping)) {
@@ -35,6 +30,7 @@ class FieldDescription extends BaseFieldDescription
 
         $this->type = $this->type ?: $associationMapping['type'];
         $this->mappingType = $this->mappingType ?: $associationMapping['type'];
+        // NEXT_MAJOR: Remove the next line.
         $this->fieldName = $associationMapping['fieldName'];
     }
 
@@ -74,6 +70,7 @@ class FieldDescription extends BaseFieldDescription
 
         $this->type = $this->type ?: $fieldMapping['type'];
         $this->mappingType = $this->mappingType ?: $fieldMapping['type'];
+        // NEXT_MAJOR: Remove the next line.
         $this->fieldName = $this->fieldName ?: $fieldMapping['fieldName'];
     }
 

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -162,9 +162,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
         [$metadata, $propertyName, $parentAssociationMappings] = $this->getParentMetadataForProperty($class, $name);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName($name);
-        $fieldDescription->setOptions($options);
+        $fieldDescription = new FieldDescription($name, $options);
         $fieldDescription->setParentAssociationMappings($parentAssociationMappings);
 
         if (isset($metadata->associationMappings[$propertyName])) {

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -24,8 +24,7 @@ class FieldDescriptionTest extends TestCase
 {
     public function testOptions(): void
     {
-        $field = new FieldDescription();
-        $field->setOptions([
+        $field = new FieldDescription('name', [
             'template' => 'foo',
             'type' => 'bar',
             'misc' => 'foobar',
@@ -87,7 +86,7 @@ class FieldDescriptionTest extends TestCase
 
     public function testAssociationMapping(): void
     {
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAssociationMapping([
             'type' => 'integer',
             'fieldName' => 'position',
@@ -114,33 +113,33 @@ class FieldDescriptionTest extends TestCase
 
     public function testSetName(): void
     {
-        $field = new FieldDescription();
-        $field->setName('New field description name');
+        $field = new FieldDescription('New field description name');
 
         $this->assertSame($field->getName(), 'New field description name');
     }
 
     public function testSetNameSetFieldNameToo(): void
     {
-        $field = new FieldDescription();
-        $field->setName('New field description name');
+        $field = new FieldDescription('New field description name');
 
         $this->assertSame($field->getFieldName(), 'New field description name');
     }
 
     public function testSetNameDoesNotSetFieldNameWhenSetBefore(): void
     {
-        $field = new FieldDescription();
-        $field->setFieldName('field name');
-        $field->setName('New field description name');
+        $field = new FieldDescription('New field description name');
 
+        $field->setFieldName('field name');
+        $this->assertSame($field->getFieldName(), 'field name');
+
+        $field->setName('New field description name');
         $this->assertSame($field->getFieldName(), 'field name');
     }
 
     public function testGetParent(): void
     {
         $adminMock = $this->createMock(AdminInterface::class);
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setParent($adminMock);
 
         $this->assertSame($adminMock, $field->getParent());
@@ -149,7 +148,7 @@ class FieldDescriptionTest extends TestCase
     public function testGetAdmin(): void
     {
         $adminMock = $this->createMock(AdminInterface::class);
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAdmin($adminMock);
 
         $this->assertSame($adminMock, $field->getAdmin());
@@ -162,7 +161,7 @@ class FieldDescriptionTest extends TestCase
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf(FieldDescriptionInterface::class));
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAssociationAdmin($adminMock);
 
         $this->assertSame($adminMock, $field->getAssociationAdmin());
@@ -175,7 +174,7 @@ class FieldDescriptionTest extends TestCase
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf(FieldDescriptionInterface::class));
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
 
         $this->assertFalse($field->hasAssociationAdmin());
 
@@ -193,8 +192,7 @@ class FieldDescriptionTest extends TestCase
             ->method('myMethod')
             ->willReturn('myMethodValue');
 
-        $field = new FieldDescription();
-        $field->setFieldName('any string, but not null');
+        $field = new FieldDescription('name');
         $field->setOption('code', 'myMethod');
 
         $this->assertSame($field->getValue($mockedObject), 'myMethodValue');
@@ -211,8 +209,7 @@ class FieldDescriptionTest extends TestCase
             ->method('myMethod')
             ->willReturn('myMethodValue');
 
-        $field = new FieldDescription();
-        $field->setFieldName('any string, but not null');
+        $field = new FieldDescription('name');
 
         $this->assertSame($field->getValue($mockedObject), 'myMethodValue');
     }
@@ -224,7 +221,7 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAssociationMapping($assocationMapping);
 
         $this->assertSame($assocationMapping, $field->getAssociationMapping());
@@ -234,7 +231,7 @@ class FieldDescriptionTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAssociationMapping('test');
     }
 
@@ -242,7 +239,7 @@ class FieldDescriptionTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setFieldMapping('test');
     }
 
@@ -253,7 +250,7 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('position');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertSame('integer', $field->getType());
@@ -266,23 +263,10 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('position');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertSame('integer', $field->getMappingType());
-    }
-
-    public function testSetFieldMappingSetFieldName(): void
-    {
-        $fieldMapping = [
-            'type' => 'integer',
-            'fieldName' => 'position',
-        ];
-
-        $field = new FieldDescription();
-        $field->setFieldMapping($fieldMapping);
-
-        $this->assertSame('position', $field->getFieldName());
     }
 
     public function testGetTargetEntity(): void
@@ -293,7 +277,7 @@ class FieldDescriptionTest extends TestCase
             'targetEntity' => 'someValue',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('position');
 
         $this->assertNull($field->getTargetModel());
 
@@ -310,7 +294,7 @@ class FieldDescriptionTest extends TestCase
             'id' => true,
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('position');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertTrue($field->isIdentifier());
@@ -324,7 +308,7 @@ class FieldDescriptionTest extends TestCase
             'id' => 'someId',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('position');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertSame($fieldMapping, $field->getFieldMapping());
@@ -346,11 +330,10 @@ class FieldDescriptionTest extends TestCase
             ->method('getMyEmbeddedObject')
             ->willReturn($mockedEmbeddedObject);
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('myMethod');
         $field->setFieldMapping([
             'declaredField' => 'myEmbeddedObject', 'type' => 'string', 'fieldName' => 'myEmbeddedObject.myMethod',
         ]);
-        $field->setFieldName('myMethod');
         $field->setOption('code', 'myMethod');
 
         $this->assertSame('myMethodValue', $field->getValue($mockedObject));
@@ -376,11 +359,10 @@ class FieldDescriptionTest extends TestCase
         $mockedObject->expects($this->once())
             ->method('getMyEmbeddedObject')
             ->willReturn($mockedEmbeddedObject);
-        $field = new FieldDescription();
+        $field = new FieldDescription('myMethod');
         $field->setFieldMapping([
             'declaredField' => 'myEmbeddedObject.child', 'type' => 'string', 'fieldName' => 'myMethod',
         ]);
-        $field->setFieldName('myMethod');
         $field->setOption('code', 'myMethod');
         $this->assertSame('myMethodValue', $field->getValue($mockedObject));
     }

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -125,8 +125,7 @@ final class DatagridBuilderTest extends TestCase
         $classMetadata->associationMappings = ['someField' => ['fieldName' => 'fakeField']];
         $classMetadata->embeddedClasses = ['someFieldDeclared' => ['fieldName' => 'fakeField']];
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('test');
+        $fieldDescription = new FieldDescription('test');
         $fieldDescription->setMappingType(ClassMetadata::ONE_TO_MANY);
 
         $this->admin->expects($this->once())->method('attachAdminClass');
@@ -142,8 +141,7 @@ final class DatagridBuilderTest extends TestCase
         $datagrid = $this->createStub(DatagridInterface::class);
         $guessType = $this->createStub(TypeGuess::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('test');
+        $fieldDescription = new FieldDescription('test');
 
         $this->admin->expects($this->once())->method('addFilterFieldDescription');
         $this->admin->method('getCode')->willReturn('someFakeCode');

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -50,8 +50,7 @@ class ListBuilderTest extends TestCase
     {
         $this->admin->expects($this->once())->method('addListFieldDescription');
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('foo');
+        $fieldDescription = new FieldDescription('foo');
 
         $list = $this->listBuilder->getBaseList();
         $this->listBuilder->addField($list, 'actions', $fieldDescription, $this->admin);
@@ -68,8 +67,7 @@ class ListBuilderTest extends TestCase
         $this->admin->expects($this->once())->method('addListFieldDescription');
         $this->typeGuesser->method('guessType')->willReturn(new TypeGuess('_action', [], Guess::LOW_CONFIDENCE));
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('_action');
+        $fieldDescription = new FieldDescription('_action');
         $fieldDescription->setOption('actions', ['test' => []]);
 
         $list = $this->listBuilder->getBaseList();
@@ -100,8 +98,7 @@ class ListBuilderTest extends TestCase
         $this->admin->expects($this->once())->method('attachAdminClass');
         $this->modelManager->method('getParentMetadataForProperty')->willReturn([$classMetadata, 2, []]);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('test');
+        $fieldDescription = new FieldDescription('test');
         $fieldDescription->setOption('sortable', true);
         $fieldDescription->setType('fakeType');
         $fieldDescription->setMappingType($type);
@@ -137,6 +134,6 @@ class ListBuilderTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $this->listBuilder->fixFieldDescription($this->admin, new FieldDescription());
+        $this->listBuilder->fixFieldDescription($this->admin, new FieldDescription('name'));
     }
 }

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -65,8 +65,7 @@ class ShowBuilderTest extends TestCase
     {
         $typeGuess = $this->createStub(TypeGuess::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('FakeName');
+        $fieldDescription = new FieldDescription('FakeName');
         $fieldDescription->setMappingType(ClassMetadata::MANY_TO_ONE);
 
         $this->admin->expects($this->once())->method('attachAdminClass');
@@ -87,8 +86,7 @@ class ShowBuilderTest extends TestCase
 
     public function testAddFieldWithType(): void
     {
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('FakeName');
+        $fieldDescription = new FieldDescription('FakeName');
 
         $this->admin->expects($this->once())->method('addShowFieldDescription');
         $this->modelManager->method('hasMetadata')->willReturn(false);
@@ -111,8 +109,7 @@ class ShowBuilderTest extends TestCase
         $classMetadata->fieldMappings = [2 => []];
         $classMetadata->associationMappings = [2 => ['fieldName' => 'fakeField']];
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('FakeName');
+        $fieldDescription = new FieldDescription('FakeName');
         $fieldDescription->setType($type);
         $fieldDescription->setMappingType($mappingType);
 
@@ -184,6 +181,6 @@ class ShowBuilderTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $this->showBuilder->fixFieldDescription($this->admin, new FieldDescription());
+        $this->showBuilder->fixFieldDescription($this->admin, new FieldDescription('name'));
     }
 }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -172,14 +172,11 @@ final class ModelManagerTest extends TestCase
         $datagrid1 = $this->createMock(Datagrid::class);
         $datagrid2 = $this->createMock(Datagrid::class);
 
-        $field1 = new FieldDescription();
-        $field1->setName('field1');
+        $field1 = new FieldDescription('field1');
 
-        $field2 = new FieldDescription();
-        $field2->setName('field2');
+        $field2 = new FieldDescription('field2');
 
-        $field3 = new FieldDescription();
-        $field3->setName('field3');
+        $field3 = new FieldDescription('field3');
         $field3->setOption('sortable', 'field3sortBy');
 
         $datagrid1


### PR DESCRIPTION
## Subject

BC

## Changelog

```markdown
### Deprecated
- Instantiate a FieldDescription without passing the name as first argument
```