### PR TITLE
close API: make classes final

### DIFF
--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -15,10 +15,7 @@ namespace Sonata\DoctrineORMAdminBundle\Admin;
 
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class FieldDescription extends BaseFieldDescription
+final class FieldDescription extends BaseFieldDescription
 {
     public function getTargetModel(): ?string
     {

--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -21,11 +21,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Twig\Environment;
 
 /**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.22
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AuditBlockService extends AbstractBlockService
+final class AuditBlockService extends AbstractBlockService
 {
     /**
      * @var AuditReader

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -28,10 +28,7 @@ use Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class DatagridBuilder implements DatagridBuilderInterface
+final class DatagridBuilder implements DatagridBuilderInterface
 {
     /**
      * @var FilterFactoryInterface

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -161,7 +161,7 @@ final class DatagridBuilder implements DatagridBuilderInterface
      *
      * @throws \RuntimeException If invalid pager type is set
      */
-    protected function getPager(string $pagerType): PagerInterface
+    private function getPager(string $pagerType): PagerInterface
     {
         switch ($pagerType) {
             case Pager::TYPE_DEFAULT:

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -33,22 +33,22 @@ final class DatagridBuilder implements DatagridBuilderInterface
     /**
      * @var FilterFactoryInterface
      */
-    protected $filterFactory;
+    private $filterFactory;
 
     /**
      * @var FormFactoryInterface
      */
-    protected $formFactory;
+    private $formFactory;
 
     /**
      * @var TypeGuesserInterface
      */
-    protected $guesser;
+    private $guesser;
 
     /**
      * @var bool
      */
-    protected $csrfTokenEnabled;
+    private $csrfTokenEnabled;
 
     public function __construct(
         FormFactoryInterface $formFactory,

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -20,10 +20,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class ListBuilder implements ListBuilderInterface
+final class ListBuilder implements ListBuilderInterface
 {
     /**
      * @var TypeGuesserInterface

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -25,12 +25,12 @@ final class ListBuilder implements ListBuilderInterface
     /**
      * @var TypeGuesserInterface
      */
-    protected $guesser;
+    private $guesser;
 
     /**
      * @var string[]
      */
-    protected $templates = [];
+    private $templates = [];
 
     /**
      * @param string[] $templates

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -25,12 +25,12 @@ final class ShowBuilder implements ShowBuilderInterface
     /**
      * @var TypeGuesserInterface
      */
-    protected $guesser;
+    private $guesser;
 
     /**
      * @var string[]
      */
-    protected $templates;
+    private $templates;
 
     /**
      * @param string[] $templates

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -20,9 +20,6 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
 class ShowBuilder implements ShowBuilderInterface
 {
     /**

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -20,7 +20,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 
-class ShowBuilder implements ShowBuilderInterface
+final class ShowBuilder implements ShowBuilderInterface
 {
     /**
      * @var TypeGuesserInterface

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -21,8 +21,6 @@ use Sonata\AdminBundle\Datagrid\Pager as BasePager;
  *
  * @author Jonathan H. Wage <jonwage@gmail.com>
  *
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- *
  * @phpstan-extends BasePager<ProxyQueryInterface>
  */
 final class Pager extends BasePager

--- a/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -17,11 +17,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AddAuditEntityCompilerPass implements CompilerPassInterface
+final class AddAuditEntityCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
@@ -18,11 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AddGuesserCompilerPass implements CompilerPassInterface
+final class AddGuesserCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
@@ -18,11 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AddTemplatesCompilerPass implements CompilerPassInterface
+final class AddTemplatesCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,8 +17,6 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- *
  * This class contains the configuration information for the bundle.
  *
  * This information is solely responsible for how the different configuration
@@ -26,7 +24,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *
  * @author Michael Williams <mtotheikle@gmail.com>
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     /**
      * Generates the configuration tree.

--- a/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
+++ b/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
@@ -20,12 +20,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  * @author Michael Williams <michael.williams@funsational.com>
  */
-class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
+final class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -18,10 +18,7 @@ use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\Form\Type\BooleanType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class BooleanFilter extends Filter
+final class BooleanFilter extends Filter
 {
     public function filter(ProxyQueryInterface $query, string $alias, string $field, array $data): void
     {

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -18,10 +18,7 @@ use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class CallbackFilter extends Filter
+final class CallbackFilter extends Filter
 {
     public function filter(ProxyQueryInterface $query, string $alias, string $field, array $data): void
     {

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -17,10 +17,7 @@ use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class ChoiceFilter extends Filter
+final class ChoiceFilter extends Filter
 {
     public function filter(ProxyQueryInterface $query, string $alias, string $field, array $data): void
     {

--- a/src/Filter/ClassFilter.php
+++ b/src/Filter/ClassFilter.php
@@ -18,10 +18,7 @@ use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class ClassFilter extends Filter
+final class ClassFilter extends Filter
 {
     public const CHOICES = [
         EqualOperatorType::TYPE_EQUAL => 'INSTANCE OF',

--- a/src/Filter/DateFilter.php
+++ b/src/Filter/DateFilter.php
@@ -15,10 +15,7 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class DateFilter extends AbstractDateFilter
+final class DateFilter extends AbstractDateFilter
 {
     /**
      * This filter has no range.

--- a/src/Filter/DateRangeFilter.php
+++ b/src/Filter/DateRangeFilter.php
@@ -15,10 +15,7 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Sonata\Form\Type\DateRangeType;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class DateRangeFilter extends AbstractDateFilter
+final class DateRangeFilter extends AbstractDateFilter
 {
     /**
      * This is a range filter.

--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -15,10 +15,7 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class DateTimeFilter extends AbstractDateFilter
+final class DateTimeFilter extends AbstractDateFilter
 {
     /**
      * This filter has time.

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -43,7 +43,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 /**
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
  */
-class ModelManager implements ModelManagerInterface, LockInterface
+final class ModelManager implements ModelManagerInterface, LockInterface
 {
     public const ID_SEPARATOR = '~';
 

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -50,17 +50,17 @@ final class ModelManager implements ModelManagerInterface, LockInterface
     /**
      * @var ManagerRegistry
      */
-    protected $registry;
+    private $registry;
 
     /**
      * @var PropertyAccessorInterface
      */
-    protected $propertyAccessor;
+    private $propertyAccessor;
 
     /**
      * @var EntityManagerInterface[]
      */
-    protected $cache = [];
+    private $cache = [];
 
     /**
      * NEXT_MAJOR: Make $propertyAccessor mandatory.

--- a/src/SonataDoctrineORMAdminBundle.php
+++ b/src/SonataDoctrineORMAdminBundle.php
@@ -19,10 +19,7 @@ use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddTemplatesCompi
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class SonataDoctrineORMAdminBundle extends Bundle
+final class SonataDoctrineORMAdminBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/src/Util/ObjectAclManipulator.php
+++ b/src/Util/ObjectAclManipulator.php
@@ -21,10 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 
-/**
- * @final since sonata-project/doctrine-orm-admin-bundle 3.24
- */
-class ObjectAclManipulator extends BaseObjectAclManipulator
+final class ObjectAclManipulator extends BaseObjectAclManipulator
 {
     public function batchConfigureAcls(OutputInterface $output, AdminInterface $admin, ?UserSecurityIdentity $securityIdentity = null): void
     {

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -24,11 +24,11 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Datagrid\SimplePager;
 use Sonata\AdminBundle\Filter\FilterFactoryInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineORMAdminBundle\Builder\DatagridBuilder;
 use Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter;
-use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Guess\TypeGuess;
@@ -62,8 +62,12 @@ final class DatagridBuilderTest extends TestCase
         );
 
         $this->admin = $this->createMock(AdminInterface::class);
-        $this->modelManager = $this->createMock(ModelManager::class);
-
+        $this->modelManager = $this->getMockBuilder(ModelManagerInterface::class)
+            ->setMethodsExcept([])
+            // NEXT_MAJOR: remove the "hasMetadata" and "getParentMetadataForProperty" methods and just mock the interface normally
+            ->addMethods(['hasMetadata', 'getParentMetadataForProperty'])
+            ->getMock()
+        ;
         $this->admin->method('getClass')->willReturn('FakeClass');
         $this->admin->method('getModelManager')->willReturn($this->modelManager);
     }

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -62,7 +62,7 @@ final class DatagridBuilderTest extends TestCase
         );
 
         $this->admin = $this->createMock(AdminInterface::class);
-        $this->modelManager = $this->getMockBuilder(ModelManagerInterface::class)->getMock();
+        $this->modelManager = $this->createMock(ModelManagerInterface::class);
         $this->admin->method('getClass')->willReturn('FakeClass');
         $this->admin->method('getModelManager')->willReturn($this->modelManager);
     }

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -62,12 +62,7 @@ final class DatagridBuilderTest extends TestCase
         );
 
         $this->admin = $this->createMock(AdminInterface::class);
-        $this->modelManager = $this->getMockBuilder(ModelManagerInterface::class)
-            ->setMethodsExcept([])
-            // NEXT_MAJOR: remove the "hasMetadata" and "getParentMetadataForProperty" methods and just mock the interface normally
-            ->addMethods(['hasMetadata', 'getParentMetadataForProperty'])
-            ->getMock()
-        ;
+        $this->modelManager = $this->getMockBuilder(ModelManagerInterface::class)->getMock();
         $this->admin->method('getClass')->willReturn('FakeClass');
         $this->admin->method('getModelManager')->willReturn($this->modelManager);
     }

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -17,9 +17,9 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineORMAdminBundle\Builder\ListBuilder;
-use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
@@ -37,7 +37,7 @@ class ListBuilderTest extends TestCase
     protected function setUp(): void
     {
         $this->typeGuesser = $this->createStub(TypeGuesserInterface::class);
-        $this->modelManager = $this->createStub(ModelManager::class);
+        $this->modelManager = $this->createStub(ModelManagerInterface::class);
         $this->admin = $this->createMock(AdminInterface::class);
 
         $this->admin->method('getClass')->willReturn('Foo');

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -19,9 +19,9 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineORMAdminBundle\Builder\ShowBuilder;
-use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Symfony\Component\Form\Guess\TypeGuess;
 
 /**
@@ -50,7 +50,7 @@ class ShowBuilderTest extends TestCase
         );
 
         $this->admin = $this->createMock(AdminInterface::class);
-        $this->modelManager = $this->createStub(ModelManager::class);
+        $this->modelManager = $this->createStub(ModelManagerInterface::class);
 
         $this->admin->method('getClass')->willReturn('FakeClass');
         $this->admin->method('getModelManager')->willReturn($this->modelManager);

--- a/tests/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Guesser/FilterTypeGuesserTest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\DoctrineORMAdminBundle\Filter\BooleanFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\DateFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\DateTimeFilter;
@@ -40,7 +41,11 @@ class FilterTypeGuesserTest extends TestCase
     protected function setUp(): void
     {
         $this->guesser = new FilterTypeGuesser();
-        $this->modelManager = $this->createStub(ModelManager::class);
+        $this->modelManager = $this->getMockBuilder(ModelManagerInterface::class)
+            ->setMethodsExcept([])
+            ->addMethods(['getParentMetadataForProperty'])
+            ->getMock()
+        ;
         $this->metadata = $this->createStub(ClassMetadata::class);
     }
 

--- a/tests/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Guesser/FilterTypeGuesserTest.php
@@ -27,7 +27,6 @@ use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\TimeFilter;
 use Sonata\DoctrineORMAdminBundle\Guesser\FilterTypeGuesser;
 use Sonata\DoctrineORMAdminBundle\Model\MissingPropertyMetadataException;
-use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Guess\Guess;

--- a/tests/Guesser/TypeGuesserTest.php
+++ b/tests/Guesser/TypeGuesserTest.php
@@ -17,8 +17,8 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\DoctrineORMAdminBundle\Guesser\TypeGuesser;
-use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Symfony\Component\Form\Guess\Guess;
 
 /**
@@ -31,7 +31,11 @@ class TypeGuesserTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->modelManager = $this->createStub(ModelManager::class);
+        $this->modelManager = $this->getMockBuilder(ModelManagerInterface::class)
+            ->setMethodsExcept([])
+            ->addMethods(['getParentMetadataForProperty'])
+            ->getMock()
+        ;
         $this->guesser = new TypeGuesser();
     }
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -172,23 +172,14 @@ final class ModelManagerTest extends TestCase
     {
         $object = new VersionedEntity();
 
-        $modelManager = $this->getMockBuilder(ModelManager::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getMetadata'])
-            ->getMock();
-
-        $metadata = $this->getMetadata(\get_class($object), $isVersioned);
-
-        $modelManager->expects($this->any())
-            ->method('getMetadata')
-            ->willReturn($metadata);
+        $this->setGetMetadataExpectation(get_class($object), $this->getMetadata(\get_class($object), $isVersioned));
 
         if ($isVersioned) {
             $object->version = 123;
 
-            $this->assertNotNull($modelManager->getLockVersion($object));
+            $this->assertNotNull($this->modelManager->getLockVersion($object));
         } else {
-            $this->assertNull($modelManager->getLockVersion($object));
+            $this->assertNull($this->modelManager->getLockVersion($object));
         }
     }
 
@@ -208,25 +199,9 @@ final class ModelManagerTest extends TestCase
     {
         $object = new VersionedEntity();
 
-        $em = $this->getMockBuilder(EntityManager::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['lock'])
-            ->getMock();
-
-        $modelManager = $this->getMockBuilder(ModelManager::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getMetadata', 'getEntityManager'])
-            ->getMock();
-
-        $modelManager->expects($this->any())
-            ->method('getEntityManager')
-            ->willReturn($em);
-
         $metadata = $this->getMetadata(\get_class($object), $isVersioned);
 
-        $modelManager->expects($this->any())
-            ->method('getMetadata')
-            ->willReturn($metadata);
+        $em = $this->setGetMetadataExpectation(get_class($object), $metadata);
 
         $em->expects($isVersioned ? $this->once() : $this->never())
             ->method('lock');
@@ -239,7 +214,7 @@ final class ModelManagerTest extends TestCase
             $this->expectException(LockException::class);
         }
 
-        $modelManager->lock($object, 123);
+        $this->modelManager->lock($object, 123);
     }
 
     public function testGetParentMetadataForProperty(): void
@@ -247,52 +222,51 @@ final class ModelManagerTest extends TestCase
         $containerEntityClass = ContainerEntity::class;
         $associatedEntityClass = AssociatedEntity::class;
         $embeddedEntityClass = EmbeddedEntity::class;
-        $modelManagerClass = ModelManager::class;
 
-        $em = $this->createMock(EntityManager::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $this->registry->expects($this->atLeastOnce())
+            ->method('getManagerForClass')
+            ->willReturn($em)
+        ;
 
-        /** @var MockObject|ModelManager $modelManager */
-        $modelManager = $this->getMockBuilder($modelManagerClass)
-            ->disableOriginalConstructor()
-            ->setMethods(['getMetadata', 'getEntityManager'])
-            ->getMock();
-
-        $modelManager->expects($this->any())
-            ->method('getEntityManager')
-            ->willReturn($em);
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $em->expects($this->atLeastOnce())
+            ->method('getMetadataFactory')
+            ->willReturn($metadataFactory)
+        ;
 
         $containerEntityMetadata = $this->getMetadataForContainerEntity();
         $associatedEntityMetadata = $this->getMetadataForAssociatedEntity();
         $embeddedEntityMetadata = $this->getMetadataForEmbeddedEntity();
 
-        $modelManager->expects($this->any())->method('getMetadata')
+        $metadataFactory->expects($this->atLeastOnce())
+            ->method('getMetadataFor')
             ->willReturnMap(
                 [
-                    // NEXT_MAJOR: Remove the 'sonata_deprecation_mute'
-                    [$containerEntityClass, 'sonata_deprecation_mute', $containerEntityMetadata],
-                    [$embeddedEntityClass, 'sonata_deprecation_mute', $embeddedEntityMetadata],
-                    [$associatedEntityClass, 'sonata_deprecation_mute', $associatedEntityMetadata],
+                    [$containerEntityClass, $containerEntityMetadata],
+                    [$embeddedEntityClass, $embeddedEntityMetadata],
+                    [$associatedEntityClass, $associatedEntityMetadata],
                 ]
             );
 
         /** @var ClassMetadata $metadata */
-        [$metadata, $lastPropertyName] = $modelManager
+        [$metadata, $lastPropertyName] = $this->modelManager
             ->getParentMetadataForProperty($containerEntityClass, 'plainField');
         $this->assertSame($metadata->fieldMappings[$lastPropertyName]['type'], 'integer');
 
-        [$metadata, $lastPropertyName] = $modelManager
+        [$metadata, $lastPropertyName] = $this->modelManager
             ->getParentMetadataForProperty($containerEntityClass, 'associatedEntity.plainField');
         $this->assertSame($metadata->fieldMappings[$lastPropertyName]['type'], 'string');
 
-        [$metadata, $lastPropertyName] = $modelManager
+        [$metadata, $lastPropertyName] = $this->modelManager
             ->getParentMetadataForProperty($containerEntityClass, 'embeddedEntity.plainField');
         $this->assertSame($metadata->fieldMappings[$lastPropertyName]['type'], 'boolean');
 
-        [$metadata, $lastPropertyName] = $modelManager
+        [$metadata, $lastPropertyName] = $this->modelManager
             ->getParentMetadataForProperty($containerEntityClass, 'associatedEntity.embeddedEntity.plainField');
         $this->assertSame($metadata->fieldMappings[$lastPropertyName]['type'], 'boolean');
 
-        [$metadata, $lastPropertyName] = $modelManager
+        [$metadata, $lastPropertyName] = $this->modelManager
             ->getParentMetadataForProperty(
                 $containerEntityClass,
                 'associatedEntity.embeddedEntity.subEmbeddedEntity.plainField'
@@ -745,18 +719,9 @@ final class ModelManagerTest extends TestCase
 
     public function testGetNewFieldDescriptionInstance(): void
     {
-        $modelManager = $this->getMockBuilder(ModelManager::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getParentMetadataForProperty'])
-            ->getMock();
+        $this->setGetMetadataExpectation(\stdClass::class, new ClassMetadata(\stdClass::class));
 
-        $modelManager->method('getParentMetadataForProperty')->willReturn([
-            $classMetadata = new ClassMetadata(\stdClass::class),
-            'property',
-            [],
-        ]);
-
-        $fieldDescription = $modelManager->getNewFieldDescriptionInstance(\stdClass::class, 'name', []);
+        $fieldDescription = $this->modelManager->getNewFieldDescriptionInstance(\stdClass::class, 'name', []);
         $options = $fieldDescription->getOptions();
 
         $this->assertSame([
@@ -768,18 +733,9 @@ final class ModelManagerTest extends TestCase
 
     public function testGetNewFieldDescriptionInstanceWithOptions(): void
     {
-        $modelManager = $this->getMockBuilder(ModelManager::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getParentMetadataForProperty'])
-            ->getMock();
+        $this->setGetMetadataExpectation(\stdClass::class, new ClassMetadata(\stdClass::class));
 
-        $modelManager->method('getParentMetadataForProperty')->willReturn([
-            $classMetadata = new ClassMetadata(\stdClass::class),
-            'property',
-            [],
-        ]);
-
-        $fieldDescription = $modelManager->getNewFieldDescriptionInstance(\stdClass::class, 'name', [
+        $fieldDescription = $this->modelManager->getNewFieldDescriptionInstance(\stdClass::class, 'name', [
             'route' => ['name' => 'edit', 'parameters' => ['foo' => 'bar']],
         ]);
         $options = $fieldDescription->getOptions();
@@ -889,16 +845,6 @@ final class ModelManagerTest extends TestCase
      */
     public function testAddIdentifiersToQuery(array $expectedParameters, array $identifierFieldNames, array $ids): void
     {
-        $modelManager = $this->getMockBuilder(ModelManager::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getIdentifierFieldNames'])
-            ->getMock();
-
-        $modelManager
-            ->expects($this->once())
-            ->method('getIdentifierFieldNames')
-            ->willReturn($identifierFieldNames);
-
         $em = $this->getMockBuilder(EntityManager::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -923,7 +869,14 @@ final class ModelManagerTest extends TestCase
             ->setMethods(['getSortBy'])
             ->getMock();
 
-        $modelManager->addIdentifiersToQuery(Product::class, $proxyQuery, $ids);
+        $metadata = $this->createMock(ClassMetadata::class);
+        $metadata->expects($this->once())
+            ->method('getIdentifierFieldNames')
+            ->willReturn($identifierFieldNames)
+        ;
+        $this->setGetMetadataExpectation(Product::class, $metadata);
+
+        $this->modelManager->addIdentifiersToQuery(Product::class, $proxyQuery, $ids);
 
         $this->assertCount(\count($expectedParameters), $proxyQuery->getParameters());
 
@@ -989,5 +942,32 @@ final class ModelManagerTest extends TestCase
         }
 
         return $metadata;
+    }
+
+    /**
+     * @return EntityManagerInterface&MockObject
+     */
+    private function setGetMetadataExpectation(string $class, ClassMetadata $classMetadata): EntityManagerInterface
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $this->registry->expects($this->atLeastOnce())
+            ->method('getManagerForClass')
+            ->with($class)
+            ->willReturn($em)
+        ;
+
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $em->expects($this->atLeastOnce())
+            ->method('getMetadataFactory')
+            ->willReturn($metadataFactory)
+        ;
+
+        $metadataFactory->expects($this->atLeastOnce())
+            ->method('getMetadataFor')
+            ->with($class)
+            ->willReturn($classMetadata)
+        ;
+
+        return $em;
     }
 }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -172,7 +172,7 @@ final class ModelManagerTest extends TestCase
     {
         $object = new VersionedEntity();
 
-        $this->setGetMetadataExpectation(get_class($object), $this->getMetadata(\get_class($object), $isVersioned));
+        $this->setGetMetadataExpectation(\get_class($object), $this->getMetadata(\get_class($object), $isVersioned));
 
         if ($isVersioned) {
             $object->version = 123;
@@ -201,7 +201,7 @@ final class ModelManagerTest extends TestCase
 
         $metadata = $this->getMetadata(\get_class($object), $isVersioned);
 
-        $em = $this->setGetMetadataExpectation(get_class($object), $metadata);
+        $em = $this->setGetMetadataExpectation(\get_class($object), $metadata);
 
         $em->expects($isVersioned ? $this->once() : $this->never())
             ->method('lock');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this breaks BC.

This is part of https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1187

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Add final modifier to classes marked as `@final`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
