### PR TITLE
Stop using deprecated FieldDescription methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.82",
+        "sonata-project/admin-bundle": "^3.83",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -20,6 +20,9 @@ use Sonata\AdminBundle\Admin\BaseFieldDescription;
  */
 class FieldDescription extends BaseFieldDescription
 {
+    /**
+     * NEXT_MAJOR: Change visibility to protected.
+     */
     public function setAssociationMapping($associationMapping)
     {
         if (!\is_array($associationMapping)) {
@@ -60,6 +63,9 @@ class FieldDescription extends BaseFieldDescription
         return null;
     }
 
+    /**
+     * NEXT_MAJOR: Change visibility to protected.
+     */
     public function setFieldMapping($fieldMapping)
     {
         if (!\is_array($fieldMapping)) {
@@ -74,6 +80,9 @@ class FieldDescription extends BaseFieldDescription
         $this->fieldName = $this->fieldName ?: $fieldMapping['fieldName'];
     }
 
+    /**
+     * NEXT_MAJOR: Change visibility to protected.
+     */
     public function setParentAssociationMappings(array $parentAssociationMappings)
     {
         foreach ($parentAssociationMappings as $parentAssociationMapping) {

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -73,7 +73,8 @@ class DatagridBuilder implements DatagridBuilderInterface
         // set default values
         $fieldDescription->setAdmin($admin);
 
-        if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
+        // NEXT_MAJOR: Remove this block.
+        if ($admin->getModelManager()->hasMetadata($admin->getClass(), 'sonata_deprecation_mute')) {
             [$metadata, $lastPropertyName, $parentAssociationMappings] = $admin->getModelManager()
                 ->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
 
@@ -118,6 +119,23 @@ class DatagridBuilder implements DatagridBuilderInterface
                 $fieldDescription->getOption('parent_association_mappings', $parentAssociationMappings)
             );
         }
+
+        // NEXT_MAJOR: Uncomment this code.
+        //if ([] !== $fieldDescription->getFieldMapping()) {
+        //    $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $fieldDescription->getFieldMapping()));
+        //
+        //    if ('string' === $fieldDescription->getFieldMapping()['type']) {
+        //        $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
+        //    }
+        //}
+        //
+        //if ([] !== $fieldDescription->getAssociationMapping()) {
+        //    $fieldDescription->setOption('association_mapping', $fieldDescription->getOption('association_mapping', $fieldDescription->getAssociationMapping()));
+        //}
+        //
+        //if ([] !== $fieldDescription->getParentAssociationMappings()) {
+        //    $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
+        //}
 
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
         $fieldDescription->setOption('name', $fieldDescription->getOption('name', $fieldDescription->getName()));

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -53,8 +53,9 @@ class FormContractor implements FormContractorInterface
 
     public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription)
     {
-        if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
-            $metadata = $admin->getModelManager()->getMetadata($admin->getClass());
+        // NEXT_MAJOR: Remove this block.
+        if ($admin->getModelManager()->hasMetadata($admin->getClass(), 'sonata_deprecation_mute')) {
+            $metadata = $admin->getModelManager()->getMetadata($admin->getClass(), 'sonata_deprecation_mute');
 
             // set the default field mapping
             if (isset($metadata->fieldMappings[$fieldDescription->getName()])) {

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -82,7 +82,8 @@ class ListBuilder implements ListBuilderInterface
 
         $fieldDescription->setAdmin($admin);
 
-        if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
+        // NEXT_MAJOR: Remove this block.
+        if ($admin->getModelManager()->hasMetadata($admin->getClass(), 'sonata_deprecation_mute')) {
             [$metadata, $lastPropertyName, $parentAssociationMappings] = $admin->getModelManager()->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
             $fieldDescription->setParentAssociationMappings($parentAssociationMappings);
 
@@ -103,6 +104,17 @@ class ListBuilder implements ListBuilderInterface
 
             $fieldDescription->setOption('_sort_order', $fieldDescription->getOption('_sort_order', 'ASC'));
         }
+
+        // NEXT_MAJOR: Uncomment this code.
+        //if ([] !== $fieldDescription->getFieldMapping()) {
+        //    if (false !== $fieldDescription->getOption('sortable')) {
+        //        $fieldDescription->setOption('sortable', $fieldDescription->getOption('sortable', true));
+        //        $fieldDescription->setOption('sort_parent_association_mappings', $fieldDescription->getOption('sort_parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
+        //        $fieldDescription->setOption('sort_field_mapping', $fieldDescription->getOption('sort_field_mapping', $fieldDescription->getFieldMapping()));
+        //    }
+        //
+        //    $fieldDescription->setOption('_sort_order', $fieldDescription->getOption('_sort_order', 'ASC'));
+        //}
 
         if (!$fieldDescription->getType()) {
             throw new \RuntimeException(sprintf(

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -69,7 +69,8 @@ class ShowBuilder implements ShowBuilderInterface
     {
         $fieldDescription->setAdmin($admin);
 
-        if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
+        // NEXT_MAJOR: Remove this block.
+        if ($admin->getModelManager()->hasMetadata($admin->getClass(), 'sonata_deprecation_mute')) {
             [$metadata, $lastPropertyName, $parentAssociationMappings] = $admin->getModelManager()->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
             $fieldDescription->setParentAssociationMappings($parentAssociationMappings);
 

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -84,6 +84,10 @@ class ModelManager implements ModelManagerInterface, LockInterface
     }
 
     /**
+     * NEXT_MAJOR: Change visibility to private.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be private in version 4.0
+     *
      * @param string $class
      *
      * @return ClassMetadata
@@ -92,6 +96,15 @@ class ModelManager implements ModelManagerInterface, LockInterface
      */
     public function getMetadata($class)
     {
+        // NEXT_MAJOR: Remove this block.
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and'
+                .' will be private in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->getEntityManager($class)->getMetadataFactory()->getMetadataFor($class);
     }
 
@@ -116,7 +129,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $parentAssociationMappings = [];
 
         foreach ($nameElements as $nameElement) {
-            $metadata = $this->getMetadata($class);
+            // NEXT_MAJOR: Remove `sonata_deprecation_mute`.
+            $metadata = $this->getMetadata($class, 'sonata_deprecation_mute');
 
             if (isset($metadata->associationMappings[$nameElement])) {
                 $parentAssociationMappings[] = $metadata->associationMappings[$nameElement];
@@ -131,10 +145,19 @@ class ModelManager implements ModelManagerInterface, LockInterface
         $properties = \array_slice($nameElements, \count($parentAssociationMappings));
         $properties[] = $lastPropertyName;
 
-        return [$this->getMetadata($class), implode('.', $properties), $parentAssociationMappings];
+        // NEXT_MAJOR: Remove `sonata_deprecation_mute`.
+        return [
+            $this->getMetadata($class, 'sonata_deprecation_mute'),
+            implode('.', $properties),
+            $parentAssociationMappings,
+        ];
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0
+     *
      * @param string $class
      *
      * @return bool
@@ -143,6 +166,14 @@ class ModelManager implements ModelManagerInterface, LockInterface
      */
     public function hasMetadata($class)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and'
+                .' will be removed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->getEntityManager($class)->getMetadataFactory()->hasMetadataFor($class);
     }
 
@@ -162,18 +193,13 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
         [$metadata, $propertyName, $parentAssociationMappings] = $this->getParentMetadataForProperty($class, $name);
 
-        $fieldDescription = new FieldDescription($name, $options);
-        $fieldDescription->setParentAssociationMappings($parentAssociationMappings);
-
-        if (isset($metadata->associationMappings[$propertyName])) {
-            $fieldDescription->setAssociationMapping($metadata->associationMappings[$propertyName]);
-        }
-
-        if (isset($metadata->fieldMappings[$propertyName])) {
-            $fieldDescription->setFieldMapping($metadata->fieldMappings[$propertyName]);
-        }
-
-        return $fieldDescription;
+        return new FieldDescription(
+            $name,
+            $options,
+            $metadata->fieldMappings[$propertyName] ?? [],
+            $metadata->associationMappings[$propertyName] ?? [],
+            $parentAssociationMappings
+        );
     }
 
     public function create($object)
@@ -241,7 +267,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
     public function getLockVersion($object)
     {
-        $metadata = $this->getMetadata(ClassUtils::getClass($object));
+        // NEXT_MAJOR: Remove `sonata_deprecation_mute`.
+        $metadata = $this->getMetadata(ClassUtils::getClass($object), 'sonata_deprecation_mute');
 
         if (!$metadata->isVersioned) {
             return null;
@@ -252,7 +279,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
     public function lock($object, $expectedVersion)
     {
-        $metadata = $this->getMetadata(ClassUtils::getClass($object));
+        // NEXT_MAJOR: Remove `sonata_deprecation_mute`.
+        $metadata = $this->getMetadata(ClassUtils::getClass($object), 'sonata_deprecation_mute');
 
         if (!$metadata->isVersioned) {
             return;
@@ -332,7 +360,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
         $fieldName = $parentAssociationMapping['fieldName'];
 
-        $metadata = $this->getMetadata($class);
+        // NEXT_MAJOR: Remove `sonata_deprecation_mute`.
+        $metadata = $this->getMetadata($class, 'sonata_deprecation_mute');
 
         $associatingMapping = $metadata->associationMappings[$parentAssociationMapping];
 
@@ -384,7 +413,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
      */
     public function getModelIdentifier($class)
     {
-        return $this->getMetadata($class)->identifier;
+        // NEXT_MAJOR: Remove `sonata_deprecation_mute`.
+        return $this->getMetadata($class, 'sonata_deprecation_mute')->identifier;
     }
 
     public function getIdentifierValues($entity)
@@ -396,7 +426,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
         //}
 
         $class = ClassUtils::getClass($entity);
-        $metadata = $this->getMetadata($class);
+        // NEXT_MAJOR: Remove `sonata_deprecation_mute`
+        $metadata = $this->getMetadata($class, 'sonata_deprecation_mute');
         $platform = $this->getEntityManager($class)->getConnection()->getDatabasePlatform();
 
         $identifiers = [];
@@ -416,7 +447,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
                 continue;
             }
 
-            $identifierMetadata = $this->getMetadata(ClassUtils::getClass($value));
+            // NEXT_MAJOR: Remove `sonata_deprecation_mute`
+            $identifierMetadata = $this->getMetadata(ClassUtils::getClass($value), 'sonata_deprecation_mute');
 
             foreach ($identifierMetadata->getIdentifierValues($value) as $value) {
                 $identifiers[] = $value;
@@ -428,7 +460,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
     public function getIdentifierFieldNames($class)
     {
-        return $this->getMetadata($class)->getIdentifierFieldNames();
+        // NEXT_MAJOR: Remove `sonata_deprecation_mute`
+        return $this->getMetadata($class, 'sonata_deprecation_mute')->getIdentifierFieldNames();
     }
 
     public function getNormalizedIdentifier($entity)
@@ -664,7 +697,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
     public function modelReverseTransform($class, array $array = [])
     {
         $instance = $this->getModelInstance($class);
-        $metadata = $this->getMetadata($class);
+        // NEXT_MAJOR: Remove `sonata_deprecation_mute`
+        $metadata = $this->getMetadata($class, 'sonata_deprecation_mute');
 
         foreach ($array as $name => $value) {
             $property = $this->getFieldName($metadata, $name);

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -86,8 +86,7 @@ class FieldDescriptionTest extends TestCase
 
     public function testAssociationMapping(): void
     {
-        $field = new FieldDescription('name');
-        $field->setAssociationMapping([
+        $field = new FieldDescription('name', [], [], [
             'type' => 'integer',
             'fieldName' => 'position',
         ]);
@@ -96,6 +95,7 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame('integer', $field->getMappingType());
         $this->assertSame('position', $field->getFieldName());
 
+        // NEXT_MAJOR: Remove all the rest of the test.
         // cannot overwrite defined definition
         $field->setAssociationMapping([
             'type' => 'overwrite?',
@@ -216,17 +216,18 @@ class FieldDescriptionTest extends TestCase
 
     public function testGetAssociationMapping(): void
     {
-        $assocationMapping = [
+        $associationMapping = [
             'type' => 'integer',
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription('name');
-        $field->setAssociationMapping($assocationMapping);
-
-        $this->assertSame($assocationMapping, $field->getAssociationMapping());
+        $field = new FieldDescription('name', [], [], $associationMapping);
+        $this->assertSame($associationMapping, $field->getAssociationMapping());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     */
     public function testSetAssociationMappingAllowOnlyForArray(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -235,6 +236,9 @@ class FieldDescriptionTest extends TestCase
         $field->setAssociationMapping('test');
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     */
     public function testSetFieldMappingAllowOnlyForArray(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -250,8 +254,7 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription('position');
-        $field->setFieldMapping($fieldMapping);
+        $field = new FieldDescription('position', [], $fieldMapping);
 
         $this->assertSame('integer', $field->getType());
     }
@@ -263,25 +266,20 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription('position');
-        $field->setFieldMapping($fieldMapping);
+        $field = new FieldDescription('position', [], $fieldMapping);
 
         $this->assertSame('integer', $field->getMappingType());
     }
 
     public function testGetTargetEntity(): void
     {
-        $assocationMapping = [
+        $associationMapping = [
             'type' => 'integer',
             'fieldName' => 'position',
             'targetEntity' => 'someValue',
         ];
 
-        $field = new FieldDescription('position');
-
-        $this->assertNull($field->getTargetModel());
-
-        $field->setAssociationMapping($assocationMapping);
+        $field = new FieldDescription('position', [], [], $associationMapping);
 
         $this->assertSame('someValue', $field->getTargetModel());
     }
@@ -294,8 +292,7 @@ class FieldDescriptionTest extends TestCase
             'id' => true,
         ];
 
-        $field = new FieldDescription('position');
-        $field->setFieldMapping($fieldMapping);
+        $field = new FieldDescription('position', [], $fieldMapping);
 
         $this->assertTrue($field->isIdentifier());
     }
@@ -308,8 +305,7 @@ class FieldDescriptionTest extends TestCase
             'id' => 'someId',
         ];
 
-        $field = new FieldDescription('position');
-        $field->setFieldMapping($fieldMapping);
+        $field = new FieldDescription('position', [], $fieldMapping);
 
         $this->assertSame($fieldMapping, $field->getFieldMapping());
     }
@@ -330,9 +326,10 @@ class FieldDescriptionTest extends TestCase
             ->method('getMyEmbeddedObject')
             ->willReturn($mockedEmbeddedObject);
 
-        $field = new FieldDescription('myMethod');
-        $field->setFieldMapping([
-            'declaredField' => 'myEmbeddedObject', 'type' => 'string', 'fieldName' => 'myEmbeddedObject.myMethod',
+        $field = new FieldDescription('myMethod', [], [
+            'declaredField' => 'myEmbeddedObject',
+            'type' => 'string',
+            'fieldName' => 'myEmbeddedObject.myMethod',
         ]);
         $field->setOption('code', 'myMethod');
 
@@ -359,11 +356,14 @@ class FieldDescriptionTest extends TestCase
         $mockedObject->expects($this->once())
             ->method('getMyEmbeddedObject')
             ->willReturn($mockedEmbeddedObject);
-        $field = new FieldDescription('myMethod');
-        $field->setFieldMapping([
-            'declaredField' => 'myEmbeddedObject.child', 'type' => 'string', 'fieldName' => 'myMethod',
+
+        $field = new FieldDescription('myMethod', [], [
+            'declaredField' => 'myEmbeddedObject.child',
+            'type' => 'string',
+            'fieldName' => 'myMethod',
         ]);
         $field->setOption('code', 'myMethod');
+
         $this->assertSame('myMethodValue', $field->getValue($mockedObject));
     }
 }

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -114,6 +114,7 @@ final class DatagridBuilderTest extends TestCase
 
     public function testFixFieldDescription(): void
     {
+        // NEXT_MAJOR: Remove the next 4 lines.
         $classMetadata = $this->createStub(ClassMetadata::class);
         $classMetadata->fieldMappings = [
             'someField' => [
@@ -125,10 +126,10 @@ final class DatagridBuilderTest extends TestCase
         $classMetadata->associationMappings = ['someField' => ['fieldName' => 'fakeField']];
         $classMetadata->embeddedClasses = ['someFieldDeclared' => ['fieldName' => 'fakeField']];
 
-        $fieldDescription = new FieldDescription('test');
-        $fieldDescription->setMappingType(ClassMetadata::ONE_TO_MANY);
+        $fieldDescription = new FieldDescription('test', [], ['type' => ClassMetadata::ONE_TO_MANY]);
 
         $this->admin->expects($this->once())->method('attachAdminClass');
+        // NEXT_MAJOR: Remove the next 2 lines.
         $this->modelManager->method('hasMetadata')->willReturn(true);
         $this->modelManager->expects($this->once())->method('getParentMetadataForProperty')
             ->willReturn([$classMetadata, 'someField', []]);
@@ -147,6 +148,7 @@ final class DatagridBuilderTest extends TestCase
         $this->admin->method('getCode')->willReturn('someFakeCode');
         $this->admin->method('getLabelTranslatorStrategy')->willReturn(new FormLabelTranslatorStrategy());
         $this->typeGuesser->method('guessType')->willReturn($guessType);
+        // NEXT_MAJOR: Remove the next line.
         $this->modelManager->expects($this->once())->method('hasMetadata')->willReturn(false);
         $this->filterFactory->method('create')->willReturn(new ModelAutocompleteFilter());
 

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -131,11 +131,12 @@ final class FormContractorTest extends TestCase
 
     public function testAdminClassAttachForNotMappedField(): void
     {
-        // Given
+        // NEXT_MAJOR: Remove the next 2 lines.
         $modelManager = $this->createMock(ModelManager::class);
         $modelManager->method('hasMetadata')->willReturn(false);
 
         $admin = $this->createMock(AdminInterface::class);
+        // NEXT_MAJOR: Remove the next line.
         $admin->method('getModelManager')->willReturn($modelManager);
 
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
@@ -146,14 +147,11 @@ final class FormContractorTest extends TestCase
             $this->equalTo('admin_code')
         ))->willReturn('sonata.admin.code');
 
-        // Then
         $admin
             ->expects($this->once())
             ->method('attachAdminClass')
-            ->with($fieldDescription)
-        ;
+            ->with($fieldDescription);
 
-        // When
         $this->formContractor->fixFieldDescription($admin, $fieldDescription);
     }
 }

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -90,18 +90,19 @@ class ListBuilderTest extends TestCase
      */
     public function testFixFieldDescription($type, $template): void
     {
+        // NEXT_MAJOR: Remove the next 3 lines.
         $classMetadata = $this->createStub(ClassMetadata::class);
         $classMetadata->fieldMappings = [2 => [1 => 'test', 'type' => 'string']];
         $classMetadata->associationMappings = [2 => ['fieldName' => 'fake']];
 
-        $this->modelManager->method('hasMetadata')->willReturn(true);
         $this->admin->expects($this->once())->method('attachAdminClass');
+        // NEXT_MAJOR: Remove the next 2 lines.
+        $this->modelManager->method('hasMetadata')->willReturn(true);
         $this->modelManager->method('getParentMetadataForProperty')->willReturn([$classMetadata, 2, []]);
 
-        $fieldDescription = new FieldDescription('test');
+        $fieldDescription = new FieldDescription('test', [], ['type' => $type]);
         $fieldDescription->setOption('sortable', true);
         $fieldDescription->setType('fakeType');
-        $fieldDescription->setMappingType($type);
 
         $this->listBuilder->fixFieldDescription($this->admin, $fieldDescription);
 

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -65,8 +65,7 @@ class ShowBuilderTest extends TestCase
     {
         $typeGuess = $this->createStub(TypeGuess::class);
 
-        $fieldDescription = new FieldDescription('FakeName');
-        $fieldDescription->setMappingType(ClassMetadata::MANY_TO_ONE);
+        $fieldDescription = new FieldDescription('FakeName', [], ['type' => ClassMetadata::MANY_TO_ONE]);
 
         $this->admin->expects($this->once())->method('attachAdminClass');
         $this->admin->expects($this->once())->method('addShowFieldDescription');
@@ -105,15 +104,16 @@ class ShowBuilderTest extends TestCase
      */
     public function testFixFieldDescription(string $type, int $mappingType, string $template): void
     {
+        // NEXT_MAJOR: Remove the next 3 lines.
         $classMetadata = $this->createStub(ClassMetadata::class);
         $classMetadata->fieldMappings = [2 => []];
         $classMetadata->associationMappings = [2 => ['fieldName' => 'fakeField']];
 
-        $fieldDescription = new FieldDescription('FakeName');
+        $fieldDescription = new FieldDescription('FakeName', [], ['type' => $mappingType]);
         $fieldDescription->setType($type);
-        $fieldDescription->setMappingType($mappingType);
 
         $this->admin->expects($this->once())->method('attachAdminClass');
+        // NEXT_MAJOR: Remove the next 2 lines.
         $this->modelManager->method('hasMetadata')->willReturn(true);
         $this->modelManager->method('getParentMetadataForProperty')->willReturn([$classMetadata, 2, []]);
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -328,10 +328,11 @@ final class ModelManagerTest extends TestCase
         $modelManager->expects($this->any())->method('getMetadata')
             ->willReturnMap(
                 [
-                        [$containerEntityClass, $containerEntityMetadata],
-                        [$embeddedEntityClass, $embeddedEntityMetadata],
-                        [$associatedEntityClass, $associatedEntityMetadata],
-                    ]
+                    // NEXT_MAJOR: Remove the 'sonata_deprecation_mute'
+                    [$containerEntityClass, 'sonata_deprecation_mute', $containerEntityMetadata],
+                    [$embeddedEntityClass, 'sonata_deprecation_mute', $embeddedEntityMetadata],
+                    [$associatedEntityClass, 'sonata_deprecation_mute', $associatedEntityMetadata],
+                ]
             );
 
         /** @var ClassMetadata $metadata */


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Closes #1230.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `ModelManager::getMetadata()` method.
- Deprecated `ModelManager::hasMetadata()` method.
```