### PR TITLE
Do not use null as default value

### DIFF
--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\NumberType;
 use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\NumberType as FormNumberType;
 
 /**
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
@@ -59,7 +60,9 @@ class NumberFilter extends Filter
 
     public function getDefaultOptions()
     {
-        return [];
+        return [
+            'field_type' => FormNumberType::class,
+        ];
     }
 
     public function getRenderSettings()

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -24,11 +24,8 @@ use Sonata\DoctrineORMAdminBundle\Filter\NumberFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\TimeFilter;
 use Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException;
-use Sonata\Form\Type\BooleanType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
@@ -44,11 +41,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             return false;
         }
 
-        $options = [
-            'field_type' => null,
-            'field_options' => [],
-            'options' => [],
-        ];
+        $options = [];
 
         [$metadata, $propertyName, $parentAssociationMappings] = $ret;
 
@@ -84,8 +77,6 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
         switch ($metadata->getTypeOfField($propertyName)) {
             case 'boolean':
-                $options['field_type'] = BooleanType::class;
-
                 return new TypeGuess(BooleanFilter::class, $options, Guess::HIGH_CONFIDENCE);
             case 'datetime':
             case 'datetime_immutable':
@@ -98,8 +89,6 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                 return new TypeGuess(DateFilter::class, $options, Guess::HIGH_CONFIDENCE);
             case 'decimal':
             case 'float':
-                $options['field_type'] = NumberType::class;
-
                 return new TypeGuess(NumberFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case 'integer':
             case 'bigint':
@@ -109,8 +98,6 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                 return new TypeGuess(NumberFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case 'string':
             case 'text':
-                $options['field_type'] = TextType::class;
-
                 return new TypeGuess(StringFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case 'time':
             case 'time_immutable':

--- a/tests/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Guesser/FilterTypeGuesserTest.php
@@ -27,11 +27,8 @@ use Sonata\DoctrineORMAdminBundle\Filter\TimeFilter;
 use Sonata\DoctrineORMAdminBundle\Guesser\FilterTypeGuesser;
 use Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException;
 use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
-use Sonata\Form\Type\BooleanType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Guess\Guess;
 
 class FilterTypeGuesserTest extends TestCase
@@ -133,11 +130,11 @@ class FilterTypeGuesserTest extends TestCase
         $this->assertSame($resultType, $result->getType());
         $this->assertSame($type, $options['field_name']);
         $this->assertSame($confidence, $result->getConfidence());
-        $this->assertSame([], $options['options']);
-        $this->assertSame([], $options['field_options']);
 
         if ($fieldType) {
             $this->assertSame($fieldType, $options['field_type']);
+        } else {
+            $this->assertArrayNotHasKey('field_type', $options);
         }
     }
 
@@ -148,7 +145,6 @@ class FilterTypeGuesserTest extends TestCase
                 'boolean',
                 BooleanFilter::class,
                 Guess::HIGH_CONFIDENCE,
-                BooleanType::class,
             ],
             'datetime' => [
                 'datetime',
@@ -189,13 +185,11 @@ class FilterTypeGuesserTest extends TestCase
                 'decimal',
                 NumberFilter::class,
                 Guess::MEDIUM_CONFIDENCE,
-                NumberType::class,
             ],
             'float' => [
                 'float',
                 NumberFilter::class,
                 Guess::MEDIUM_CONFIDENCE,
-                NumberType::class,
             ],
             'integer' => [
                 'integer',
@@ -219,13 +213,11 @@ class FilterTypeGuesserTest extends TestCase
                 'string',
                 StringFilter::class,
                 Guess::MEDIUM_CONFIDENCE,
-                TextType::class,
             ],
             'text' => [
                 'text',
                 StringFilter::class,
                 Guess::MEDIUM_CONFIDENCE,
-                TextType::class,
             ],
             'time' => [
                 'time',


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

`getOptions` is using `array_key_exist` so
```
$this->getOptions('field_type', DateTimeFilter::class)
```
will return `null` instead of `DateTimeFiler::class` when the type is guessed by our guesser.

This issue was reported on slack by someone using the master branch and he tried the fix for me.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Do not provide a default `null` `field_type` option for Filter
```
