### PR TITLE
Address some direct deprecations from tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.88",
+        "sonata-project/admin-bundle": "^3.89.1",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -22,6 +22,12 @@ use Sonata\DoctrineORMAdminBundle\Admin\FieldDescription;
 
 class FieldDescriptionTest extends TestCase
 {
+    /**
+     * NEXT_MAJOR: Remove the "legacy" group when `Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter`
+     * class is removed or stops extending `NullFilter`.
+     *
+     * @group legacy
+     */
     public function testOptions(): void
     {
         $field = new FieldDescription('name', [
@@ -255,7 +261,7 @@ class FieldDescriptionTest extends TestCase
         $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
         $mockedObject->expects($this->once())->method('myMethod')->willReturn('myMethodValue');
 
-        $field = new FieldDescription('name', ['code' => 'myMethod']);
+        $field = new FieldDescription('name', ['accessor' => 'myMethod']);
 
         $this->assertSame('myMethodValue', $field->getValue($mockedObject));
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Address some direct deprecations from tests.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->