### PR TITLE
Add DataSource

### DIFF
--- a/src/Exporter/DataSource.php
+++ b/src/Exporter/DataSource.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Exporter;
+
+use Doctrine\ORM\Query;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Exporter\DataSourceInterface;
+use Sonata\DoctrineORMAdminBundle\Datagrid\OrderByToSelectWalker;
+use Sonata\Exporter\Source\DoctrineORMQuerySourceIterator;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+
+class DataSource implements DataSourceInterface
+{
+    public function createIterator(ProxyQueryInterface $query, array $fields): SourceIteratorInterface
+    {
+        $query->select('DISTINCT '.current($query->getRootAliases()));
+        $query->setFirstResult(null);
+        $query->setMaxResults(null);
+
+        $sortBy = $query->getSortBy();
+
+        if (null !== $sortBy) {
+            $query->addOrderBy($sortBy, $query->getSortOrder());
+            $doctrineQuery = $query->getQuery();
+            $doctrineQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [OrderByToSelectWalker::class]);
+        } else {
+            $doctrineQuery = $query->getQuery();
+        }
+
+        return new DoctrineORMQuerySourceIterator($doctrineQuery, $fields);
+    }
+}

--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -49,5 +49,6 @@
         <service id="sonata.admin.guesser.orm_datagrid_chain" class="Sonata\AdminBundle\Guesser\TypeGuesserChain">
             <argument/>
         </service>
+        <service id="sonata.admin.data_source.orm" class="Sonata\DoctrineORMAdminBundle\Exporter\DataSource"/>
     </services>
 </container>

--- a/tests/Exporter/DataSourceTest.php
+++ b/tests/Exporter/DataSourceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Exporter;
+
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineORMAdminBundle\Datagrid\OrderByToSelectWalker;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Exporter\DataSource;
+
+final class DataSourceTest extends TestCase
+{
+    /**
+     * @var DataSource
+     */
+    private $dataSource;
+
+    protected function setup(): void
+    {
+        $this->dataSource = new DataSource();
+    }
+
+    /**
+     * @phpstan-return array<array{string|null, string|null, bool}>
+     */
+    public function getSortableInDataSourceIteratorDataProvider(): array
+    {
+        return [
+            [null, null, false],
+            [null, 'ASC', false],
+            ['field', 'ASC', true],
+            ['field', null, true],
+        ];
+    }
+
+    /**
+     * @dataProvider getSortableInDataSourceIteratorDataProvider
+     */
+    public function testSortableInDataSourceIterator(
+        ?string $sortBy,
+        ?string $sortOrder,
+        bool $isAddOrderBy
+    ): void {
+        $configuration = $this->createStub(Configuration::class);
+        $configuration->method('getDefaultQueryHints')->willReturn([]);
+
+        $em = $this->createStub(EntityManager::class);
+        $em->method('getConfiguration')->willReturn($configuration);
+
+        $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
+            ->setConstructorArgs([$em])
+            ->getMock();
+
+        $queryBuilder->expects($isAddOrderBy ? $this->atLeastOnce() : $this->never())->method('addOrderBy');
+        $queryBuilder->method('getRootAliases')->willReturn(['a']);
+
+        $query = new Query($em);
+        $queryBuilder->method('getQuery')->willReturn($query);
+
+        $proxyQuery = $this->getMockBuilder(ProxyQuery::class)
+            ->setConstructorArgs([$queryBuilder])
+            ->onlyMethods(['getSortBy', 'getSortOrder'])
+            ->getMock();
+
+        $proxyQuery->method('getSortOrder')->willReturn($sortOrder);
+        $proxyQuery->method('getSortBy')->willReturn($sortBy);
+
+        $this->dataSource->createIterator($proxyQuery, []);
+
+        if ($isAddOrderBy) {
+            $this->assertArrayHasKey($key = 'doctrine.customTreeWalkers', $hints = $query->getHints());
+            $this->assertContains(OrderByToSelectWalker::class, $hints[$key]);
+        }
+    }
+}


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

This is the ORM implementation of https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Exporter/DataSourceInterface.php

This will should be automatically injected thanks to https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php#L275

## Changelog
```markdown
### Added
- Added `DataSourceInterface` implementation
```