### PR TITLE
Add NotEmptyFilter

### DIFF
--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -192,6 +192,8 @@ Empty
         }
     }
 
+The ``inverse`` option can be used to filter values that are not empty.
+
 Advanced usage
 --------------
 

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -31,19 +31,18 @@ final class EmptyFilter extends Filter
             return;
         }
 
-        if (BooleanType::TYPE_YES === (int) $value['value']) {
+        $isYes = BooleanType::TYPE_YES === (int) $value['value'];
+        $isNo = BooleanType::TYPE_NO === (int) $value['value'];
+
+        if (!$this->getOption('inverse') && $isYes || $this->getOption('inverse') && $isNo) {
             $this->applyWhere(
                 $queryBuilder,
-                $queryBuilder
-                ->expr()
-                ->isNull(sprintf('%s.%s', $alias, $field))
+                $queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $field))
             );
-        } elseif (BooleanType::TYPE_NO === (int) $value['value']) {
+        } elseif (!$this->getOption('inverse') && $isNo || $this->getOption('inverse') && $isYes) {
             $this->applyWhere(
                 $queryBuilder,
-                $queryBuilder
-                ->expr()
-                ->isNotNull(sprintf('%s.%s', $alias, $field))
+                $queryBuilder->expr()->isNotNull(sprintf('%s.%s', $alias, $field))
             );
         }
     }
@@ -54,6 +53,7 @@ final class EmptyFilter extends Filter
             'field_type' => BooleanType::class,
             'operator_type' => HiddenType::class,
             'operator_options' => [],
+            'inverse' => false,
         ];
     }
 

--- a/tests/Filter/EmptyFilterTest.php
+++ b/tests/Filter/EmptyFilterTest.php
@@ -38,11 +38,12 @@ final class EmptyFilterTest extends TestCase
     /**
      * @dataProvider valueDataProvider
      */
-    public function testValue(int $value, string $expectedQuery): void
+    public function testValue(bool $inverse, int $value, string $expectedQuery): void
     {
         $filter = new EmptyFilter();
         $filter->initialize('field_name', [
             'field_options' => ['class' => 'FooBar'],
+            'inverse' => $inverse,
         ]);
 
         $builder = new ProxyQuery(new QueryBuilder());
@@ -68,8 +69,10 @@ final class EmptyFilterTest extends TestCase
     public function valueDataProvider(): array
     {
         return [
-            [BooleanType::TYPE_YES, 'alias.field IS NULL'],
-            [BooleanType::TYPE_NO, 'alias.field IS NOT NULL'],
+            [false, BooleanType::TYPE_YES, 'alias.field IS NULL'],
+            [false, BooleanType::TYPE_NO, 'alias.field IS NOT NULL'],
+            [true, BooleanType::TYPE_YES, 'alias.field IS NOT NULL'],
+            [true, BooleanType::TYPE_NO, 'alias.field IS NULL'],
         ];
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject 
I am targeting this branch, because BC.

I'm adding a `inverse` option in order to use the EmptyFilter as a NotEmptyFilter.
You may want to have a filter called `Has foo`, instead of a `Has no foo` one.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added an option `inverse` for the EmptyFilter.
```