### PR TITLE
Add deprecation for method removed from the interface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -5,6 +5,10 @@ UPGRADE 3.x
 
 The EmptyFilter is deprecated, use NullFilter instead.
 
+### Sonata\DoctrineORMAdminBundle\Model\ModelManager
+
+Deprecate `modelTransform()`, `getDefaultPerPageOptions()`, `getDefaultSortValues()` and `getDataSourceIterator()` with no replacement.
+
 ### Sonata\DoctrineORMAdminBundle\Filter\Filter
 
 Deprecate passing an instance of `Sonata\AdminBundle\Datagrid\ProxyQueryInterface`

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -543,8 +543,20 @@ class ModelManager implements ModelManagerInterface, LockInterface
         }
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-admin/doctrine-orm-admin-bundle 3.x and will be removed in 4.0.
+     *
+     * @return DoctrineORMQuerySourceIterator
+     */
     public function getDataSourceIterator(DatagridInterface $datagrid, array $fields, $firstResult = null, $maxResult = null)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $datagrid->buildPager();
         $query = $datagrid->getQuery();
 
@@ -641,8 +653,18 @@ class ModelManager implements ModelManagerInterface, LockInterface
         return ['filter' => $values];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getDefaultSortValues($class)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return [
             '_sort_order' => 'ASC',
             '_sort_by' => implode(',', $this->getModelIdentifier($class)),
@@ -651,13 +673,33 @@ class ModelManager implements ModelManagerInterface, LockInterface
         ];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getDefaultPerPageOptions(string $class): array
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return [10, 25, 50, 100, 250];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function modelTransform($class, $instance)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $instance;
     }
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -652,6 +652,8 @@ final class ModelManagerTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this dataprovider.
+     *
      * [sortBy, sortOrder, isAddOrderBy].
      *
      * @return array
@@ -667,6 +669,10 @@ final class ModelManagerTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
      * @dataProvider getSortableInDataSourceIteratorDataProvider
      *
      * @param string|null $sortBy
@@ -722,6 +728,7 @@ final class ModelManagerTest extends TestCase
             ->method('getQuery')
             ->willReturn($proxyQuery);
 
+        $this->expectDeprecation('Method Sonata\DoctrineORMAdminBundle\Model\ModelManager::getDataSourceIterator() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in 4.0.');
         $this->modelManager->getDataSourceIterator($datagrid, []);
 
         if ($isAddOrderBy) {
@@ -791,8 +798,15 @@ final class ModelManagerTest extends TestCase
         $this->assertTrue($collection->isEmpty());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testModelTransform(): void
     {
+        $this->expectDeprecation('Method Sonata\DoctrineORMAdminBundle\Model\ModelManager::modelTransform() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.');
+
         $result = $this->modelManager->modelTransform('thisIsNotUsed', 'doWeNeedThisMethod');
 
         $this->assertSame('doWeNeedThisMethod', $result);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Similar to https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/473

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `Sonata\DoctrineORMAdminBundle\Model\ModelManager::modelTransform()` with no replacement.
- Deprecate `Sonata\DoctrineORMAdminBundle\Model\ModelManager::getDefaultPerPageOptions()` with no replacement.
- Deprecate `Sonata\DoctrineORMAdminBundle\Model\ModelManager::getDefaultSortValues()` with no replacement.
- Deprecate `Sonata\DoctrineORMAdminBundle\Model\ModelManager::getDataSourceIterator()` with no replacement.
```