### PR TITLE
Pass collection_by_reference instead of by_reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.78.1",
+        "sonata-project/admin-bundle": "^3.79",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -224,7 +224,7 @@ class FormContractor implements FormContractorInterface
         ];
 
         if (isset($formOptions['by_reference'])) {
-            $typeOptions['by_reference'] = $formOptions['by_reference'];
+            $typeOptions['collection_by_reference'] = $formOptions['by_reference'];
         }
 
         return $typeOptions;

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -125,7 +125,7 @@ final class FormContractorTest extends TestCase
             $this->assertSame($fieldDescription, $options['type_options']['sonata_field_description']);
             $this->assertSame($modelClass, $options['type_options']['data_class']);
             $this->assertSame($model, $options['type_options']['empty_data']());
-            $this->assertFalse($options['type_options']['by_reference']);
+            $this->assertFalse($options['type_options']['collection_by_reference']);
         }
     }
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because bug fix.

`by_reference` had conflict with the symfony option, so SonataAdmin change the name of the option.

Close https://github.com/sonata-project/SonataAdminBundle/issues/6564

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `FormContractor::getDefaultOptions()` passes `collection_by_reference` option instead of `by_reference` to `AdminType` in order to respect the new API
```