### PR TITLE
make AuditBlockService::$auditReader private

### DIFF
--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -28,7 +28,7 @@ final class AuditBlockService extends AbstractBlockService
     /**
      * @var AuditReader
      */
-    protected $auditReader;
+    private $auditReader;
 
     public function __construct(Environment $twig, AuditReader $auditReader)
     {


### PR DESCRIPTION
No changelog needed, or? The class was final already so this should not impact anyone.

closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1187