### PR TITLE
Fix deprecation of EmptyFilter

### DIFF
--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -13,16 +13,19 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-// NEXT_MAJOR: remove this file
-@trigger_error(sprintf(
-    'The %1$s\EmptyFilter class is deprecated since version 3.x and will be removed in 4.0.'
-    .' Use %1$s\NullFilter instead.',
-    __NAMESPACE__
-), E_USER_DEPRECATED);
-
 /**
  * @psalm-suppress InvalidExtendClass
  */
 final class EmptyFilter extends NullFilter
 {
+    public function __construct()
+    {
+        // NEXT_MAJOR: remove this file
+        @trigger_error(sprintf(
+            'The %s class is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use %s instead.',
+            __CLASS__,
+            NullFilter::class
+        ), E_USER_DEPRECATED);
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
EmptyFilter
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
