### PR TITLE
Deprecate EmptyFilter in favor of NullFilter

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+### Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter
+
+The EmptyFilter is deprecated, use NullFilter instead.
+
 ### Sonata\DoctrineORMAdminBundle\Filter\Filter
 
 Deprecate passing an instance of `Sonata\AdminBundle\Datagrid\ProxyQueryInterface`

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -44,7 +44,7 @@ For now, only `Doctrine ORM` filters are available:
 * ``Sonata\DoctrineORMAdminBundle\Filter\DateTimeFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DateTimeType`` Form Type, renders a datetime field,
 * ``Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType`` Form Type, renders a 2 datetime fields,
 * ``Sonata\DoctrineORMAdminBundle\Filter\ClassFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DefaultType`` Form type, renders a choice list field.
-* ``Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DefaultType`` Form type, renders a choice list field.
+* ``Sonata\DoctrineORMAdminBundle\Filter\NullFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DefaultType`` Form type, renders a choice list field.
 
 Example
 -------
@@ -175,20 +175,20 @@ ClassFilter
 Empty
 -----
 
-``Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter`` supports filtering for empty (null) entity fields::
+``Sonata\DoctrineORMAdminBundle\Filter\NullFilter`` supports filtering for null entity fields::
 
     namespace Sonata\NewsBundle\Admin;
 
     use Sonata\AdminBundle\Admin\AbstractAdmin;
     use Sonata\AdminBundle\Datagrid\DatagridMapper;
-    use Sonata\AdminBundle\Filter\EmptyFilter;
+    use Sonata\AdminBundle\Filter\NullFilter;
 
     final class PostAdmin extends AbstractAdmin
     {
         protected function configureDatagridFilters(DatagridMapper $datagridMapper)
         {
             $datagridMapper
-                ->add('deleted', EmptyFilter::class, ['field_name' => 'deletedAt']);
+                ->add('deleted', NullFilter::class, ['field_name' => 'deletedAt']);
         }
     }
 

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -13,70 +13,16 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
-use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
-use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\Form\Type\BooleanType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+// NEXT_MAJOR: remove this file
+@trigger_error(sprintf(
+    'The %1$s\EmptyFilter class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use %1$s\NullFilter instead.',
+    __NAMESPACE__
+), E_USER_DEPRECATED);
 
-final class EmptyFilter extends Filter
+/**
+ * @psalm-suppress InvalidExtendClass
+ */
+final class EmptyFilter extends NullFilter
 {
-    /**
-     * @param string       $alias
-     * @param string       $field
-     * @param mixed[]|null $data
-     */
-    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data): void
-    {
-        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
-        if (!$query instanceof ProxyQueryInterface) {
-            @trigger_error(sprintf(
-                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
-                \get_class($query),
-                __METHOD__,
-                ProxyQueryInterface::class
-            ));
-        }
-
-        if (null === $data || !\is_array($data) || !\array_key_exists('value', $data)) {
-            return;
-        }
-
-        $isYes = BooleanType::TYPE_YES === (int) $data['value'];
-        $isNo = BooleanType::TYPE_NO === (int) $data['value'];
-
-        if (!$this->getOption('inverse') && $isYes || $this->getOption('inverse') && $isNo) {
-            $this->applyWhere(
-                $query,
-                $query->getQueryBuilder()->expr()->isNull(sprintf('%s.%s', $alias, $field))
-            );
-        } elseif (!$this->getOption('inverse') && $isNo || $this->getOption('inverse') && $isYes) {
-            $this->applyWhere(
-                $query,
-                $query->getQueryBuilder()->expr()->isNotNull(sprintf('%s.%s', $alias, $field))
-            );
-        }
-    }
-
-    public function getDefaultOptions()
-    {
-        return [
-            'field_type' => BooleanType::class,
-            'operator_type' => HiddenType::class,
-            'operator_options' => [],
-            'inverse' => false,
-        ];
-    }
-
-    public function getRenderSettings()
-    {
-        return [DefaultType::class, [
-            'field_type' => $this->getFieldType(),
-            'field_options' => $this->getFieldOptions(),
-            'operator_type' => $this->getOption('operator_type'),
-            'operator_options' => $this->getOption('operator_options'),
-            'label' => $this->getLabel(),
-        ]];
-    }
 }

--- a/src/Filter/NullFilter.php
+++ b/src/Filter/NullFilter.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Filter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+
+/**
+ * NEXT_MAJOR: Declare this class as final.
+ *
+ * @final
+ */
+class NullFilter extends Filter
+{
+    /**
+     * @param string       $alias
+     * @param string       $field
+     * @param mixed[]|null $data
+     */
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data): void
+    {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
+        if (null === $data || !\is_array($data) || !\array_key_exists('value', $data)) {
+            return;
+        }
+
+        $isYes = BooleanType::TYPE_YES === (int) $data['value'];
+        $isNo = BooleanType::TYPE_NO === (int) $data['value'];
+
+        if (!$this->getOption('inverse') && $isYes || $this->getOption('inverse') && $isNo) {
+            $this->applyWhere(
+                $query,
+                $query->getQueryBuilder()->expr()->isNull(sprintf('%s.%s', $alias, $field))
+            );
+        } elseif (!$this->getOption('inverse') && $isNo || $this->getOption('inverse') && $isYes) {
+            $this->applyWhere(
+                $query,
+                $query->getQueryBuilder()->expr()->isNotNull(sprintf('%s.%s', $alias, $field))
+            );
+        }
+    }
+
+    public function getDefaultOptions()
+    {
+        return [
+            'field_type' => BooleanType::class,
+            'operator_type' => HiddenType::class,
+            'operator_options' => [],
+            'inverse' => false,
+        ];
+    }
+
+    public function getRenderSettings()
+    {
+        return [DefaultType::class, [
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
+            'label' => $this->getLabel(),
+        ]];
+    }
+}

--- a/tests/Filter/NullFilterTest.php
+++ b/tests/Filter/NullFilterTest.php
@@ -14,19 +14,14 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
-use Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter;
+use Sonata\DoctrineORMAdminBundle\Filter\NullFilter;
 use Sonata\Form\Type\BooleanType;
 
-/**
- * NEXT_MAJOR: Remove this test.
- *
- * @group legacy
- */
-final class EmptyFilterTest extends FilterTestCase
+final class NullFilterTest extends FilterTestCase
 {
     public function testEmpty(): void
     {
-        $filter = new EmptyFilter();
+        $filter = new NullFilter();
         $filter->initialize('field_name', [
             'field_options' => ['class' => 'FooBar'],
         ]);
@@ -44,7 +39,7 @@ final class EmptyFilterTest extends FilterTestCase
      */
     public function testValue(bool $inverse, int $value, string $expectedQuery): void
     {
-        $filter = new EmptyFilter();
+        $filter = new NullFilter();
         $filter->initialize('field_name', [
             'field_options' => ['class' => 'FooBar'],
             'inverse' => $inverse,
@@ -61,7 +56,7 @@ final class EmptyFilterTest extends FilterTestCase
 
     public function testRenderSettings(): void
     {
-        $filter = new EmptyFilter();
+        $filter = new NullFilter();
         $filter->initialize('field_name', [
             'field_options' => ['class' => 'FooBar'],
         ]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1208.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\DoctrineORMAdminBundle\Filter\NullFilter`

### Deprecated
- Deprecated `Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter`
```