### PR TITLE
Re-add getUniqueParameterId and entityJoin

### DIFF
--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -18,5 +18,12 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 
 interface ProxyQueryInterface extends BaseProxyQueryInterface
 {
+    public function getUniqueParameterId(): int;
+
+    /**
+     * @param mixed[] $associationMappings
+     */
+    public function entityJoin(array $associationMappings): string;
+
     public function getQueryBuilder(): QueryBuilder;
 }


### PR DESCRIPTION
These methods were removed from `Sonata\AdminBundle\Datagrid\ProxyQueryInterface` in master but are still used in DoctrineORMAdminBundle.