### PR TITLE
Add composite primary keys tests and use Paginator

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -201,8 +201,6 @@ class DatagridBuilder implements DatagridBuilderInterface
     {
         $pager = $this->getPager($admin->getPagerType());
 
-        $pager->setCountColumn($admin->getModelManager()->getIdentifierFieldNames($admin->getClass()));
-
         $defaultOptions = ['validation_groups' => false];
         if ($this->csrfTokenEnabled) {
             $defaultOptions['csrf_protection'] = false;

--- a/tests/App/Admin/CarAdmin.php
+++ b/tests/App/Admin/CarAdmin.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class CarAdmin extends AbstractAdmin
+{
+    protected function configureListFields(ListMapper $list): void
+    {
+        $list
+            ->add('name')
+            ->add('year');
+    }
+
+    protected function configureDatagridFilters(DatagridMapper $filter): void
+    {
+        $filter
+            ->add('name')
+            ->add('year');
+    }
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+        $form
+            ->add('name', TextType::class)
+            ->add('year', IntegerType::class);
+    }
+}

--- a/tests/App/Admin/ItemAdmin.php
+++ b/tests/App/Admin/ItemAdmin.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+
+final class ItemAdmin extends AbstractAdmin
+{
+    protected function configureListFields(ListMapper $list): void
+    {
+        $list
+            ->add('command')
+            ->add('product')
+            ->add('offeredPrice');
+    }
+}

--- a/tests/App/DataFixtures/CarFixtures.php
+++ b/tests/App/DataFixtures/CarFixtures.php
@@ -21,13 +21,13 @@ final class CarFixtures extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
-        $peugeot2000 = new Car('Peugeot', 2000);
-        $peugeot2010 = new Car('Peugeot', 2010);
-        $ferrari2000 = new Car('Ferrari', 2000);
+        $foo2000 = new Car('Foo', 2000);
+        $foo2010 = new Car('Foo', 2010);
+        $bar2000 = new Car('Bar', 2000);
 
-        $manager->persist($peugeot2000);
-        $manager->persist($peugeot2010);
-        $manager->persist($ferrari2000);
+        $manager->persist($foo2000);
+        $manager->persist($foo2010);
+        $manager->persist($bar2000);
         $manager->flush();
     }
 }

--- a/tests/App/DataFixtures/CarFixtures.php
+++ b/tests/App/DataFixtures/CarFixtures.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Car;
+
+final class CarFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $peugeot2000 = new Car('Peugeot', 2000);
+        $peugeot2010 = new Car('Peugeot', 2010);
+        $ferrari2000 = new Car('Ferrari', 2000);
+
+        $manager->persist($peugeot2000);
+        $manager->persist($peugeot2010);
+        $manager->persist($ferrari2000);
+        $manager->flush();
+    }
+}

--- a/tests/App/DataFixtures/CommandFixtures.php
+++ b/tests/App/DataFixtures/CommandFixtures.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Command;
+
+final class CommandFixtures extends Fixture
+{
+    public const COMMAND_1 = 'command_1';
+    public const COMMAND_2 = 'command_2';
+
+    public function load(ObjectManager $manager): void
+    {
+        $command1 = new Command(1);
+        $command2 = new Command(2);
+
+        $manager->persist($command1);
+        $manager->persist($command2);
+        $manager->flush();
+
+        $this->addReference(self::COMMAND_1, $command1);
+        $this->addReference(self::COMMAND_2, $command2);
+    }
+}

--- a/tests/App/DataFixtures/ItemFixtures.php
+++ b/tests/App/DataFixtures/ItemFixtures.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Item;
+
+final class ItemFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+        $command1 = $this->getReference(CommandFixtures::COMMAND_1);
+        $command2 = $this->getReference(CommandFixtures::COMMAND_2);
+        $product1 = $this->getReference(ProductFixtures::PRODUCT_1);
+        $product2 = $this->getReference(ProductFixtures::PRODUCT_2);
+
+        $item1 = new Item($command1, $product1);
+        $item2 = new Item($command1, $product2);
+        $item3 = new Item($command2, $product2);
+
+        $manager->persist($item1);
+        $manager->persist($item2);
+        $manager->persist($item3);
+        $manager->flush();
+    }
+
+    /**
+     * @phpstan-return class-string[]
+     */
+    public function getDependencies(): array
+    {
+        return [
+            ProductFixtures::class,
+            CommandFixtures::class,
+        ];
+    }
+}

--- a/tests/App/DataFixtures/ProductFixtures.php
+++ b/tests/App/DataFixtures/ProductFixtures.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Product;
+
+final class ProductFixtures extends Fixture
+{
+    public const PRODUCT_1 = 'product_1';
+    public const PRODUCT_2 = 'product_2';
+
+    public function load(ObjectManager $manager): void
+    {
+        $product1 = new Product(1, 'Knife', '3.0');
+        $product2 = new Product(2, 'Fork', '2.0');
+
+        $manager->persist($product1);
+        $manager->persist($product2);
+        $manager->flush();
+
+        $this->addReference(self::PRODUCT_1, $product1);
+        $this->addReference(self::PRODUCT_2, $product2);
+    }
+}

--- a/tests/App/Entity/Car.php
+++ b/tests/App/Entity/Car.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class Car
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $year;
+
+    public function __construct(string $name = '', int $year = 0)
+    {
+        $this->name = $name;
+        $this->year = $year;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name.' - '.$this->year;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getYear(): int
+    {
+        return $this->year;
+    }
+
+    public function setYear(int $year): void
+    {
+        $this->year = $year;
+    }
+}

--- a/tests/App/Entity/Command.php
+++ b/tests/App/Entity/Command.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class Command
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="datetime")
+     *
+     * @param \DateTime
+     */
+    private $createdAt;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+        $this->createdAt = new \DateTime();
+    }
+
+    public function __toString()
+    {
+        return (string) $this->id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+}

--- a/tests/App/Entity/Item.php
+++ b/tests/App/Entity/Item.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class Item
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Command")
+     *
+     * @var Command
+     */
+    private $command;
+
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Product")
+     *
+     * @var Product
+     */
+    private $product;
+
+    /**
+     * @ORM\Column(type="decimal")
+     *
+     * @var string
+     */
+    private $offeredPrice;
+
+    public function __construct(Command $command, Product $product)
+    {
+        $this->command = $command;
+        $this->product = $product;
+        $this->offeredPrice = $product->getCurrentPrice();
+    }
+
+    public function getCommand(): Command
+    {
+        return $this->command;
+    }
+
+    public function getProduct(): Product
+    {
+        return $this->product;
+    }
+
+    public function getOfferedPrice(): string
+    {
+        return $this->offeredPrice;
+    }
+}

--- a/tests/App/Entity/Product.php
+++ b/tests/App/Entity/Product.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class Product
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(type="decimal")
+     *
+     * @var string
+     */
+    private $currentPrice;
+
+    public function __construct(int $id, string $name = '', string $currentPrice = '0.0')
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->currentPrice = $currentPrice;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->id;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getCurrentPrice(): string
+    {
+        return $this->currentPrice;
+    }
+
+    public function setCurrentPrice(string $currentPrice): void
+    {
+        $this->currentPrice = $currentPrice;
+    }
+}

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -15,10 +15,12 @@ use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CarAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CategoryAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\ItemAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Car;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Category;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Item;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -73,6 +75,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 '',
                 Car::class,
+                null,
+            ])
+
+        ->set(ItemAdmin::class)
+            ->public()
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'label' => 'Command item',
+            ])
+            ->args([
+                '',
+                Item::class,
                 null,
             ])
     ;

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CarAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CategoryAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Car;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Category;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -62,5 +64,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 null,
             ])
 
+        ->set(CarAdmin::class)
+            ->public()
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'label' => 'Car',
+            ])
+            ->args([
+                '',
+                Car::class,
+                null,
+            ])
     ;
 };

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -34,24 +34,21 @@ class PagerTest extends TestCase
     /**
      * @dataProvider entityClassDataProvider
      */
-    public function testComputeResultsCountForCompositeId(string $className): void
+    public function testCountResults(string $className): void
     {
         $em = DoctrineTestHelper::createTestEntityManager();
-        $classes = [
-            $em->getClassMetadata($className),
-        ];
         $schemaTool = new SchemaTool($em);
-        $schemaTool->createSchema($classes);
+        $schemaTool->createSchema([
+            $em->getClassMetadata($className),
+        ]);
 
-        $qb = $em->createQueryBuilder()
-            ->select('e')
-            ->from($className, 'e')
-        ;
+        $qb = $em->createQueryBuilder()->select('e')->from($className, 'e');
         $pq = new ProxyQuery($qb);
+
         $pager = new Pager();
-        $pager->setCountColumn($em->getClassMetadata($className)->getIdentifierFieldNames());
         $pager->setQuery($pq);
         $pager->init();
+
         $this->assertSame(0, $pager->countResults());
     }
 }

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -69,15 +69,6 @@ class FilterTest extends TestCase
         $this->assertSame(['class' => 'FooBar'], $filter->getFieldOptions());
     }
 
-    public function testValues(): void
-    {
-        $filter = new FilterTest_Filter();
-        $this->assertEmpty($filter->getValue());
-
-        $filter->setValue(42);
-        $this->assertSame(42, $filter->getValue());
-    }
-
     public function testExceptionOnEmptyFieldName(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Functional/CompositePrimaryKeysTest.php
+++ b/tests/Functional/CompositePrimaryKeysTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class CompositePrimaryKeysTest extends BasePantherTestCase
+{
+    public function testListCompositePrimaryKeys(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/admin/tests/app/car/list');
+
+        self::assertSelectorTextContains('.box-footer', '1 / 1  -  3 results');
+    }
+}

--- a/tests/Functional/CompositePrimaryKeysTest.php
+++ b/tests/Functional/CompositePrimaryKeysTest.php
@@ -23,4 +23,11 @@ final class CompositePrimaryKeysTest extends BasePantherTestCase
 
         self::assertSelectorTextContains('.box-footer', '1 / 1  -  3 results');
     }
+
+    public function testListRelationsCompositePrimaryKeys(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/admin/tests/app/item/list');
+
+        self::assertSelectorTextContains('.box-footer', '1 / 1  -  3 results');
+    }
 }


### PR DESCRIPTION
I added some functional tests for composite primary keys.

https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1268/checks?check_run_id=1717007313 show the failure if I removed the code for composite keys.

Then I added the PR https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1217, to check that the code is still working fine.

## Changelog

```markdown
### Changed
- Use Doctrine ORM Paginator to count in Pager.

### Fixed
- Support of composite key for computeNbResult
```