### PR TITLE
Add deprecation for filter method

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,12 @@
 UPGRADE 3.x
 ===========
 
+### Sonata\DoctrineORMAdminBundle\Filter\Filter
+
+Deprecate passing an instance of `Sonata\AdminBundle\Datagrid\ProxyQueryInterface`
+which is not an instance of `Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery` as
+argument 1 to the `Sonata\DoctrineORMAdminBundle\Filter\Filter::filter()` method.
+
 UPGRADE FROM 3.25 to 3.26
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.80",
+        "sonata-project/admin-bundle": "^3.82",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
  */
 class BooleanFilter extends Filter
 {
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -37,33 +37,33 @@ class BooleanFilter extends Filter
             ));
         }
 
-        if (!$value || !\is_array($value) || !\array_key_exists('type', $value) || !\array_key_exists('value', $value)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {
             return;
         }
 
-        if (\is_array($value['value'])) {
-            $values = [];
-            foreach ($value['value'] as $v) {
+        if (\is_array($data['value'])) {
+            $datas = [];
+            foreach ($data['value'] as $v) {
                 if (!\in_array($v, [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
                     continue;
                 }
 
-                $values[] = (BooleanType::TYPE_YES === $v) ? 1 : 0;
+                $datas[] = (BooleanType::TYPE_YES === $v) ? 1 : 0;
             }
 
-            if (0 === \count($values)) {
+            if (0 === \count($datas)) {
                 return;
             }
 
-            $this->applyWhere($query, $query->getQueryBuilder()->expr()->in(sprintf('%s.%s', $alias, $field), $values));
+            $this->applyWhere($query, $query->getQueryBuilder()->expr()->in(sprintf('%s.%s', $alias, $field), $datas));
         } else {
-            if (!\in_array($value['value'], [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
+            if (!\in_array($data['value'], [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
                 return;
             }
 
             $parameterName = $this->getNewParameterName($query);
             $this->applyWhere($query, sprintf('%s.%s = :%s', $alias, $field, $parameterName));
-            $query->getQueryBuilder()->setParameter($parameterName, (BooleanType::TYPE_YES === $value['value']) ? 1 : 0);
+            $query->getQueryBuilder()->setParameter($parameterName, (BooleanType::TYPE_YES === $data['value']) ? 1 : 0);
         }
     }
 

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\Form\Type\BooleanType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
@@ -23,8 +24,19 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
  */
 class BooleanFilter extends Filter
 {
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!$value || !\is_array($value) || !\array_key_exists('type', $value) || !\array_key_exists('value', $value)) {
             return;
         }
@@ -43,15 +55,15 @@ class BooleanFilter extends Filter
                 return;
             }
 
-            $this->applyWhere($queryBuilder, $queryBuilder->expr()->in(sprintf('%s.%s', $alias, $field), $values));
+            $this->applyWhere($query, $query->getQueryBuilder()->expr()->in(sprintf('%s.%s', $alias, $field), $values));
         } else {
             if (!\in_array($value['value'], [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
                 return;
             }
 
-            $parameterName = $this->getNewParameterName($queryBuilder);
-            $this->applyWhere($queryBuilder, sprintf('%s.%s = :%s', $alias, $field, $parameterName));
-            $queryBuilder->setParameter($parameterName, (BooleanType::TYPE_YES === $value['value']) ? 1 : 0);
+            $parameterName = $this->getNewParameterName($query);
+            $this->applyWhere($query, sprintf('%s.%s = :%s', $alias, $field, $parameterName));
+            $query->getQueryBuilder()->setParameter($parameterName, (BooleanType::TYPE_YES === $value['value']) ? 1 : 0);
         }
     }
 

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -42,20 +42,20 @@ class BooleanFilter extends Filter
         }
 
         if (\is_array($data['value'])) {
-            $datas = [];
+            $values = [];
             foreach ($data['value'] as $v) {
                 if (!\in_array($v, [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
                     continue;
                 }
 
-                $datas[] = (BooleanType::TYPE_YES === $v) ? 1 : 0;
+                $values[] = (BooleanType::TYPE_YES === $v) ? 1 : 0;
             }
 
-            if (0 === \count($datas)) {
+            if (0 === \count($values)) {
                 return;
             }
 
-            $this->applyWhere($query, $query->getQueryBuilder()->expr()->in(sprintf('%s.%s', $alias, $field), $datas));
+            $this->applyWhere($query, $query->getQueryBuilder()->expr()->in(sprintf('%s.%s', $alias, $field), $values));
         } else {
             if (!\in_array($data['value'], [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
                 return;

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 class CallbackFilter extends Filter
 {
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -41,7 +41,7 @@ class CallbackFilter extends Filter
             throw new \RuntimeException(sprintf('Please provide a valid callback option "filter" for field "%s"', $this->getName()));
         }
 
-        $isActive = \call_user_func($this->getOption('callback'), $query, $alias, $field, $value);
+        $isActive = \call_user_func($this->getOption('callback'), $query, $alias, $field, $data);
         if (!\is_bool($isActive)) {
             @trigger_error(
                 'Using another return type than boolean for the callback option is deprecated'
@@ -81,11 +81,11 @@ class CallbackFilter extends Filter
     }
 
     /**
-     * @param mixed[] $value
+     * @param mixed[] $data
      *
      * @return array
      */
-    protected function association(BaseProxyQueryInterface $query, $value)
+    protected function association(BaseProxyQueryInterface $query, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
@@ -23,13 +24,24 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 class CallbackFilter extends Filter
 {
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!\is_callable($this->getOption('callback'))) {
             throw new \RuntimeException(sprintf('Please provide a valid callback option "filter" for field "%s"', $this->getName()));
         }
 
-        $isActive = \call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $value);
+        $isActive = \call_user_func($this->getOption('callback'), $query, $alias, $field, $value);
         if (!\is_bool($isActive)) {
             @trigger_error(
                 'Using another return type than boolean for the callback option is deprecated'
@@ -73,9 +85,20 @@ class CallbackFilter extends Filter
      *
      * @return array
      */
-    protected function association(ProxyQueryInterface $queryBuilder, $value)
+    protected function association(BaseProxyQueryInterface $query, $value)
     {
-        $alias = $queryBuilder->entityJoin($this->getParentAssociationMappings());
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
+        $alias = $query->entityJoin($this->getParentAssociationMappings());
 
         return [$this->getOption('alias', $alias), $this->getFieldName()];
     }

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -66,23 +66,16 @@ class ChoiceFilter extends Filter
         ]];
     }
 
+    /**
+     * NEXT_MAJOR: Change the typehint to ProxyQueryInterface.
+     */
     private function filterWithMultipleValues(BaseProxyQueryInterface $query, string $alias, string $field, array $data = []): void
     {
-        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
-        if (!$query instanceof ProxyQueryInterface) {
-            @trigger_error(sprintf(
-                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
-                \get_class($query),
-                __METHOD__,
-                ProxyQueryInterface::class
-            ));
-        }
-
         if (0 === \count($data['value'])) {
             return;
         }
 
+        // NEXT_MAJOR: Remove this case.
         if (\in_array('all', $data['value'], true)) {
             return;
         }
@@ -112,19 +105,12 @@ class ChoiceFilter extends Filter
         }
     }
 
+    /**
+     * NEXT_MAJOR: Change the typehint to ProxyQueryInterface.
+     */
     private function filterWithSingleValue(BaseProxyQueryInterface $query, string $alias, string $field, array $data = []): void
     {
-        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
-        if (!$query instanceof ProxyQueryInterface) {
-            @trigger_error(sprintf(
-                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
-                \get_class($query),
-                __METHOD__,
-                ProxyQueryInterface::class
-            ));
-        }
-
+        // NEXT_MAJOR: Remove 'all' case.
         if ('' === $data['value'] || false === $data['value'] || 'all' === $data['value']) {
             return;
         }

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -23,7 +23,7 @@ use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
  */
 class ChoiceFilter extends Filter
 {
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -36,14 +36,14 @@ class ChoiceFilter extends Filter
             ));
         }
 
-        if (!$value || !\is_array($value) || !\array_key_exists('type', $value) || !\array_key_exists('value', $value)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {
             return;
         }
 
-        if (\is_array($value['value'])) {
-            $this->filterWithMultipleValues($query, $alias, $field, $value);
+        if (\is_array($data['value'])) {
+            $this->filterWithMultipleValues($query, $alias, $field, $data);
         } else {
-            $this->filterWithSingleValue($query, $alias, $field, $value);
+            $this->filterWithSingleValue($query, $alias, $field, $data);
         }
     }
 
@@ -88,8 +88,8 @@ class ChoiceFilter extends Filter
         }
 
         $isNullSelected = \in_array(null, $data['value'], true);
-        $data['value'] = array_filter($data['value'], static function ($value): bool {
-            return null !== $value;
+        $data['value'] = array_filter($data['value'], static function ($data): bool {
+            return null !== $data;
         });
 
         // Have to pass IN array value as parameter. See: http://www.doctrine-project.org/jira/browse/DDC-3759

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 /**
@@ -28,8 +29,19 @@ class ClassFilter extends Filter
         EqualOperatorType::TYPE_NOT_EQUAL => 'NOT INSTANCE OF',
     ];
 
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!$value || !\is_array($value) || !\array_key_exists('value', $value)) {
             return;
         }
@@ -41,7 +53,7 @@ class ClassFilter extends Filter
         $type = $value['type'] ?? EqualOperatorType::TYPE_EQUAL;
         $operator = $this->getOperator((int) $type);
 
-        $this->applyWhere($queryBuilder, sprintf('%s %s %s', $alias, $operator, $value['value']));
+        $this->applyWhere($query, sprintf('%s %s %s', $alias, $operator, $value['value']));
     }
 
     public function getDefaultOptions()

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -29,7 +29,7 @@ class ClassFilter extends Filter
         EqualOperatorType::TYPE_NOT_EQUAL => 'NOT INSTANCE OF',
     ];
 
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -42,18 +42,18 @@ class ClassFilter extends Filter
             ));
         }
 
-        if (!$value || !\is_array($value) || !\array_key_exists('value', $value)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('value', $data)) {
             return;
         }
 
-        if (0 === \strlen($value['value'])) {
+        if (0 === \strlen($data['value'])) {
             return;
         }
 
-        $type = $value['type'] ?? EqualOperatorType::TYPE_EQUAL;
+        $type = $data['type'] ?? EqualOperatorType::TYPE_EQUAL;
         $operator = $this->getOperator((int) $type);
 
-        $this->applyWhere($query, sprintf('%s %s %s', $alias, $operator, $value['value']));
+        $this->applyWhere($query, sprintf('%s %s %s', $alias, $operator, $data['value']));
     }
 
     public function getDefaultOptions()

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -24,9 +24,9 @@ final class EmptyFilter extends Filter
     /**
      * @param string       $alias
      * @param string       $field
-     * @param mixed[]|null $value
+     * @param mixed[]|null $data
      */
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value): void
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data): void
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -39,12 +39,12 @@ final class EmptyFilter extends Filter
             ));
         }
 
-        if (null === $value || !\is_array($value) || !\array_key_exists('value', $value)) {
+        if (null === $data || !\is_array($data) || !\array_key_exists('value', $data)) {
             return;
         }
 
-        $isYes = BooleanType::TYPE_YES === (int) $value['value'];
-        $isNo = BooleanType::TYPE_NO === (int) $value['value'];
+        $isYes = BooleanType::TYPE_YES === (int) $data['value'];
+        $isNo = BooleanType::TYPE_NO === (int) $data['value'];
 
         if (!$this->getOption('inverse') && $isYes || $this->getOption('inverse') && $isNo) {
             $this->applyWhere(

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -31,17 +31,17 @@ abstract class Filter extends BaseFilter
      *
      * @param string  $alias
      * @param string  $field
-     * @param mixed[] $value
+     * @param mixed[] $data
      */
-    abstract public function filter(BaseProxyQueryInterface $query, $alias, $field, $value);
+    abstract public function filter(BaseProxyQueryInterface $query, $alias, $field, $data);
 
-    public function apply($query, $value)
+    public function apply($query, $filterData)
     {
-        $this->value = $value;
-        if (\is_array($value) && \array_key_exists('value', $value)) {
-            [$alias, $field] = $this->association($query, $value);
+        $this->value = $filterData;
+        if (\is_array($filterData) && \array_key_exists('value', $filterData)) {
+            [$alias, $field] = $this->association($query, $filterData);
 
-            $this->filter($query, $alias, $field, $value);
+            $this->filter($query, $alias, $field, $filterData);
         }
     }
 
@@ -51,11 +51,11 @@ abstract class Filter extends BaseFilter
     }
 
     /**
-     * @param mixed[] $value
+     * @param mixed[] $data
      *
      * @return string[]
      */
-    protected function association(BaseProxyQueryInterface $query, array $value)
+    protected function association(BaseProxyQueryInterface $query, array $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Doctrine\ORM\QueryBuilder;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter as BaseFilter;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 
 abstract class Filter extends BaseFilter
 {
@@ -23,6 +23,17 @@ abstract class Filter extends BaseFilter
      * @var bool
      */
     protected $active = false;
+
+    /**
+     * NEXT_MAJOR change $query type for Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface.
+     *
+     * Apply the filter to the QueryBuilder instance.
+     *
+     * @param string  $alias
+     * @param string  $field
+     * @param mixed[] $value
+     */
+    abstract public function filter(BaseProxyQueryInterface $query, $alias, $field, $value);
 
     public function apply($query, $value)
     {
@@ -44,23 +55,44 @@ abstract class Filter extends BaseFilter
      *
      * @return string[]
      */
-    protected function association(ProxyQueryInterface $queryBuilder, array $value)
+    protected function association(BaseProxyQueryInterface $query, array $value)
     {
-        $alias = $queryBuilder->entityJoin($this->getParentAssociationMappings());
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
+        $alias = $query->entityJoin($this->getParentAssociationMappings());
 
         return [$alias, $this->getFieldName()];
     }
 
     /**
-     * @param ProxyQueryInterface|QueryBuilder $queryBuilder
-     * @param mixed                            $parameter
+     * @param mixed $parameter
      */
-    protected function applyWhere(ProxyQueryInterface $queryBuilder, $parameter)
+    protected function applyWhere(BaseProxyQueryInterface $query, $parameter)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (self::CONDITION_OR === $this->getCondition()) {
-            $queryBuilder->orWhere($parameter);
+            $query->getQueryBuilder()->orWhere($parameter);
         } else {
-            $queryBuilder->andWhere($parameter);
+            $query->getQueryBuilder()->andWhere($parameter);
         }
 
         // filter is active since it's added to the queryBuilder
@@ -70,10 +102,21 @@ abstract class Filter extends BaseFilter
     /**
      * @return string
      */
-    protected function getNewParameterName(ProxyQueryInterface $queryBuilder)
+    protected function getNewParameterName(BaseProxyQueryInterface $query)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         // dots are not accepted in a DQL identifier so replace them
         // by underscores.
-        return str_replace('.', '_', $this->getName()).'_'.$queryBuilder->getUniqueParameterId();
+        return str_replace('.', '_', $this->getName()).'_'.$query->getUniqueParameterId();
     }
 }

--- a/src/Filter/ModelAutocompleteFilter.php
+++ b/src/Filter/ModelAutocompleteFilter.php
@@ -25,7 +25,7 @@ use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
  */
 class ModelAutocompleteFilter extends Filter
 {
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -38,18 +38,18 @@ class ModelAutocompleteFilter extends Filter
             ));
         }
 
-        if (!$value || !\is_array($value) || !\array_key_exists('value', $value)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('value', $data)) {
             return;
         }
 
-        if ($value['value'] instanceof Collection) {
-            $value['value'] = $value['value']->toArray();
+        if ($data['value'] instanceof Collection) {
+            $data['value'] = $data['value']->toArray();
         }
 
-        if (\is_array($value['value'])) {
-            $this->handleMultiple($query, $alias, $value);
+        if (\is_array($data['value'])) {
+            $this->handleMultiple($query, $alias, $data);
         } else {
-            $this->handleModel($query, $alias, $value);
+            $this->handleModel($query, $alias, $data);
         }
     }
 
@@ -80,11 +80,11 @@ class ModelAutocompleteFilter extends Filter
      *  so the field value is not used here.
      *
      * @param string  $alias
-     * @param mixed[] $value
+     * @param mixed[] $data
      *
      * @return void
      */
-    protected function handleMultiple(BaseProxyQueryInterface $query, $alias, $value)
+    protected function handleMultiple(BaseProxyQueryInterface $query, $alias, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -97,28 +97,28 @@ class ModelAutocompleteFilter extends Filter
             ));
         }
 
-        if (0 === \count($value['value'])) {
+        if (0 === \count($data['value'])) {
             return;
         }
 
         $parameterName = $this->getNewParameterName($query);
 
-        if (isset($value['type']) && EqualOperatorType::TYPE_NOT_EQUAL === $value['type']) {
+        if (isset($data['type']) && EqualOperatorType::TYPE_NOT_EQUAL === $data['type']) {
             $this->applyWhere($query, $query->getQueryBuilder()->expr()->notIn($alias, ':'.$parameterName));
         } else {
             $this->applyWhere($query, $query->getQueryBuilder()->expr()->in($alias, ':'.$parameterName));
         }
 
-        $query->getQueryBuilder()->setParameter($parameterName, $value['value']);
+        $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
     }
 
     /**
      * @param string  $alias
-     * @param mixed[] $value
+     * @param mixed[] $data
      *
      * @return void
      */
-    protected function handleModel(BaseProxyQueryInterface $query, $alias, $value)
+    protected function handleModel(BaseProxyQueryInterface $query, $alias, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -131,29 +131,29 @@ class ModelAutocompleteFilter extends Filter
             ));
         }
 
-        if (empty($value['value'])) {
+        if (empty($data['value'])) {
             return;
         }
 
         $parameterName = $this->getNewParameterName($query);
 
-        if (isset($value['type']) && EqualOperatorType::TYPE_NOT_EQUAL === $value['type']) {
+        if (isset($data['type']) && EqualOperatorType::TYPE_NOT_EQUAL === $data['type']) {
             $this->applyWhere($query, sprintf('%s != :%s', $alias, $parameterName));
         } else {
             $this->applyWhere($query, sprintf('%s = :%s', $alias, $parameterName));
         }
 
-        $query->getQueryBuilder()->setParameter($parameterName, $value['value']);
+        $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
     }
 
     /**
-     * @param mixed[] $value
+     * @param mixed[] $data
      *
      * @return array
      *
      * @phpstan-return array{string, bool}
      */
-    protected function association(BaseProxyQueryInterface $query, $value)
+    protected function association(BaseProxyQueryInterface $query, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {

--- a/src/Filter/ModelAutocompleteFilter.php
+++ b/src/Filter/ModelAutocompleteFilter.php
@@ -14,19 +14,30 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\QueryBuilder;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
  */
 class ModelAutocompleteFilter extends Filter
 {
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!$value || !\is_array($value) || !\array_key_exists('value', $value)) {
             return;
         }
@@ -36,9 +47,9 @@ class ModelAutocompleteFilter extends Filter
         }
 
         if (\is_array($value['value'])) {
-            $this->handleMultiple($queryBuilder, $alias, $value);
+            $this->handleMultiple($query, $alias, $value);
         } else {
-            $this->handleModel($queryBuilder, $alias, $value);
+            $this->handleModel($query, $alias, $value);
         }
     }
 
@@ -68,51 +79,71 @@ class ModelAutocompleteFilter extends Filter
      * For the record, the $alias value is provided by the association method (and the entity join method)
      *  so the field value is not used here.
      *
-     * @param ProxyQueryInterface|QueryBuilder $queryBuilder
-     * @param string                           $alias
-     * @param mixed[]                          $value
+     * @param string  $alias
+     * @param mixed[] $value
      *
      * @return void
      */
-    protected function handleMultiple(ProxyQueryInterface $queryBuilder, $alias, $value)
+    protected function handleMultiple(BaseProxyQueryInterface $query, $alias, $value)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (0 === \count($value['value'])) {
             return;
         }
 
-        $parameterName = $this->getNewParameterName($queryBuilder);
+        $parameterName = $this->getNewParameterName($query);
 
         if (isset($value['type']) && EqualOperatorType::TYPE_NOT_EQUAL === $value['type']) {
-            $this->applyWhere($queryBuilder, $queryBuilder->expr()->notIn($alias, ':'.$parameterName));
+            $this->applyWhere($query, $query->getQueryBuilder()->expr()->notIn($alias, ':'.$parameterName));
         } else {
-            $this->applyWhere($queryBuilder, $queryBuilder->expr()->in($alias, ':'.$parameterName));
+            $this->applyWhere($query, $query->getQueryBuilder()->expr()->in($alias, ':'.$parameterName));
         }
 
-        $queryBuilder->setParameter($parameterName, $value['value']);
+        $query->getQueryBuilder()->setParameter($parameterName, $value['value']);
     }
 
     /**
-     * @param ProxyQueryInterface|QueryBuilder $queryBuilder
-     * @param string                           $alias
-     * @param mixed[]                          $value
+     * @param string  $alias
+     * @param mixed[] $value
      *
      * @return void
      */
-    protected function handleModel(ProxyQueryInterface $queryBuilder, $alias, $value)
+    protected function handleModel(BaseProxyQueryInterface $query, $alias, $value)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (empty($value['value'])) {
             return;
         }
 
-        $parameterName = $this->getNewParameterName($queryBuilder);
+        $parameterName = $this->getNewParameterName($query);
 
         if (isset($value['type']) && EqualOperatorType::TYPE_NOT_EQUAL === $value['type']) {
-            $this->applyWhere($queryBuilder, sprintf('%s != :%s', $alias, $parameterName));
+            $this->applyWhere($query, sprintf('%s != :%s', $alias, $parameterName));
         } else {
-            $this->applyWhere($queryBuilder, sprintf('%s = :%s', $alias, $parameterName));
+            $this->applyWhere($query, sprintf('%s = :%s', $alias, $parameterName));
         }
 
-        $queryBuilder->setParameter($parameterName, $value['value']);
+        $query->getQueryBuilder()->setParameter($parameterName, $value['value']);
     }
 
     /**
@@ -122,11 +153,22 @@ class ModelAutocompleteFilter extends Filter
      *
      * @phpstan-return array{string, bool}
      */
-    protected function association(ProxyQueryInterface $queryBuilder, $value)
+    protected function association(BaseProxyQueryInterface $query, $value)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         $associationMappings = $this->getParentAssociationMappings();
         $associationMappings[] = $this->getAssociationMapping();
-        $alias = $queryBuilder->entityJoin($associationMappings);
+        $alias = $query->entityJoin($associationMappings);
 
         return [$alias, false];
     }

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -26,7 +26,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
  */
 class ModelFilter extends Filter
 {
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -39,19 +39,19 @@ class ModelFilter extends Filter
             ));
         }
 
-        if (!$value || !\is_array($value) || !\array_key_exists('value', $value) || empty($value['value'])) {
+        if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || empty($data['value'])) {
             return;
         }
 
-        if ($value['value'] instanceof Collection) {
-            $value['value'] = $value['value']->toArray();
+        if ($data['value'] instanceof Collection) {
+            $data['value'] = $data['value']->toArray();
         }
 
-        if (!\is_array($value['value'])) {
-            $value['value'] = [$value['value']];
+        if (!\is_array($data['value'])) {
+            $data['value'] = [$data['value']];
         }
 
-        $this->handleMultiple($query, $alias, $value);
+        $this->handleMultiple($query, $alias, $data);
     }
 
     public function getDefaultOptions()
@@ -82,11 +82,11 @@ class ModelFilter extends Filter
      *  so the field value is not used here.
      *
      * @param string  $alias
-     * @param mixed[] $value
+     * @param mixed[] $data
      *
      * @return void
      */
-    protected function handleMultiple(BaseProxyQueryInterface $query, $alias, $value)
+    protected function handleMultiple(BaseProxyQueryInterface $query, $alias, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -99,13 +99,13 @@ class ModelFilter extends Filter
             ));
         }
 
-        if (0 === \count($value['value'])) {
+        if (0 === \count($data['value'])) {
             return;
         }
 
         $parameterName = $this->getNewParameterName($query);
 
-        if (isset($value['type']) && EqualOperatorType::TYPE_NOT_EQUAL === $value['type']) {
+        if (isset($data['type']) && EqualOperatorType::TYPE_NOT_EQUAL === $data['type']) {
             $or = $query->getQueryBuilder()->expr()->orX();
 
             $or->add($query->getQueryBuilder()->expr()->notIn($alias, ':'.$parameterName));
@@ -125,17 +125,17 @@ class ModelFilter extends Filter
             $this->applyWhere($query, $query->getQueryBuilder()->expr()->in($alias, ':'.$parameterName));
         }
 
-        $query->getQueryBuilder()->setParameter($parameterName, $value['value']);
+        $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
     }
 
     /**
-     * @param mixed[] $value
+     * @param mixed[] $data
      *
      * @return array
      *
      * @phpstan-return array{string, bool}
      */
-    protected function association(BaseProxyQueryInterface $query, $value)
+    protected function association(BaseProxyQueryInterface $query, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -31,7 +31,7 @@ class NumberFilter extends Filter
         NumberOperatorType::TYPE_LESS_THAN => '<',
     ];
 
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -44,17 +44,17 @@ class NumberFilter extends Filter
             ));
         }
 
-        if (!$value || !\is_array($value) || !\array_key_exists('value', $value) || !is_numeric($value['value'])) {
+        if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || !is_numeric($data['value'])) {
             return;
         }
 
-        $type = $value['type'] ?? NumberOperatorType::TYPE_EQUAL;
+        $type = $data['type'] ?? NumberOperatorType::TYPE_EQUAL;
         $operator = $this->getOperator((int) $type);
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($query);
         $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
-        $query->getQueryBuilder()->setParameter($parameterName, $value['value']);
+        $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
     }
 
     public function getDefaultOptions()

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\NumberType;
 use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
@@ -30,8 +31,19 @@ class NumberFilter extends Filter
         NumberOperatorType::TYPE_LESS_THAN => '<',
     ];
 
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!$value || !\is_array($value) || !\array_key_exists('value', $value) || !is_numeric($value['value'])) {
             return;
         }
@@ -40,9 +52,9 @@ class NumberFilter extends Filter
         $operator = $this->getOperator((int) $type);
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
-        $parameterName = $this->getNewParameterName($queryBuilder);
-        $this->applyWhere($queryBuilder, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
-        $queryBuilder->setParameter($parameterName, $value['value']);
+        $parameterName = $this->getNewParameterName($query);
+        $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
+        $query->getQueryBuilder()->setParameter($parameterName, $value['value']);
     }
 
     public function getDefaultOptions()

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -47,7 +47,7 @@ class StringFilter extends Filter
         StringOperatorType::TYPE_NOT_CONTAINS,
     ];
 
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -60,15 +60,15 @@ class StringFilter extends Filter
             ));
         }
 
-        if (!\is_array($value) || !\array_key_exists('value', $value)) {
+        if (!\is_array($data) || !\array_key_exists('value', $data)) {
             return;
         }
 
-        $value['value'] = $this->trim((string) ($value['value'] ?? ''));
-        $type = $value['type'] ?? StringOperatorType::TYPE_CONTAINS;
+        $data['value'] = $this->trim((string) ($data['value'] ?? ''));
+        $type = $data['type'] ?? StringOperatorType::TYPE_CONTAINS;
 
         // ignore empty value if it doesn't make sense
-        if ('' === $value['value'] &&
+        if ('' === $data['value'] &&
             (!$this->getOption('allow_empty') || \in_array($type, self::MEANINGLESS_TYPES, true))
         ) {
             return;
@@ -121,7 +121,7 @@ class StringFilter extends Filter
             $parameterName,
             sprintf(
                 $format,
-                $this->getOption('case_sensitive') ? $value['value'] : mb_strtolower($value['value'])
+                $this->getOption('case_sensitive') ? $data['value'] : mb_strtolower($data['value'])
             )
         );
     }

--- a/src/Filter/StringListFilter.php
+++ b/src/Filter/StringListFilter.php
@@ -20,7 +20,7 @@ use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 
 final class StringListFilter extends Filter
 {
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $value): void
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data): void
     {
         /* NEXT_MAJOR: Remove this deprecation and update the typehint */
         if (!$query instanceof ProxyQueryInterface) {
@@ -33,26 +33,26 @@ final class StringListFilter extends Filter
             ));
         }
 
-        if (!$value || !\is_array($value) || !\array_key_exists('type', $value) || !\array_key_exists('value', $value)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {
             return;
         }
 
-        if (!\is_array($value['value'])) {
-            $value['value'] = [$value['value']];
+        if (!\is_array($data['value'])) {
+            $data['value'] = [$data['value']];
         }
 
-        $operator = ContainsOperatorType::TYPE_NOT_CONTAINS === $value['type'] ? 'NOT LIKE' : 'LIKE';
+        $operator = ContainsOperatorType::TYPE_NOT_CONTAINS === $data['type'] ? 'NOT LIKE' : 'LIKE';
 
         $andConditions = $query->getQueryBuilder()->expr()->andX();
-        foreach ($value['value'] as $item) {
+        foreach ($data['value'] as $item) {
             $parameterName = $this->getNewParameterName($query);
             $andConditions->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
 
             $query->getQueryBuilder()->setParameter($parameterName, '%'.serialize($item).'%');
         }
 
-        if (ContainsOperatorType::TYPE_EQUAL === $value['type']) {
-            $andConditions->add(sprintf("%s.%s LIKE 'a:%s:%%'", $alias, $field, \count($value['value'])));
+        if (ContainsOperatorType::TYPE_EQUAL === $data['type']) {
+            $andConditions->add(sprintf("%s.%s LIKE 'a:%s:%%'", $alias, $field, \count($data['value'])));
         }
 
         $this->applyWhere($query, $andConditions);

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -519,15 +519,15 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $qb->andWhere(sprintf('( %s )', implode(' OR ', $sqls)));
     }
 
-    public function batchDelete($class, ProxyQueryInterface $queryProxy)
+    public function batchDelete($class, ProxyQueryInterface $query)
     {
-        $queryProxy->select('DISTINCT '.current($queryProxy->getRootAliases()));
+        $query->select('DISTINCT '.current($query->getRootAliases()));
 
         try {
             $entityManager = $this->getEntityManager($class);
 
             $i = 0;
-            foreach ($queryProxy->getQuery()->iterate() as $pos => $object) {
+            foreach ($query->getQuery()->iterate() as $pos => $object) {
                 $entityManager->remove($object[0]);
 
                 if (0 === (++$i % 20)) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

The method `filter` won't be in the interface anymore so we can restrict the typehint.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate passing an instance of `ProxyQueryInterface` which is not an instance of `Sonata\DoctrineORMAdminBundle\Datagrid::ProxyQuery` as argument 1 to the `Sonata\DoctrineORMAdminBundle\Filter\Filter::filter()` method.
```