### PR TITLE
Deprecate passing arguments to `ProxyQuery::execute()`, regardless its values

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -192,7 +192,7 @@ class ProxyQuery implements ProxyQueryInterface
     public function execute(array $params = [], $hydrationMode = null)
     {
         // NEXT_MAJOR: Remove this check and update method signature to `execute()`.
-        if ([] !== $params || null !== $hydrationMode) {
+        if (\func_num_args() > 0) {
             @trigger_error(sprintf(
                 'Passing arguments to "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x.',
                 __METHOD__,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Deprecate passing arguments to `ProxyQuery::execute()`, regardless its values.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Follow up of #1333.