### PR TITLE
mark EmptyFilter service as deprecated

### DIFF
--- a/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
+++ b/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\DependencyInjection;
 
 use Sonata\AdminBundle\DependencyInjection\AbstractSonataAdminExtension;
+use Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter;
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -59,5 +61,21 @@ class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
 
         $container->getDefinition('sonata.admin.builder.orm_show')
             ->replaceArgument(1, $config['templates']['types']['show']);
+
+        // NEXT_MAJOR: remove this block.
+        $deprecatedEmptyFilterDefinition = $container->getDefinition(EmptyFilter::class);
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            // Symfony 5.1+
+            $deprecatedEmptyFilterDefinition->setDeprecated(
+                'sonata-project/doctrine-orm-admin-bundle',
+                '3.x',
+                'The "%service_id%" service is deprecated since sonata-project/doctrine-orm-admin-bundle version 3.x and will be removed in 4.0.'
+            );
+        } else {
+            // Symfony < 5.1
+            $deprecatedEmptyFilterDefinition->setDeprecated(
+                'The "%service_id%" service is deprecated since sonata-project/doctrine-orm-admin-bundle version 3.x and will be removed in 4.0.'
+            );
+        }
     }
 }

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -15,6 +15,8 @@ namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 /**
  * @psalm-suppress InvalidExtendClass
+ *
+ * @deprecated since sonata-project/doctrine-orm-admin-bundle version 3.27 and will be removed in 4.0.
  */
 final class EmptyFilter extends NullFilter
 {
@@ -22,7 +24,7 @@ final class EmptyFilter extends NullFilter
     {
         // NEXT_MAJOR: remove this file
         @trigger_error(sprintf(
-            'The %s class is deprecated since version 3.27 and will be removed in 4.0.'
+            'The %s class is deprecated since sonata-project/doctrine-orm-admin-bundle version 3.27 and will be removed in 4.0.'
             .' Use %s instead.',
             __CLASS__,
             NullFilter::class

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -24,7 +24,7 @@ final class EmptyFilter extends NullFilter
     {
         // NEXT_MAJOR: remove this file
         @trigger_error(sprintf(
-            'The %s class is deprecated since sonata-project/doctrine-orm-admin-bundle version 3.27 and will be removed in 4.0.'
+            'The "%s" class is deprecated since sonata-project/doctrine-orm-admin-bundle version 3.27 and will be removed in 4.0.'
             .' Use %s instead.',
             __CLASS__,
             NullFilter::class


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This is an attempt at fixing the failing tests due to reported deprecations by the phpunit bridge.
See conversation [here](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1339#issuecomment-793932725).

Locally for me the issue is fixed by deprecating the Symfony service.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- deprecated the `Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter` service since its class is already deprecated since version 3.27
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
