### PR TITLE
[Tests] Split fixtures into files

### DIFF
--- a/tests/App/DataFixtures/AuthorFixtures.php
+++ b/tests/App/DataFixtures/AuthorFixtures.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Address;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
+
+final class AuthorFixtures extends Fixture
+{
+    public const AUTHOR = 'author';
+
+    public function load(ObjectManager $manager): void
+    {
+        $author = new Author('Miguel de Cervantes');
+        $author->setAddress(new Address('Somewhere in La Mancha, in a place whose name I do not care to remember'));
+
+        $manager->persist($author);
+        $manager->flush();
+
+        $this->addReference(self::AUTHOR, $author);
+    }
+}

--- a/tests/App/DataFixtures/BookFixtures.php
+++ b/tests/App/DataFixtures/BookFixtures.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book;
+
+final class BookFixtures extends Fixture implements DependentFixtureInterface
+{
+    public const BOOK = 'book';
+
+    public function load(ObjectManager $manager): void
+    {
+        $book = new Book('book_id', 'Don Quixote', $this->getReference(AuthorFixtures::AUTHOR));
+        $book->addCategory($this->getReference(CategoryFixtures::CATEGORY));
+
+        $manager->persist($book);
+        $manager->flush();
+
+        $this->addReference(self::BOOK, $book);
+    }
+
+    /**
+     * @phpstan-return class-string[]
+     */
+    public function getDependencies(): array
+    {
+        return [
+            CategoryFixtures::class,
+            AuthorFixtures::class,
+        ];
+    }
+}

--- a/tests/App/DataFixtures/CategoryFixtures.php
+++ b/tests/App/DataFixtures/CategoryFixtures.php
@@ -15,27 +15,21 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
-use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Address;
-use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
-use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Category;
 
-final class AppFixtures extends Fixture
+final class CategoryFixtures extends Fixture
 {
+    public const CATEGORY = 'category_novel';
+
     public function load(ObjectManager $manager): void
     {
         $dystopianCategory = new Category('category_dystopian', 'Dystopian');
         $novelCategory = new Category('category_novel', 'Novel');
 
-        $author = new Author('Miguel de Cervantes');
-        $author->setAddress(new Address('Somewhere in La Mancha, in a place whose name I do not care to remember'));
-        $book = new Book('book_id', 'Don Quixote', $author);
-        $book->addCategory($novelCategory);
-
-        $manager->persist($author);
         $manager->persist($novelCategory);
         $manager->persist($dystopianCategory);
-        $manager->persist($book);
         $manager->flush();
+
+        $this->addReference(self::CATEGORY, $novelCategory);
     }
 }

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -11,11 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CategoryAdmin;
-use Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures\AppFixtures;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Category;
@@ -23,6 +21,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
+        ->load('Sonata\\DoctrineORMAdminBundle\\Tests\\App\\DataFixtures\\', dirname(__DIR__).'/DataFixtures')
 
         ->set(CategoryAdmin::class)
             ->public()
@@ -60,7 +62,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 null,
             ])
 
-        ->set(AppFixtures::class)
-            ->tag(FixturesCompilerPass::FIXTURE_TAG)
     ;
 };

--- a/tests/Functional/CRUDTest.php
+++ b/tests/Functional/CRUDTest.php
@@ -76,10 +76,10 @@ final class CRUDTest extends BasePantherTestCase
 
     public function testDelete(): void
     {
-        $documentManager = static::bootKernel()->getContainer()->get('doctrine')->getManager();
+        $entityManager = static::bootKernel()->getContainer()->get('doctrine')->getManager();
 
-        $documentManager->persist(new Category('category_to_remove', 'name'));
-        $documentManager->flush();
+        $entityManager->persist(new Category('category_to_remove', 'name'));
+        $entityManager->flush();
 
         $this->client->request(Request::METHOD_GET, '/admin/tests/app/category/category_to_remove/delete');
 

--- a/tests/Functional/EmbeddedMappingTest.php
+++ b/tests/Functional/EmbeddedMappingTest.php
@@ -31,7 +31,7 @@ final class EmbeddedMappingTest extends BasePantherTestCase
         self::assertSelectorTextContains('.sonata-link-identifier', 'Miguel de Cervantes');
     }
 
-    public function testCreateDocumentWithEmbedded(): void
+    public function testCreateEntityWithEmbedded(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/author/create');
 

--- a/tests/Functional/ManyToOneMappingTest.php
+++ b/tests/Functional/ManyToOneMappingTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Panther\DomCrawler\Crawler;
 
 final class ManyToOneMappingTest extends BasePantherTestCase
 {
-    public function testCreateDocumentWithReferences(): void
+    public function testCreateEntityWithReferences(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/book/create');
 


### PR DESCRIPTION
This makes easier to add more fixtures and also autowiring and autoconfiguring have been added to fixture files, so there is no need to register new fixture files.