### PR TITLE
Update Pager.php

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -203,7 +203,7 @@ class Pager extends BasePager
         }
 
         if (!$this->getQuery() instanceof ProxyQueryInterface) {
-            throw new \InvalidArgumentException(
+            throw new \TypeError(
                 sprintf('The datagrid query MUST implement %s.', ProxyQueryInterface::class)
             );
         }

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -16,7 +16,6 @@ namespace Sonata\DoctrineORMAdminBundle\Datagrid;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sonata\AdminBundle\Datagrid\Pager as BasePager;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * Doctrine pager class.


### PR DESCRIPTION
## Subject

I have entity with composite key, just created admin for it and I found this bug.

I'm using: sonata-project/doctrine-orm-admin-bundle:3.24.0, doctrine/orm:2.7.4

I am targeting this branch, because it's bug fix.

```markdown
### Changed
- Use Doctrine ORM Paginator to count in Pager.

### Fixed
- Support of composite key for computeNbResult
```

# Notes

I think it can be used as single method of generating query, no matter if it's composite or not.
