### PR TITLE
Deprecate passing a non integer or non existing type

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -127,6 +127,14 @@ abstract class AbstractDateFilter extends Filter
             // default type for simple filter
             $data['type'] = $data['type'] ?? DateOperatorType::TYPE_EQUAL;
 
+            // NEXT_MAJOR: Remove this if.
+            if (!\is_int($data['type'])) {
+                @trigger_error(
+                    'Passing a non integer type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                    .' and will throw a \TypeError error in version 4.0.',
+                );
+            }
+
             // just find an operator and apply query
             $operator = $this->getOperator($data['type']);
 
@@ -195,6 +203,7 @@ abstract class AbstractDateFilter extends Filter
 
     /**
      * NEXT_MAJOR: Change the visibility for private.
+     * NEXT_MAJOR: Add typehint and remove the int cast.
      *
      * Resolves DateOperatorType:: constants to SQL operators.
      *
@@ -212,6 +221,11 @@ abstract class AbstractDateFilter extends Filter
                 'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
                 .' and will throw an \OutOfRangeException error in version 4.0.',
             );
+//            throw new \OutOfRangeException(sprintf(
+//                'The type "%s" is not supported, allowed one are "%s".',
+//                $type,
+//                implode('", "', array_keys(self::CHOICES))
+//            ));
         }
 
         // NEXT_MAJOR: Remove the default value

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -125,7 +125,7 @@ abstract class AbstractDateFilter extends Filter
             }
 
             // default type for simple filter
-            $data['type'] = !isset($data['type']) || !is_numeric($data['type']) ? DateOperatorType::TYPE_EQUAL : $data['type'];
+            $data['type'] = $data['type'] ?? DateOperatorType::TYPE_EQUAL;
 
             // just find an operator and apply query
             $operator = $this->getOperator($data['type']);
@@ -206,6 +206,15 @@ abstract class AbstractDateFilter extends Filter
     {
         $type = (int) $type;
 
+        if (!isset(self::CHOICES[$type])) {
+            // NEXT_MAJOR: Throw an \OutOfRangeException instead.
+            @trigger_error(
+                'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw an \OutOfRangeException error in version 4.0.',
+            );
+        }
+
+        // NEXT_MAJOR: Remove the default value
         return self::CHOICES[$type] ?? self::CHOICES[DateOperatorType::TYPE_EQUAL];
     }
 }

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -105,6 +105,11 @@ class ClassFilter extends Filter
                 'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
                 .' and will throw an \OutOfRangeException error in version 4.0.',
             );
+//            throw new \OutOfRangeException(sprintf(
+//                'The type "%s" is not supported, allowed one are "%s".',
+//                $type,
+//                implode('", "', array_keys(self::CHOICES))
+//            ));
         }
 
         // NEXT_MAJOR: Remove the default value

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -51,6 +51,13 @@ class ClassFilter extends Filter
         }
 
         $type = $data['type'] ?? EqualOperatorType::TYPE_EQUAL;
+        // NEXT_MAJOR: Remove this if and the (int) cast.
+        if (!\is_int($type)) {
+            @trigger_error(
+                'Passing a non integer type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0.',
+            );
+        }
         $operator = $this->getOperator((int) $type);
 
         $this->applyWhere($query, sprintf('%s %s %s', $alias, $operator, $data['value']));
@@ -92,6 +99,15 @@ class ClassFilter extends Filter
 
     private function getOperator(int $type): string
     {
+        if (!isset(self::CHOICES[$type])) {
+            // NEXT_MAJOR: Throw an \OutOfRangeException instead.
+            @trigger_error(
+                'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw an \OutOfRangeException error in version 4.0.',
+            );
+        }
+
+        // NEXT_MAJOR: Remove the default value
         return self::CHOICES[$type] ?? self::CHOICES[EqualOperatorType::TYPE_EQUAL];
     }
 }

--- a/src/Filter/CountFilter.php
+++ b/src/Filter/CountFilter.php
@@ -47,6 +47,13 @@ final class CountFilter extends Filter
         }
 
         $type = $data['type'] ?? NumberOperatorType::TYPE_EQUAL;
+        // NEXT_MAJOR: Remove this if and the (int) cast.
+        if (!\is_int($type)) {
+            @trigger_error(
+                'Passing a non integer type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0.',
+            );
+        }
         $operator = $this->getOperator((int) $type);
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
@@ -75,6 +82,15 @@ final class CountFilter extends Filter
 
     private function getOperator(int $type): string
     {
+        if (!isset(self::CHOICES[$type])) {
+            // NEXT_MAJOR: Throw an \OutOfRangeException instead.
+            @trigger_error(
+                'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw an \OutOfRangeException error in version 4.0.',
+            );
+        }
+
+        // NEXT_MAJOR: Remove the default value
         return self::CHOICES[$type] ?? self::CHOICES[NumberOperatorType::TYPE_EQUAL];
     }
 }

--- a/src/Filter/CountFilter.php
+++ b/src/Filter/CountFilter.php
@@ -88,6 +88,11 @@ final class CountFilter extends Filter
                 'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
                 .' and will throw an \OutOfRangeException error in version 4.0.',
             );
+//            throw new \OutOfRangeException(sprintf(
+//                'The type "%s" is not supported, allowed one are "%s".',
+//                $type,
+//                implode('", "', array_keys(self::CHOICES))
+//            ));
         }
 
         // NEXT_MAJOR: Remove the default value

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -89,6 +89,11 @@ class NumberFilter extends Filter
                 'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
                 .' and will throw an \OutOfRangeException error in version 4.0.',
             );
+//            throw new \OutOfRangeException(sprintf(
+//                'The type "%s" is not supported, allowed one are "%s".',
+//                $type,
+//                implode('", "', array_keys(self::CHOICES))
+//            ));
         }
 
         // NEXT_MAJOR: Remove the default value

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -50,6 +50,13 @@ class NumberFilter extends Filter
         }
 
         $type = $data['type'] ?? NumberOperatorType::TYPE_EQUAL;
+        // NEXT_MAJOR: Remove this if and the (int) cast.
+        if (!\is_int($type)) {
+            @trigger_error(
+                'Passing a non integer type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0.',
+            );
+        }
         $operator = $this->getOperator((int) $type);
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
@@ -76,6 +83,15 @@ class NumberFilter extends Filter
 
     private function getOperator(int $type): string
     {
+        if (!isset(self::CHOICES[$type])) {
+            // NEXT_MAJOR: Throw an \OutOfRangeException instead.
+            @trigger_error(
+                'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw an \OutOfRangeException error in version 4.0.',
+            );
+        }
+
+        // NEXT_MAJOR: Remove the default value
         return self::CHOICES[$type] ?? self::CHOICES[NumberOperatorType::TYPE_EQUAL];
     }
 }

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -161,6 +161,11 @@ class StringFilter extends Filter
                 'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
                 .' and will throw an \OutOfRangeException error in version 4.0.',
             );
+//            throw new \OutOfRangeException(sprintf(
+//                'The type "%s" is not supported, allowed one are "%s".',
+//                $type,
+//                implode('", "', array_keys(self::CHOICES))
+//            ));
         }
 
         // NEXT_MAJOR: Remove the default value

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -74,6 +74,13 @@ class StringFilter extends Filter
             return;
         }
 
+        // NEXT_MAJOR: Remove this if and the (int) cast.
+        if (!\is_int($type)) {
+            @trigger_error(
+                'Passing a non integer type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0.',
+            );
+        }
         $operator = $this->getOperator((int) $type);
 
         // c.name > '1' => c.name OPERATOR :FIELDNAME
@@ -148,6 +155,15 @@ class StringFilter extends Filter
 
     private function getOperator(int $type): string
     {
+        if (!isset(self::CHOICES[$type])) {
+            // NEXT_MAJOR: Throw an \OutOfRangeException instead.
+            @trigger_error(
+                'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will throw an \OutOfRangeException error in version 4.0.',
+            );
+        }
+
+        // NEXT_MAJOR: Remove the default value
         return self::CHOICES[$type] ?? self::CHOICES[StringOperatorType::TYPE_CONTAINS];
     }
 


### PR DESCRIPTION
## Changelog

```markdown
### Deprecated
- Passing another `type` value to a filter than an integer handled
```