### PR TITLE
Use ModelManagerException in ModelManager

### DIFF
--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -15,7 +15,6 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
@@ -262,6 +261,10 @@ final class ModelManagerTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove the group legacy and change the dataprovider from [false, false] to [false, true]
+     *
+     * @group legacy
+     *
      * @dataProvider lockDataProvider
      */
     public function testLock($isVersioned, $expectsException): void
@@ -840,7 +843,7 @@ final class ModelManagerTest extends TestCase
 
     public function testGetModelInstanceException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(ModelManagerException::class);
 
         $this->modelManager->getModelInstance(AbstractEntity::class);
     }
@@ -852,7 +855,7 @@ final class ModelManagerTest extends TestCase
 
     public function testGetEntityManagerException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(ModelManagerException::class);
 
         $this->modelManager->getEntityManager(VersionedEntity::class);
     }
@@ -864,10 +867,7 @@ final class ModelManagerTest extends TestCase
         $this->modelManager->getNewFieldDescriptionInstance(VersionedEntity::class, [], []);
     }
 
-    /**
-     * @dataProvider createUpdateRemoveData
-     */
-    public function testCreate($exception): void
+    public function testCreate(): void
     {
         $entityManger = $this->createMock(EntityManager::class);
 
@@ -880,29 +880,14 @@ final class ModelManagerTest extends TestCase
 
         $entityManger->expects($this->once())
             ->method('flush')
-            ->willThrowException($exception);
+            ->willThrowException(new \Exception());
 
         $this->expectException(ModelManagerException::class);
 
         $this->modelManager->create(new VersionedEntity());
     }
 
-    public function createUpdateRemoveData()
-    {
-        return [
-            'PDOException' => [
-                new \PDOException(),
-            ],
-            'DBALException' => [
-                new DBALException(),
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider createUpdateRemoveData
-     */
-    public function testUpdate($exception): void
+    public function testUpdate(): void
     {
         $entityManger = $this->createMock(EntityManager::class);
 
@@ -915,17 +900,14 @@ final class ModelManagerTest extends TestCase
 
         $entityManger->expects($this->once())
             ->method('flush')
-            ->willThrowException($exception);
+            ->willThrowException(new \Exception());
 
         $this->expectException(ModelManagerException::class);
 
         $this->modelManager->update(new VersionedEntity());
     }
 
-    /**
-     * @dataProvider createUpdateRemoveData
-     */
-    public function testRemove($exception): void
+    public function testRemove(): void
     {
         $entityManger = $this->createMock(EntityManager::class);
 
@@ -938,7 +920,7 @@ final class ModelManagerTest extends TestCase
 
         $entityManger->expects($this->once())
             ->method('flush')
-            ->willThrowException($exception);
+            ->willThrowException(new \Exception());
 
         $this->expectException(ModelManagerException::class);
 


### PR DESCRIPTION
## Subject

In SonataAdmin, some methods have phpdoc about exception thrown. Some don't.
I wanted to add `@throws` for every methods throwing an exception in the interface, so I looked at the persistence bundle when exception are thrown and which kind.

Seems there is a `ModelManagerException`, I assume that most of the exception thrown should be this one.

This PR is more a way to open a discussion about multiple subject:
- `$this->getEntityManager($class)` or `$this->getMetadata($class)` are throwing an exception when the class has no entity manager / metadata. Currently `getEntityManager` throw a `RuntimeException` which is not documented in the interface. I think we should instead one of the two solutions
  - throw an InvalidArgument because it means the call was made which a wrong class and LogicException "should lead directly to a fix in your code." according to https://www.php.net/manual/en/class.logicexception.php. (I personally prefer this choice)
  - throw a ModelManagerException because it's more specific. (But it needs to add a `@throws` tag for every method calling these methods)
- `create`, `update`, ... methods have catch `\PDOException` and `DBALException` but not for others exception (And I didn't find a method throwing a `DBALException`). I think we should catch every exception instead to always throw a `ModelManagerException`.
- `lock` is doing nothing if the metadata is not versioned. I think it should throw an exception instead (Which one ?) because it shouldn't do nothing silently.
- `getIdentifierValues` could throw an exception because of the call `$connection->getDatabasePlatform()`, I think we can catch it instead like I did in this PR.
- `getModelInstance` could throw a `\ReflectionException` so I added a TryCatch, but I think we should deprecate this method and move it to SonataAdmin instead, since there is nothing database-related ; WDYT ?

I will update this PR (and create one adding the `@throws` tag to the Interface in SonataAdmin, after your opinion @sonata-project/contributors :) 

## Changelog

```markdown
### Added
- Added some `Class::newMethod()` to do great stuff.

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
