### PR TITLE
Set the correct fieldName to get the correct value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.83",
+        "sonata-project/admin-bundle": "^3.84",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -105,16 +105,6 @@ class FieldDescription extends BaseFieldDescription
             $object = $this->getFieldValue($object, $parentAssociationMapping['fieldName']);
         }
 
-        $fieldMapping = $this->getFieldMapping();
-        // Support embedded object for mapping
-        // Ref: https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html
-        if (isset($fieldMapping['declaredField'])) {
-            $parentFields = explode('.', $fieldMapping['declaredField']);
-            foreach ($parentFields as $parentField) {
-                $object = $this->getFieldValue($object, $parentField);
-            }
-        }
-
-        return $this->getFieldValue($object, $this->fieldName);
+        return $this->getFieldValue($object, $this->getFieldName());
     }
 }

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -92,6 +92,7 @@ class DatagridBuilder implements DatagridBuilderInterface
                     $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
                 }
 
+                // NEXT_MAJOR: Remove this, the fieldName should be correctly set at the creation.
                 if (!empty($embeddedClasses = $metadata->embeddedClasses)
                     && isset($fieldMapping['declaredField'])
                     && \array_key_exists($fieldMapping['declaredField'], $embeddedClasses)

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -198,7 +198,8 @@ class ModelManager implements ModelManagerInterface, LockInterface
             $options,
             $metadata->fieldMappings[$propertyName] ?? [],
             $metadata->associationMappings[$propertyName] ?? [],
-            $parentAssociationMappings
+            $parentAssociationMappings,
+            $propertyName
         );
     }
 

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -84,6 +84,11 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame($expected, $field->getOptions());
     }
 
+    /**
+     * NEXT_MAJOR: Remove half of the test.
+     *
+     * @group legacy
+     */
     public function testAssociationMapping(): void
     {
         $field = new FieldDescription('name', [], [], [
@@ -185,15 +190,10 @@ class FieldDescriptionTest extends TestCase
 
     public function testGetValue(): void
     {
-        $mockedObject = $this->getMockBuilder('stdClass')
-            ->setMethods(['myMethod'])
-            ->getMock();
-        $mockedObject->expects($this->once())
-            ->method('myMethod')
-            ->willReturn('myMethodValue');
+        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
+        $mockedObject->expects($this->once())->method('myMethod')->willReturn('myMethodValue');
 
-        $field = new FieldDescription('name');
-        $field->setOption('code', 'myMethod');
+        $field = new FieldDescription('name', ['code' => 'myMethod']);
 
         $this->assertSame($field->getValue($mockedObject), 'myMethodValue');
     }
@@ -202,12 +202,8 @@ class FieldDescriptionTest extends TestCase
     {
         $this->expectException(NoValueException::class);
 
-        $mockedObject = $this->getMockBuilder('stdClass')
-            ->setMethods(['myMethod'])
-            ->getMock();
-        $mockedObject->expects($this->never())
-            ->method('myMethod')
-            ->willReturn('myMethodValue');
+        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
+        $mockedObject->expects($this->never())->method('myMethod')->willReturn('myMethodValue');
 
         $field = new FieldDescription('name');
 
@@ -312,57 +308,29 @@ class FieldDescriptionTest extends TestCase
 
     public function testGetValueForEmbeddedObject(): void
     {
-        $mockedEmbeddedObject = $this->getMockBuilder('stdClass')
-            ->setMethods(['myMethod'])
-            ->getMock();
-        $mockedEmbeddedObject->expects($this->once())
-                    ->method('myMethod')
-                    ->willReturn('myMethodValue');
+        $mockedEmbeddedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getMyMethod'])->getMock();
+        $mockedEmbeddedObject->expects($this->once())->method('getMyMethod')->willReturn('myMethodValue');
 
-        $mockedObject = $this->getMockBuilder('stdClass')
-            ->setMethods(['getMyEmbeddedObject'])
-            ->getMock();
-        $mockedObject->expects($this->once())
-            ->method('getMyEmbeddedObject')
-            ->willReturn($mockedEmbeddedObject);
+        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getMyEmbeddedObject'])->getMock();
+        $mockedObject->expects($this->once())->method('getMyEmbeddedObject')->willReturn($mockedEmbeddedObject);
 
-        $field = new FieldDescription('myMethod', [], [
-            'declaredField' => 'myEmbeddedObject',
-            'type' => 'string',
-            'fieldName' => 'myEmbeddedObject.myMethod',
-        ]);
-        $field->setOption('code', 'myMethod');
+        $field = new FieldDescription('myMethod', [], [], [], [], 'myEmbeddedObject.myMethod');
 
         $this->assertSame('myMethodValue', $field->getValue($mockedObject));
     }
 
     public function testGetValueForMultiLevelEmbeddedObject(): void
     {
-        $mockedChildEmbeddedObject = $this->getMockBuilder('stdClass')
-            ->setMethods(['myMethod'])
-            ->getMock();
-        $mockedChildEmbeddedObject->expects($this->once())
-            ->method('myMethod')
-            ->willReturn('myMethodValue');
-        $mockedEmbeddedObject = $this->getMockBuilder('stdClass')
-            ->setMethods(['getChild'])
-            ->getMock();
-        $mockedEmbeddedObject->expects($this->once())
-            ->method('getChild')
-            ->willReturn($mockedChildEmbeddedObject);
-        $mockedObject = $this->getMockBuilder('stdClass')
-            ->setMethods(['getMyEmbeddedObject'])
-            ->getMock();
-        $mockedObject->expects($this->once())
-            ->method('getMyEmbeddedObject')
-            ->willReturn($mockedEmbeddedObject);
+        $mockedChildEmbeddedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getMyMethod'])->getMock();
+        $mockedChildEmbeddedObject->expects($this->once())->method('getMyMethod')->willReturn('myMethodValue');
 
-        $field = new FieldDescription('myMethod', [], [
-            'declaredField' => 'myEmbeddedObject.child',
-            'type' => 'string',
-            'fieldName' => 'myMethod',
-        ]);
-        $field->setOption('code', 'myMethod');
+        $mockedEmbeddedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getChild'])->getMock();
+        $mockedEmbeddedObject->expects($this->once())->method('getChild')->willReturn($mockedChildEmbeddedObject);
+
+        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getMyEmbeddedObject'])->getMock();
+        $mockedObject->expects($this->once())->method('getMyEmbeddedObject')->willReturn($mockedEmbeddedObject);
+
+        $field = new FieldDescription('myMethod', [], [], [], [], 'myEmbeddedObject.child.myMethod');
 
         $this->assertSame('myMethodValue', $field->getValue($mockedObject));
     }

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -84,11 +84,6 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame($expected, $field->getOptions());
     }
 
-    /**
-     * NEXT_MAJOR: Remove half of the test.
-     *
-     * @group legacy
-     */
     public function testAssociationMapping(): void
     {
         $field = new FieldDescription('name', [], [], [
@@ -110,35 +105,6 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame('integer', $field->getType());
         $this->assertSame('integer', $field->getMappingType());
         $this->assertSame('overwritten', $field->getFieldName());
-
-        $field->setMappingType('string');
-        $this->assertSame('string', $field->getMappingType());
-        $this->assertSame('integer', $field->getType());
-    }
-
-    public function testSetName(): void
-    {
-        $field = new FieldDescription('New field description name');
-
-        $this->assertSame($field->getName(), 'New field description name');
-    }
-
-    public function testSetNameSetFieldNameToo(): void
-    {
-        $field = new FieldDescription('New field description name');
-
-        $this->assertSame($field->getFieldName(), 'New field description name');
-    }
-
-    public function testSetNameDoesNotSetFieldNameWhenSetBefore(): void
-    {
-        $field = new FieldDescription('New field description name');
-
-        $field->setFieldName('field name');
-        $this->assertSame($field->getFieldName(), 'field name');
-
-        $field->setName('New field description name');
-        $this->assertSame($field->getFieldName(), 'field name');
     }
 
     public function testGetParent(): void

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -154,28 +154,6 @@ class FieldDescriptionTest extends TestCase
         $this->assertTrue($field->hasAssociationAdmin());
     }
 
-    public function testGetValue(): void
-    {
-        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
-        $mockedObject->expects($this->once())->method('myMethod')->willReturn('myMethodValue');
-
-        $field = new FieldDescription('name', ['code' => 'myMethod']);
-
-        $this->assertSame($field->getValue($mockedObject), 'myMethodValue');
-    }
-
-    public function testGetValueWhenCannotRetrieve(): void
-    {
-        $this->expectException(NoValueException::class);
-
-        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
-        $mockedObject->expects($this->never())->method('myMethod')->willReturn('myMethodValue');
-
-        $field = new FieldDescription('name');
-
-        $this->assertSame($field->getValue($mockedObject), 'myMethodValue');
-    }
-
     public function testGetAssociationMapping(): void
     {
         $associationMapping = [
@@ -233,7 +211,7 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame('integer', $field->getMappingType());
     }
 
-    public function testGetTargetEntity(): void
+    public function testGetTargetModel(): void
     {
         $associationMapping = [
             'type' => 'integer',
@@ -270,6 +248,41 @@ class FieldDescriptionTest extends TestCase
         $field = new FieldDescription('position', [], $fieldMapping);
 
         $this->assertSame($fieldMapping, $field->getFieldMapping());
+    }
+
+    public function testGetValue(): void
+    {
+        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
+        $mockedObject->expects($this->once())->method('myMethod')->willReturn('myMethodValue');
+
+        $field = new FieldDescription('name', ['code' => 'myMethod']);
+
+        $this->assertSame('myMethodValue', $field->getValue($mockedObject));
+    }
+
+    public function testGetValueWithParentAssociationMappings(): void
+    {
+        $mockedSubObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getFieldName'])->getMock();
+        $mockedSubObject->expects($this->once())->method('getFieldName')->willReturn('value');
+
+        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getSubObject'])->getMock();
+        $mockedObject->expects($this->once())->method('getSubObject')->willReturn($mockedSubObject);
+
+        $field = new FieldDescription('name', [], [], [], [['fieldName' => 'subObject']], 'fieldName');
+
+        $this->assertSame('value', $field->getValue($mockedObject));
+    }
+
+    public function testGetValueWhenCannotRetrieve(): void
+    {
+        $this->expectException(NoValueException::class);
+
+        $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
+        $mockedObject->expects($this->never())->method('myMethod')->willReturn('myMethodValue');
+
+        $field = new FieldDescription('name');
+
+        $this->assertSame('myMethodValue', $field->getValue($mockedObject));
     }
 
     public function testGetValueForEmbeddedObject(): void


### PR DESCRIPTION
## Subject

I am targeting this branch, because the wrong field name is a bug, so this PR would be a bug fix.

When using the following code 
```
->add('foo.bar')
```

If the subject has a relation to a Foo entity, which has a relation to a Bar entity, the fieldDescription has the following data:
- fieldName: bar
- parentAssociationMapping: An array containing foo.

If it's an embedded entity, the fieldDescription had the following data:
- fieldName: bar
- no parentAssociationMapping.

That's why the there was extra code for embedded fields.
- in getValue
- in fixFieldDescription

But both of these code could be avoid if we correctly set the fieldDescription fieldName when looking for parentAssociationMapping. I propose to change this to:
- fieldName: foo.bar
- no parentAssociationMapping.

Then, no code is needed in fixFieldDescription. And in getValue, we just have to iterate on `explode('.', $fieldName)`.

Bonus point: it works with custom getters too.

Closes #1219.

## Changelog

```markdown
### Changed
- When using embedded fields or fake field 'foo.bar' (with custom getters in the entity), `FieldDescription::fieldName` is changed from `bar` to the correct value `foo.bar`.

### Fixed
- Support for embedded and custom getters by the FieldDescription.
```