### PR TITLE
Remove the deprecation from getNormalizedIdentifier

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.24 to 3.25
 =========================
 
+### Sonata\DoctrineORMAdminBundle\Model\ModelManager
+
+Previously passing an object which is in state new or removed as argument 1 for `getNormalizedIdentifier()` was deprecated and would throw an exception in 4.0. Since throwing an exception is not allowed (and returning `null` is still allowed), the deprecation is removed.
+
 ### Added full support for `\DateTimeImmutable` in filters extending `Sonata\DoctrineORMAdminBundle\Filter\AbstractDateFilter`
 
 - `Sonata\DoctrineORMAdminBundle\Filter\DateFilter`

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -451,21 +451,6 @@ class ModelManager implements ModelManagerInterface, LockInterface
             UnitOfWork::STATE_NEW,
             UnitOfWork::STATE_REMOVED,
         ], true)) {
-            // NEXT_MAJOR: Uncomment the following exception, remove the deprecation and the return statement inside this conditional block.
-            // throw new \InvalidArgumentException(sprintf(
-            //    'Can not get the normalized identifier for %s since it is in state %u.',
-            //    ClassUtils::getClass($entity),
-            //    $this->getEntityManager($entity)->getUnitOfWork()->getEntityState($entity)
-            // ));
-
-            @trigger_error(sprintf(
-                'Passing an object which is in state %u (new) or %u (removed) as argument 1 for %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.20'
-                .'and will be not allowed in version 4.0.',
-                UnitOfWork::STATE_NEW,
-                UnitOfWork::STATE_REMOVED,
-                __METHOD__
-            ), E_USER_DEPRECATED);
-
             return null;
         }
 


### PR DESCRIPTION
## Subject

Remove the deprecation in `getNormalizedIdentifier`, because of allow null as return type for `getUrlSafeIdentifier`, `getNormalizedIdentifier` and `id` in **SonataAdmin**.

I am targeting this branch, because this change respects BC.
