### PR TITLE
Add support for `\DateTimeImmutable` at `AbstractDateFilter::filter()`

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -65,7 +65,7 @@ abstract class AbstractDateFilter extends Filter
             }
 
             // date filter should filter records for the whole days
-            if (false === $this->time && $value['value']['end'] instanceof \DateTime) {
+            if (false === $this->time && ($value['value']['end'] instanceof \DateTime || $value['value']['end'] instanceof \DateTimeImmutable)) {
                 // since the received `\DateTime` object  uses the model timezone to represent
                 // the value submitted by the view (which can use a different timezone) and this
                 // value is intended to contain a time in the begining of a date (IE, if the model
@@ -73,13 +73,13 @@ abstract class AbstractDateFilter extends Filter
                 // is transformed to "2020-11-07 03:00:00.0+00:00" in the model object), we increment
                 // the time part by adding "23:59:59" in order to cover the whole end date and get proper
                 // results from queries like "o.created_at <= :date_end".
-                $value['value']['end']->modify('+23 hours 59 minutes 59 seconds');
+                $value['value']['end'] = $value['value']['end']->modify('+23 hours 59 minutes 59 seconds');
             }
 
             // transform types
             if ('timestamp' === $this->getOption('input_type')) {
-                $value['value']['start'] = $value['value']['start'] instanceof \DateTime ? $value['value']['start']->getTimestamp() : 0;
-                $value['value']['end'] = $value['value']['end'] instanceof \DateTime ? $value['value']['end']->getTimestamp() : 0;
+                $value['value']['start'] = $value['value']['start'] instanceof \DateTimeInterface ? $value['value']['start']->getTimestamp() : 0;
+                $value['value']['end'] = $value['value']['end'] instanceof \DateTimeInterface ? $value['value']['end']->getTimestamp() : 0;
             }
 
             // default type for range filter
@@ -120,7 +120,7 @@ abstract class AbstractDateFilter extends Filter
 
             // transform types
             if ('timestamp' === $this->getOption('input_type')) {
-                $value['value'] = $value['value'] instanceof \DateTime ? $value['value']->getTimestamp() : 0;
+                $value['value'] = $value['value'] instanceof \DateTimeInterface ? $value['value']->getTimestamp() : 0;
             }
 
             // null / not null only check for col

--- a/tests/Filter/DateRangeFilterTest.php
+++ b/tests/Filter/DateRangeFilterTest.php
@@ -188,4 +188,27 @@ final class DateRangeFilterTest extends TestCase
             new \DateTimeZone('Africa/Cairo'),
         ];
     }
+
+    public function testFilterEndDateImmutable(): void
+    {
+        $filter = new DateRangeFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $builder = new ProxyQuery(new QueryBuilder());
+
+        $endDateTime = new \DateTimeImmutable('2016-08-31');
+
+        $filter->filter($builder, 'alias', 'field', [
+            'type' => null,
+            'value' => [
+                'start' => '',
+                'end' => $endDateTime,
+            ],
+        ]);
+
+        $this->assertSame(['alias.field <= :field_name_1'], $builder->query);
+        $this->assertCount(1, $builder->parameters);
+        $this->assertSame($endDateTime->modify('+23 hours 59 minutes 59 seconds')->getTimestamp(), $builder->parameters['field_name_1']->getTimestamp());
+        $this->assertTrue($filter->isActive());
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add support for `\DateTimeImmutable` at `AbstractDateFilter::filter()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for `\DateTimeImmutable` at `AbstractDateFilter::filter()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
