### PR TITLE
Avoid calling a non existant method

### DIFF
--- a/src/Resources/config/security.xml
+++ b/src/Resources/config/security.xml
@@ -4,6 +4,8 @@
         <parameter key="sonata.admin.manipulator.acl.object.orm.class">Sonata\DoctrineORMAdminBundle\Util\ObjectAclManipulator</parameter>
     </parameters>
     <services>
-        <service id="sonata.admin.manipulator.acl.object.orm" class="%sonata.admin.manipulator.acl.object.orm.class%" public="true"/>
+        <service id="sonata.admin.manipulator.acl.object.orm" class="%sonata.admin.manipulator.acl.object.orm.class%" public="true">
+            <argument type="service" id="doctrine"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
## Subject

ModelManagerInterface->getEntityManager() does not exist.
Similar to https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/src/Util/ObjectAclManipulator.php

## Changelog

```markdown
### Deprecated
- Not passing a `ManagerRegistry` as first argument of `ObjectAclManipulator`
```