### PR TITLE
Handle null when using NOT_EQUALS with ChoiceFilter

### DIFF
--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -81,28 +81,26 @@ class ChoiceFilter extends Filter
         }
 
         $isNullSelected = \in_array(null, $data['value'], true);
-        $data['value'] = array_filter($data['value'], static function ($data): bool {
-            return null !== $data;
-        });
-
-        // Have to pass IN array value as parameter. See: http://www.doctrine-project.org/jira/browse/DDC-3759
         $completeField = sprintf('%s.%s', $alias, $field);
         $parameterName = $this->getNewParameterName($query);
+
+        $or = $query->getQueryBuilder()->expr()->orX();
         if (EqualOperatorType::TYPE_NOT_EQUAL === $data['type']) {
-            $andConditions = [$query->getQueryBuilder()->expr()->isNotNull($completeField)];
-            if (0 !== \count($data['value'])) {
-                $andConditions[] = $query->getQueryBuilder()->expr()->notIn($completeField, ':'.$parameterName);
-                $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
+            $or->add($query->getQueryBuilder()->expr()->notIn($completeField, ':'.$parameterName));
+
+            if (!$isNullSelected) {
+                $or->add($query->getQueryBuilder()->expr()->isNull($completeField));
             }
-            $this->applyWhere($query, $query->getQueryBuilder()->expr()->andX()->addMultiple($andConditions));
         } else {
-            $orConditions = [$query->getQueryBuilder()->expr()->in($completeField, ':'.$parameterName)];
+            $or->add($query->getQueryBuilder()->expr()->in($completeField, ':'.$parameterName));
+
             if ($isNullSelected) {
-                $orConditions[] = $query->getQueryBuilder()->expr()->isNull($completeField);
+                $or->add($query->getQueryBuilder()->expr()->isNull($completeField));
             }
-            $this->applyWhere($query, $query->getQueryBuilder()->expr()->orX()->addMultiple($orConditions));
-            $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
         }
+
+        $this->applyWhere($query, $or);
+        $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
     }
 
     /**
@@ -116,19 +114,23 @@ class ChoiceFilter extends Filter
         }
 
         $parameterName = $this->getNewParameterName($query);
+        $completeField = sprintf('%s.%s', $alias, $field);
 
         if (EqualOperatorType::TYPE_NOT_EQUAL === $data['type']) {
             if (null === $data['value']) {
-                $this->applyWhere($query, $query->getQueryBuilder()->expr()->isNotNull(sprintf('%s.%s', $alias, $field)));
+                $this->applyWhere($query, $query->getQueryBuilder()->expr()->isNotNull($completeField));
             } else {
-                $this->applyWhere($query, sprintf('%s.%s != :%s', $alias, $field, $parameterName));
+                $this->applyWhere(
+                    $query,
+                    sprintf('%s != :%s OR %s IS NULL', $completeField, $parameterName, $completeField)
+                );
                 $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
             }
         } else {
             if (null === $data['value']) {
-                $this->applyWhere($query, $query->getQueryBuilder()->expr()->isNull(sprintf('%s.%s', $alias, $field)));
+                $this->applyWhere($query, $query->getQueryBuilder()->expr()->isNull($completeField));
             } else {
-                $this->applyWhere($query, sprintf('%s.%s = :%s', $alias, $field, $parameterName));
+                $this->applyWhere($query, sprintf('%s = :%s', $completeField, $parameterName));
                 $query->getQueryBuilder()->setParameter($parameterName, $data['value']);
             }
         }

--- a/tests/Filter/ChoiceFilterTest.php
+++ b/tests/Filter/ChoiceFilterTest.php
@@ -61,7 +61,7 @@ class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', '2']]);
 
-        $this->assertSame(['alias.field NOT IN :field_name_0 OR alias.field IS NULL'], $builder->query);
+        $this->assertSame(['WHERE alias.field NOT IN :field_name_0 OR alias.field IS NULL'], $builder->query);
         $this->assertSame(['field_name_0' => ['1', '2']], $builder->queryParameters);
         $this->assertTrue($filter->isActive());
     }
@@ -105,7 +105,7 @@ class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => '1']);
 
-        $this->assertSame(['alias.field != :field_name_0 OR alias.field IS NULL'], $builder->query);
+        $this->assertSame(['WHERE alias.field != :field_name_0 OR alias.field IS NULL'], $builder->query);
         $this->assertSame(['field_name_0' => '1'], $builder->queryParameters);
         $this->assertTrue($filter->isActive());
     }

--- a/tests/Filter/ChoiceFilterTest.php
+++ b/tests/Filter/ChoiceFilterTest.php
@@ -56,6 +56,14 @@ class ChoiceFilterTest extends FilterTestCase
         $this->assertSame(['WHERE alias.field IN :field_name_0'], $builder->query);
         $this->assertSame(['field_name_0' => ['1', '2']], $builder->queryParameters);
         $this->assertTrue($filter->isActive());
+
+        $builder = new ProxyQuery($this->createQueryBuilderStub());
+
+        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', '2']]);
+
+        $this->assertSame(['alias.field NOT IN :field_name_0 OR alias.field IS NULL'], $builder->query);
+        $this->assertSame(['field_name_0' => ['1', '2']], $builder->queryParameters);
+        $this->assertTrue($filter->isActive());
     }
 
     public function testFilterArrayWithNullValue(): void
@@ -68,15 +76,15 @@ class ChoiceFilterTest extends FilterTestCase
         $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => ['1', null]]);
 
         $this->assertSame(['WHERE alias.field IN :field_name_0 OR alias.field IS NULL'], $builder->query);
-        $this->assertSame(['field_name_0' => ['1']], $builder->queryParameters);
+        $this->assertSame(['field_name_0' => ['1', null]], $builder->queryParameters);
         $this->assertTrue($filter->isActive());
 
         $builder = new ProxyQuery($this->createQueryBuilderStub());
 
         $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', null]]);
 
-        $this->assertSame(['WHERE alias.field IS NOT NULL AND alias.field NOT IN :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => ['1']], $builder->queryParameters);
+        $this->assertSame(['WHERE alias.field NOT IN :field_name_0'], $builder->query);
+        $this->assertSame(['field_name_0' => ['1', null]], $builder->queryParameters);
         $this->assertTrue($filter->isActive());
     }
 
@@ -90,6 +98,14 @@ class ChoiceFilterTest extends FilterTestCase
         $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => '1']);
 
         $this->assertSame(['WHERE alias.field = :field_name_0'], $builder->query);
+        $this->assertSame(['field_name_0' => '1'], $builder->queryParameters);
+        $this->assertTrue($filter->isActive());
+
+        $builder = new ProxyQuery($this->createQueryBuilderStub());
+
+        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => '1']);
+
+        $this->assertSame(['alias.field != :field_name_0 OR alias.field IS NULL'], $builder->query);
         $this->assertSame(['field_name_0' => '1'], $builder->queryParameters);
         $this->assertTrue($filter->isActive());
     }

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -14,25 +14,12 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\ModelFilter;
 
 class ModelFilterTest extends FilterTestCase
 {
-    /**
-     * @return \Sonata\AdminBundle\Admin\FieldDescriptionInterface
-     */
-    public function getFieldDescription(array $options)
-    {
-        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
-        $fieldDescription->expects($this->once())->method('getOptions')->willReturn($options);
-        $fieldDescription->expects($this->once())->method('getName')->willReturn('field_name');
-
-        return $fieldDescription;
-    }
-
     public function testFilterEmpty(): void
     {
         $filter = new ModelFilter();


### PR DESCRIPTION
## Subject

Related to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1040
I started with ChoiceFilter because it's easier for me. I never used ModelFilter/ModelAutocompleteFilter.
I am targeting this branch, because we can consider this as a patch. But it may need discussions.

## Changelog

```markdown
### Fixed
- `ChoiceFilter` now returns `null` values when used with the type `NOT_EQUAL`
```