### PR TITLE
Fix not to call an id method without object.

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -56,7 +56,7 @@ file that was distributed with this source code.
 {% block sonata_type_model_list_widget %}
     <div id="field_container_{{ id }}" class="field-container">
         <span id="field_widget_{{ id }}" class="field-short-description">
-            {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
+            {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
                 {{ render(path('sonata_admin_short_object_information', {
                     'code':     sonata_admin.field_description.associationadmin.code,
                     'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -56,7 +56,7 @@ file that was distributed with this source code.
 {% block sonata_type_model_list_widget %}
     <div id="field_container_{{ id }}" class="field-container">
         <span id="field_widget_{{ id }}" class="field-short-description">
-            {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
+            {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) is not null %}
                 {{ render(path('sonata_admin_short_object_information', {
                     'code':     sonata_admin.field_description.associationadmin.code,
                     'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),


### PR DESCRIPTION
## Subject
In next major of **SonataAdminBundle** only object will be allowed as argument for the `id` method, so we need to skip calling this method without object.

I am targeting this branch, because this change respects BC.
