### PR TITLE
Set default field_name value in DatagridBuilder

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -83,6 +83,8 @@ final class DatagridBuilder implements DatagridBuilderInterface
             $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
         }
 
+        $fieldDescription->setOption('field_name', $fieldDescription->getOption('field_name', $fieldDescription->getFieldName()));
+
         $fieldDescription->mergeOption('field_options', ['required' => false]);
 
         if (ModelAutocompleteFilter::class === $fieldDescription->getType()) {

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -120,6 +120,15 @@ final class DatagridBuilderTest extends TestCase
         $this->datagridBuilder->fixFieldDescription($this->admin, $fieldDescription);
     }
 
+    public function testFixFieldDescriptionWithoutFieldName(): void
+    {
+        $fieldDescription = new FieldDescription('test', [], [], [], [], 'fieldName');
+
+        $this->datagridBuilder->fixFieldDescription($this->admin, $fieldDescription);
+
+        $this->assertSame('fieldName', $fieldDescription->getOption('field_name'));
+    }
+
     public function testAddFilterNoType(): void
     {
         $datagrid = $this->createStub(DatagridInterface::class);


### PR DESCRIPTION
## Subject

I am targeting this branch, because the issue introduced in master branch.

Setting `field_name` was removed in https://github.com/sonata-project/SonataAdminBundle/pull/6838 and since then SonataAdminBundle relies on the persistence bundle (which SonataDoctrineORMAdminBundle is) to set correct value of this option. Setting of this option was added in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1297/files#diff-f1cf10ef5a385627958c076574e9aefa52d2e24c254e239128812f868aca6808R90 and then was accidentally (I think) removed in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/commit/823c3583553276e1e7dd39c2e94ca87942718ba9#diff-f1cf10ef5a385627958c076574e9aefa52d2e24c254e239128812f868aca6808L87 during resolving conflicts of merging https://github.com/sonata-project/SonataDoctrineORMAdminBundle/commit/aa3e3270c3b404ce99f8b70c4e5a7d37b4affe1c changes to master.

Without this fix users have to explicitly specify (and duplicate at the same time) the name of the field in `filterOptions` for each declared Datagrid Filter which has not-null type, and this introduces the great BC break and requires a lot of changes in all `configureDatagridFilters()` methods of `Admin` classes.