### PR TITLE
handle SonataAdminBundle Pager::nbresults deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.84",
+        "sonata-project/admin-bundle": "^3.86",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -34,7 +34,7 @@ class PagerTest extends TestCase
     /**
      * @dataProvider entityClassDataProvider
      */
-    public function testComputeNbResultForCompositeId(string $className): void
+    public function testComputeResultsCountForCompositeId(string $className): void
     {
         $em = DoctrineTestHelper::createTestEntityManager();
         $classes = [
@@ -45,11 +45,13 @@ class PagerTest extends TestCase
 
         $qb = $em->createQueryBuilder()
             ->select('e')
-            ->from($className, 'e');
+            ->from($className, 'e')
+        ;
         $pq = new ProxyQuery($qb);
         $pager = new Pager();
         $pager->setCountColumn($em->getClassMetadata($className)->getIdentifierFieldNames());
         $pager->setQuery($pq);
-        $this->assertSame(0, $pager->computeNbResult());
+        $pager->init();
+        $this->assertSame(0, $pager->countResults());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- implemented `Sonata\AdminBundle\Datagrid\PagerInterface::countResults()`

### Deprecated
- `Sonata\DoctrineORMAdminBundle\Datagrid\Pager::computeNbResult()`
- `Sonata\DoctrineORMAdminBundle\Datagrid\Pager::getNbResults()`
- `Sonata\DoctrineORMAdminBundle\Datagrid\Pager::setNbResults()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
