### PR TITLE
Group by is better than distinct

### DIFF
--- a/src/Datagrid/OrderByToSelectWalker.php
+++ b/src/Datagrid/OrderByToSelectWalker.php
@@ -21,6 +21,10 @@ use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
+ * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x
+ *
  * Finds all PathExpressions in an AST's OrderByClause, and ensures that
  * the referenced fields are present in the SelectClause of the passed AST.
  *
@@ -30,6 +34,16 @@ use Doctrine\ORM\Query\TreeWalkerAdapter;
  */
 final class OrderByToSelectWalker extends TreeWalkerAdapter
 {
+    public function __construct($query, $parserResult, array $queryComponents)
+    {
+        parent::__construct($query, $parserResult, $queryComponents);
+
+        @trigger_error(sprintf(
+            'The %s class is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.',
+            __CLASS__,
+        ), \E_USER_DEPRECATED);
+    }
+
     public function walkSelectStatement(SelectStatement $AST)
     {
         if (!$AST->orderByClause instanceof OrderByClause) {

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -397,7 +397,7 @@ class ProxyQuery implements ProxyQueryInterface
         $queryBuilderId->distinct($this->isDistinct());
 
         if ($this->isDistinct()) {
-            $queryBuilderId->groupBy($idxSelect);
+            $queryBuilderId->groupBy(implode(', ', $selects));
         }
 
         // for SELECT DISTINCT, ORDER BY expressions must appear in idxSelect list

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -291,8 +291,19 @@ class ProxyQuery implements ProxyQueryInterface
         return $this->sortOrder;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-orm-admin-bundle 3.x, to be removed in 4.0.
+     */
     public function getSingleScalarResult()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+            .' and will be removed in version 4.0.',
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
+
         $query = $this->queryBuilder->getQuery();
 
         return $query->getSingleScalarResult();

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -392,8 +392,13 @@ class ProxyQuery implements ProxyQueryInterface
             }
             $idxSelect .= ('' !== $idxSelect ? ', ' : '').$idSelect;
         }
+
         $queryBuilderId->select($idxSelect);
         $queryBuilderId->distinct($this->isDistinct());
+
+        if ($this->isDistinct()) {
+            $queryBuilderId->groupBy($idxSelect);
+        }
 
         // for SELECT DISTINCT, ORDER BY expressions must appear in idxSelect list
         /* Consider

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -365,62 +365,20 @@ class ProxyQuery implements ProxyQueryInterface
      */
     protected function getFixedQueryBuilder(QueryBuilder $queryBuilder)
     {
-        $queryBuilderId = clone $queryBuilder;
-        $rootAlias = current($queryBuilderId->getRootAliases());
+        $rootAlias = current($queryBuilder->getRootAliases());
 
-        // step 1 : retrieve the targeted class
-        $from = $queryBuilderId->getDQLPart('from');
-        $class = $from[0]->getFrom();
-        $metadata = $queryBuilderId->getEntityManager()->getMetadataFactory()->getMetadataFor($class);
+        // step 1 : retrieve the identifier columns
+        $identifierFields = $queryBuilder
+            ->getEntityManager()
+            ->getMetadataFactory()
+            ->getMetadataFor(current($queryBuilder->getRootEntities()))
+            ->getIdentifierFieldNames();
 
-        // step 2 : retrieve identifier columns
-        $idNames = $metadata->getIdentifierFieldNames();
-
-        // step 3 : retrieve the different subjects ids
-        $queryBuilderId->resetDQLPart('select');
-
-        $selects = [];
-        foreach ($idNames as $idName) {
-            $select = sprintf('%s.%s', $rootAlias, $idName);
-
-            // Put the ID select on this array to use it on results QB
-            $selects[$idName] = $select;
-
-            // Use IDENTITY if id is a relation too.
-            // See: http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html
-            if ($metadata->hasAssociation($idName)) {
-                $queryBuilderId->addSelect(sprintf('IDENTITY(%s) as %s', $select, $idName));
-            } else {
-                $queryBuilderId->addSelect($select);
-            }
-        }
-
+        // step 2 : group by identifier columns
         if ($this->isDistinct()) {
-            $queryBuilderId->groupBy(implode(', ', $selects));
-        }
-
-        $results = $queryBuilderId->getQuery()->execute([], Query::HYDRATE_ARRAY);
-        $platform = $queryBuilderId->getEntityManager()->getConnection()->getDatabasePlatform();
-        $idxMatrix = [];
-        foreach ($results as $id) {
-            foreach ($idNames as $idName) {
-                // Convert ids to database value in case of custom type, if provided.
-                $fieldType = $metadata->getTypeOfField($idName);
-                $idxMatrix[$idName][] = $fieldType && Type::hasType($fieldType)
-                    ? Type::getType($fieldType)->convertToDatabaseValue($id[$idName], $platform)
-                    : $id[$idName];
-            }
-        }
-
-        // step 4 : alter the query to match the targeted ids
-        foreach ($idxMatrix as $idName => $idx) {
-            if (\count($idx) > 0) {
-                $idxParamName = sprintf('%s_idx', $idName);
-                $idxParamName = preg_replace('/[^\w]+/', '_', $idxParamName);
-                $queryBuilder->andWhere(sprintf('%s IN (:%s)', $selects[$idName], $idxParamName));
-                $queryBuilder->setParameter($idxParamName, $idx);
-                $queryBuilder->setMaxResults(null);
-                $queryBuilder->setFirstResult(null);
+            $queryBuilder->resetDQLPart('groupBy');
+            foreach ($identifierFields as $identifierField) {
+                $queryBuilder->addGroupBy(sprintf('%s.%s', $rootAlias, $identifierField));
             }
         }
 

--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -31,7 +31,7 @@ interface ProxyQueryInterface extends BaseProxyQueryInterface
 
 //    /**
 //     * This method should be preferred over `$this->getQueryBuilder()->getQuery()`
-//     * since some changed are done to the query builder in order to handle all the
+//     * since some changes are done to the query builder in order to handle all the
 //     * previously called Sonata\AdminBundle\Datagrid\ProxyQueryInterface methods.
 //     *
 //     * @return Query

--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -13,13 +13,28 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Datagrid;
 
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 
+/**
+ * NEXT_MAJOR: Remove the "@method" and uncomment the methods instead.
+ *
+ * @method Query getDoctrineQuery()
+ */
 interface ProxyQueryInterface extends BaseProxyQueryInterface
 {
     /**
      * @return QueryBuilder
      */
     public function getQueryBuilder();
+
+//    /**
+//     * This method should be preferred over `$this->getQueryBuilder()->getQuery()`
+//     * since some changed are done to the query builder in order to handle all the
+//     * previously called Sonata\AdminBundle\Datagrid\ProxyQueryInterface methods.
+//     *
+//     * @return Query
+//     */
+//    public function getDoctrineQuery(): Query;
 }

--- a/src/Exporter/DataSource.php
+++ b/src/Exporter/DataSource.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Exporter;
 
 use Doctrine\ORM\Query;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Exporter\DataSourceInterface;
 use Sonata\DoctrineORMAdminBundle\Datagrid\OrderByToSelectWalker;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\Exporter\Source\DoctrineORMQuerySourceIterator;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 
@@ -25,20 +26,38 @@ use Sonata\Exporter\Source\SourceIteratorInterface;
  */
 class DataSource implements DataSourceInterface
 {
-    public function createIterator(ProxyQueryInterface $query, array $fields): SourceIteratorInterface
+    public function createIterator(BaseProxyQueryInterface $query, array $fields): SourceIteratorInterface
     {
-        $query->select('DISTINCT '.current($query->getRootAliases()));
-        $query->setFirstResult(null);
-        $query->setMaxResults(null);
+        // NEXT_MAJOR: Keep the else part and throw a TypeError instead.
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
 
-        $sortBy = $query->getSortBy();
+            $query->select('DISTINCT '.current($query->getRootAliases()));
+            $query->setFirstResult(null);
+            $query->setMaxResults(null);
 
-        if (null !== $sortBy) {
-            $query->addOrderBy($sortBy, $query->getSortOrder());
-            $doctrineQuery = $query->getQuery();
-            $doctrineQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [OrderByToSelectWalker::class]);
+            $sortBy = $query->getSortBy();
+            if (null !== $sortBy) {
+                $query->addOrderBy($sortBy, $query->getSortOrder());
+                $doctrineQuery = $query->getQuery();
+                $doctrineQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [OrderByToSelectWalker::class]);
+            } else {
+                $doctrineQuery = $query->getQuery();
+            }
         } else {
-            $doctrineQuery = $query->getQuery();
+            // Distinct is need to iterate, even if group by is used
+            // @see https://github.com/doctrine/orm/issues/5868
+            $query->getQueryBuilder()->distinct();
+            $query->setFirstResult(null);
+            $query->setMaxResults(null);
+
+            $doctrineQuery = $query->getDoctrineQuery();
         }
 
         return new DoctrineORMQuerySourceIterator($doctrineQuery, $fields);

--- a/src/Exporter/DataSource.php
+++ b/src/Exporter/DataSource.php
@@ -51,7 +51,7 @@ class DataSource implements DataSourceInterface
                 $doctrineQuery = $query->getQuery();
             }
         } else {
-            // Distinct is need to iterate, even if group by is used
+            // Distinct is needed to iterate, even if group by is used
             // @see https://github.com/doctrine/orm/issues/5868
             $query->getQueryBuilder()->distinct();
             $query->setFirstResult(null);

--- a/tests/Datagrid/OrderByToSelectWalkerTest.php
+++ b/tests/Datagrid/OrderByToSelectWalkerTest.php
@@ -22,6 +22,10 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\StoreProduct;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 
 /**
+ * NEXT_MAJOR: Remove this test.
+ *
+ * @group legacy
+ *
  * @author Dariusz Markowicz <dmarkowicz77@gmail.com>
  */
 final class OrderByToSelectWalkerTest extends TestCase

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -118,11 +118,8 @@ class ProxyQueryTest extends TestCase
 
         $q = $this->getMockBuilder(AbstractQuery::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setHint', 'execute'])
+            ->setMethods(['execute'])
             ->getMockForAbstractClass();
-        $q->expects($this->once())
-           ->method('setHint')
-           ->willReturn($q);
         $q->expects($this->any())
             ->method('execute')
             ->willReturn([[$id => $value]]);
@@ -130,9 +127,8 @@ class ProxyQueryTest extends TestCase
         $qb = $this->getMockBuilder(QueryBuilder::class)
             ->setConstructorArgs([$em])
             ->getMock();
-        $qb->expects($this->once())
-            ->method('distinct')
-            ->with($this->equalTo($distinct));
+        $qb->expects($distinct ? $this->once() : $this->never())
+            ->method('groupBy');
         $qb->expects($this->any())
             ->method('getEntityManager')
             ->willReturn($em);

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -13,24 +13,15 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Datagrid;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Query;
-use Doctrine\ORM\Query\Expr\From;
-use Doctrine\ORM\Query\Expr\OrderBy;
-use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\DoubleNameEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Query\FooWalker;
-use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestClass;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 
 class ProxyQueryTest extends TestCase
@@ -70,103 +61,6 @@ class ProxyQueryTest extends TestCase
     protected function tearDown(): void
     {
         $this->em = null;
-    }
-
-    public function dataGetFixedQueryBuilder()
-    {
-        return [
-            ['aaa', 'bbb', 'id', 'id_idx', 33, Type::INTEGER, true],
-            ['aaa', 'bbb', 'associatedId', 'associatedId_idx', 33, null, true],
-            ['aaa', 'bbb', 'id.value', 'id_value_idx', 33, Type::INTEGER, false],
-            ['aaa', 'bbb', 'id.uuid', 'id_uuid_idx', new NonIntegerIdentifierTestClass('80fb6f91-bba1-4d35-b3d4-e06b24494e85'), UuidType::NAME, false],
-        ];
-    }
-
-    /**
-     * @dataProvider dataGetFixedQueryBuilder
-     */
-    public function testGetFixedQueryBuilder($class, $alias, $id, $expectedId, $value, $identifierType, $distinct): void
-    {
-        $meta = $this->createMock(ClassMetadata::class);
-        $meta->expects($this->any())
-            ->method('getIdentifierFieldNames')
-            ->willReturn([$id]);
-        $meta->expects($this->any())
-            ->method('getTypeOfField')
-            ->willReturn($identifierType);
-
-        $mf = $this->createMock(ClassMetadataFactory::class);
-        $mf->expects($this->any())
-            ->method('getMetadataFor')
-            ->with($this->equalTo($class))
-            ->willReturn($meta);
-
-        $platform = $this->createMock(PostgreSqlPlatform::class);
-
-        $conn = $this->createMock(Connection::class);
-        $conn->expects($this->any())
-            ->method('getDatabasePlatform')
-            ->willReturn($platform);
-
-        $em = $this->createMock(EntityManager::class);
-        $em->expects($this->any())
-            ->method('getMetadataFactory')
-            ->willReturn($mf);
-        $em->expects($this->any())
-            ->method('getConnection')
-            ->willReturn($conn);
-
-        $q = $this->getMockBuilder(AbstractQuery::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['execute'])
-            ->getMockForAbstractClass();
-        $q->expects($this->any())
-            ->method('execute')
-            ->willReturn([[$id => $value]]);
-
-        $qb = $this->getMockBuilder(QueryBuilder::class)
-            ->setConstructorArgs([$em])
-            ->getMock();
-        $qb->expects($distinct ? $this->once() : $this->never())
-            ->method('groupBy');
-        $qb->expects($this->any())
-            ->method('getEntityManager')
-            ->willReturn($em);
-        $qb->expects($this->any())
-            ->method('getQuery')
-            ->willReturn($q);
-        $qb->expects($this->once())
-            ->method('setParameter')
-            ->with($this->equalTo($expectedId), $this->equalTo([$value]));
-        $qb->expects($this->any())
-            ->method('getDQLPart')
-            ->willReturnCallback(static function ($part) use ($class, $alias) {
-                $parts = [
-                    'from' => [new From($class, $alias)],
-                    'orderBy' => [new OrderBy('whatever', 'DESC')],
-                ];
-
-                return $parts[$part];
-            });
-        $qb->expects($this->once())
-            ->method('addOrderBy')
-            ->with("$alias.$id", null);
-        $qb->expects($this->once())
-            ->method('getRootEntities')
-            ->willReturn([$class]);
-        $qb->expects($this->exactly(2))
-            ->method('getRootAliases')
-            ->willReturn([$alias]);
-
-        $pq = $this->getMockBuilder(ProxyQuery::class)
-            ->setConstructorArgs([$qb])
-            ->setMethods(['a'])
-            ->getMock();
-
-        $pq->setDistinct($distinct);
-
-        /* Work */
-        $pq->execute();
     }
 
     public function testSetHint(): void

--- a/tests/Exporter/DataSourceTest.php
+++ b/tests/Exporter/DataSourceTest.php
@@ -18,9 +18,11 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\Datagrid\OrderByToSelectWalker;
-use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\Exporter\DataSource;
+use Sonata\Exporter\Source\DoctrineORMQuerySourceIterator;
 
 final class DataSourceTest extends TestCase
 {
@@ -48,6 +50,10 @@ final class DataSourceTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
      * @dataProvider getSortableInDataSourceIteratorDataProvider
      */
     public function testSortableInDataSourceIterator(
@@ -61,23 +67,16 @@ final class DataSourceTest extends TestCase
         $em = $this->createStub(EntityManager::class);
         $em->method('getConfiguration')->willReturn($configuration);
 
-        $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
-            ->setConstructorArgs([$em])
-            ->getMock();
-
-        $queryBuilder->expects($isAddOrderBy ? $this->atLeastOnce() : $this->never())->method('addOrderBy');
-        $queryBuilder->method('getRootAliases')->willReturn(['a']);
-
         $query = new Query($em);
-        $queryBuilder->method('getQuery')->willReturn($query);
+        $proxyQuery = $this->getMockBuilder(BaseProxyQueryInterface::class)
+            ->addMethods(['select', 'getRootAliases', 'addOrderBy', 'getQuery'])
+            ->getMockForAbstractClass();
 
-        $proxyQuery = $this->getMockBuilder(ProxyQuery::class)
-            ->setConstructorArgs([$queryBuilder])
-            ->onlyMethods(['getSortBy', 'getSortOrder'])
-            ->getMock();
-
+        $proxyQuery->method('getRootAliases')->willReturn(['a']);
         $proxyQuery->method('getSortOrder')->willReturn($sortOrder);
         $proxyQuery->method('getSortBy')->willReturn($sortBy);
+        $proxyQuery->expects($isAddOrderBy ? $this->atLeastOnce() : $this->never())->method('addOrderBy');
+        $proxyQuery->method('getQuery')->willReturn($query);
 
         $this->dataSource->createIterator($proxyQuery, []);
 
@@ -85,5 +84,33 @@ final class DataSourceTest extends TestCase
             $this->assertArrayHasKey($key = 'doctrine.customTreeWalkers', $hints = $query->getHints());
             $this->assertContains(OrderByToSelectWalker::class, $hints[$key]);
         }
+    }
+
+    public function testCreateIterator(): void
+    {
+        $configuration = $this->createStub(Configuration::class);
+        $configuration->method('getDefaultQueryHints')->willReturn([]);
+
+        $em = $this->createStub(EntityManager::class);
+        $em->method('getConfiguration')->willReturn($configuration);
+
+        $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
+            ->setConstructorArgs([$em])
+            ->getMock();
+        $query = new Query($em);
+
+        $queryBuilder->expects($this->once())->method('distinct');
+
+        $proxyQuery = $this->getMockBuilder(ProxyQueryInterface::class)
+            ->addMethods(['getDoctrineQuery'])
+            ->getMockForAbstractClass();
+
+        $proxyQuery->method('getQueryBuilder')->willReturn($queryBuilder);
+        $proxyQuery->method('getDoctrineQuery')->willReturn($query);
+        $proxyQuery->expects($this->once())->method('setFirstResult')->with(null);
+        $proxyQuery->expects($this->once())->method('setMaxResults')->with(null);
+
+        $iterator = $this->dataSource->createIterator($proxyQuery, []);
+        $this->assertInstanceOf(DoctrineORMQuerySourceIterator::class, $iterator);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I have a Contract entity and a Client entity.
A client can have multiple contracts. A contract can be associated to multiple clients.

In the `configureQuery` of my `ContractAdmin`, I'm using a `leftJoin('contract.client')`.
I got a weird behavior:
- The total of result was 102.
- I got 4 pages of 32 results (which mean 128 results)
- Some results were missing (in database the query was returning 133 results, but there was no page 5 on the admin)

Distinct is not a good thing to use with pagination:
If the results are:
```
-----------
contract | client
-----------
1 | 1
-----------
2 | 1
-----------
2 | 2
-----------
1 | 2
-----------
3 | 1
-----------
```

With distinct on col 1 and a limit of 2
- Page 1 return contract 1 and 2
- Page 2 return contract 2 and 1
- There is no page 3

With groupby, it's applied BEFORE the pagination, so it became
```
-----------
contract | client
-----------
1 | 1
-----------
2 | 1
-----------
3 | 1
-----------
```
and the result are the one expected.

I tried on my project and it works.

Another thing: `setDistinct` and `isDistinct` are not in the ProxyQueryInterface.
I think we should deprecate them, and always adding the groupBy in the fixQueryBuilder method.

WDYT @sonata-project/contributors ?

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface::getDoctrineQuery()`

### Deprecated
- class `Sonata\DoctrineORMAdminBundle\Datagrid\OrderByToSelectWalker`
- `Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery::getFixedQueryBuilder()`
- `Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery::getSingleScalarResult()`

### Fixed
- Do not display multiple times the same row in the admin list and the export list.
```