### PR TITLE
Fix date handling through `DateRangeFilter`

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -65,13 +65,15 @@ abstract class AbstractDateFilter extends Filter
             }
 
             // date filter should filter records for the whole days
-            if (false === $this->time) {
-                if ($value['value']['start'] instanceof \DateTime) {
-                    $value['value']['start']->setTime(0, 0, 0);
-                }
-                if ($value['value']['end'] instanceof \DateTime) {
-                    $value['value']['end']->setTime(23, 59, 59);
-                }
+            if (false === $this->time && $value['value']['end'] instanceof \DateTime) {
+                // since the received `\DateTime` object  uses the model timezone to represent
+                // the value submitted by the view (which can use a different timezone) and this
+                // value is intended to contain a time in the begining of a date (IE, if the model
+                // object is configured to use UTC timezone, the view object "2020-11-07 00:00:00.0-03:00"
+                // is transformed to "2020-11-07 03:00:00.0+00:00" in the model object), we increment
+                // the time part by adding "23:59:59" in order to cover the whole end date and get proper
+                // results from queries like "o.created_at <= :date_end".
+                $value['value']['end']->modify('+23 hours 59 minutes 59 seconds');
             }
 
             // transform types

--- a/tests/Filter/DateRangeFilterTest.php
+++ b/tests/Filter/DateRangeFilterTest.php
@@ -20,7 +20,7 @@ use Sonata\DoctrineORMAdminBundle\Filter\DateRangeFilter;
 /**
  * @author Patrick Landolt <patrick.landolt@artack.ch>
  */
-class DateRangeFilterTest extends TestCase
+final class DateRangeFilterTest extends TestCase
 {
     public function testFilterEmpty(): void
     {
@@ -118,5 +118,74 @@ class DateRangeFilterTest extends TestCase
         $this->assertSame(['alias.field <= :field_name_1'], $builder->query);
         $this->assertSame(['field_name_1' => $endDateTime], $builder->parameters);
         $this->assertTrue($filter->isActive());
+    }
+
+    /**
+     * @dataProvider provideDates
+     */
+    public function testFilterEndDateCoversWholeDay(
+        \DateTimeImmutable $expectedEndDateTime,
+        \DateTime $viewEndDateTime,
+        \DateTimeZone $modelTimeZone
+    ): void {
+        $filter = new DateRangeFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $modelEndDateTime = clone $viewEndDateTime;
+        $modelEndDateTime->setTimezone($modelTimeZone);
+
+        $this->assertSame($modelTimeZone->getName(), $modelEndDateTime->getTimezone()->getName());
+        $this->assertNotSame($modelTimeZone->getName(), $viewEndDateTime->getTimezone()->getName());
+
+        $filter->filter($builder, 'alias', 'field', [
+            'type' => null,
+            'value' => [
+                'start' => '',
+                'end' => $modelEndDateTime,
+            ],
+        ]);
+
+        $this->assertTrue($filter->isActive());
+        $this->assertSame(['alias.field <= :field_name_1'], $builder->query);
+        $this->assertSame(['field_name_1' => $modelEndDateTime], $builder->parameters);
+        $this->assertSame($expectedEndDateTime->getTimestamp(), $modelEndDateTime->getTimestamp());
+    }
+
+    /**
+     * @return \Generator<array{\DateTimeImmutable, \DateTime, \DateTimeZone}>
+     */
+    public function provideDates(): iterable
+    {
+        yield [
+            new \DateTimeImmutable('2016-08-31 23:59:59.0-03:00'),
+            new \DateTime('2016-08-31 00:00:00.0-03:00'),
+            new \DateTimeZone('UTC'),
+        ];
+
+        yield [
+            new \DateTimeImmutable('2016-09-01 05:59:59.0-03:00'),
+            new \DateTime('2016-08-31 06:00:00.0-03:00'),
+            new \DateTimeZone('Antarctica/McMurdo'),
+        ];
+
+        yield [
+            new \DateTimeImmutable('2016-09-01 06:07:07.0-03:00'),
+            new \DateTime('2016-08-31 06:07:08.0-03:00'),
+            new \DateTimeZone('Australia/Adelaide'),
+        ];
+
+        yield [
+            new \DateTimeImmutable('2016-08-31 23:59:59.0-00:00'),
+            new \DateTime('2016-08-31 00:00:00.0-00:00'),
+            new \DateTimeZone('Pacific/Honolulu'),
+        ];
+
+        yield [
+            new \DateTimeImmutable('2017-01-01 18:59:59.0+01:00'),
+            new \DateTime('2016-12-31 19:00:00.0+01:00'),
+            new \DateTimeZone('Africa/Cairo'),
+        ];
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix how dates from `DateRangeType` are handled by `DateRangeFilter`.
    
When the `DateRangeType` uses different values between "view_timezone" and "model_timezone" options, the values that are processed by `AbstractDateFilter::filter()` are `\DateTime` objects (start and end) holding the same timestamp than the view data, but represented in the timezone configured for the model data (thus, the offset of these objects is set to the model timezone and the date and time references are adjusted accordingly).
Previous to this commit, these date and time conversions were becoming imprecise since the `\DateTime` objects used in the filter were being manipulated to set the time part to "00:00:00" (in case of start) and to "23:59:59" (in case of end), which produces wrong results given the offset between the view and the model data is lost in these operations.
This commit removes the manipulation of the start time completely, and changes the manipulation done for the end time, by adding "23:59:59" hours to the received value, since both dates are expressed originally at "00:00:00" in the view timezone.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are intended to respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #477.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Setting wrong date and time references at `AbstractDateFilter::filter()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do

- [x] Update the tests;
- [x] Add the corresponding entries for the changelog;
- [x] Add details to the commit message and explain better what this PR fixes.

