### PR TITLE
Remove useless options

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -138,9 +138,6 @@ class DatagridBuilder implements DatagridBuilderInterface
         //    $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
         //}
 
-        $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
-        $fieldDescription->setOption('name', $fieldDescription->getOption('name', $fieldDescription->getName()));
-
         if (\in_array($fieldDescription->getMappingType(), [
             ClassMetadata::ONE_TO_MANY,
             ClassMetadata::MANY_TO_MANY,

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -124,9 +124,6 @@ class ListBuilder implements ListBuilderInterface
             ));
         }
 
-        $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
-        $fieldDescription->setOption('label', $fieldDescription->getOption('label', $fieldDescription->getName()));
-
         if (!$fieldDescription->getTemplate()) {
             $fieldDescription->setTemplate($this->getTemplate($fieldDescription->getType()));
 
@@ -181,14 +178,6 @@ class ListBuilder implements ListBuilderInterface
 
         if (\in_array($fieldDescription->getType(), [null, '_action'], true)) {
             $fieldDescription->setType('actions');
-        }
-
-        if (null === $fieldDescription->getOption('name')) {
-            $fieldDescription->setOption('name', 'Action');
-        }
-
-        if (null === $fieldDescription->getOption('code')) {
-            $fieldDescription->setOption('code', 'Action');
         }
 
         if (null !== $fieldDescription->getOption('actions')) {

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -89,9 +89,6 @@ class ShowBuilder implements ShowBuilderInterface
             throw new \RuntimeException(sprintf('Please define a type for field `%s` in `%s`', $fieldDescription->getName(), \get_class($admin)));
         }
 
-        $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
-        $fieldDescription->setOption('label', $fieldDescription->getOption('label', $fieldDescription->getName()));
-
         if (!$fieldDescription->getTemplate()) {
             $fieldDescription->setTemplate($this->getTemplate($fieldDescription->getType()));
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

We're setting `code`, `name` and `label`.
- As explained [here](https://github.com/sonata-project/SonataAdminBundle/pull/6837#discussion_r576771541), I think that removing `code` should be considered as a bugfix. 
- The `name` option is not used.
- The `label` option is useless ; it's already set in the SonataAdminBundle, so the line is doing nothing.

I try it on my project and saw no impact.

## Changelog

```markdown
### Fixed
- Unavoidable deprecation about the `code` option.
```