### PR TITLE
AuditReader::find and AuditReader::findRevision should not throw exception and return null instead

### DIFF
--- a/src/Model/AuditReader.php
+++ b/src/Model/AuditReader.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Model;
 
 use SimpleThings\EntityAudit\AuditReader as SimpleThingsAuditReader;
-use SimpleThings\EntityAudit\Exception\AuditException;
 use Sonata\AdminBundle\Model\AuditReaderInterface;
 
 final class AuditReader implements AuditReaderInterface
@@ -33,7 +32,7 @@ final class AuditReader implements AuditReaderInterface
     {
         try {
             return $this->auditReader->find($className, $id, $revisionId);
-        } catch (AuditException $exception) {
+        } catch (\Throwable $exception) {
             return null;
         }
     }
@@ -47,7 +46,7 @@ final class AuditReader implements AuditReaderInterface
     {
         try {
             return $this->auditReader->findRevision($revisionId);
-        } catch (AuditException $exception) {
+        } catch (\Throwable $exception) {
             return null;
         }
     }
@@ -56,7 +55,7 @@ final class AuditReader implements AuditReaderInterface
     {
         try {
             return $this->auditReader->findRevisions($className, $id);
-        } catch (AuditException $exception) {
+        } catch (\Throwable $exception) {
             return [];
         }
     }
@@ -65,7 +64,7 @@ final class AuditReader implements AuditReaderInterface
     {
         try {
             return $this->auditReader->diff($className, $id, $oldRevisionId, $newRevisionId);
-        } catch (AuditException $exception) {
+        } catch (\Throwable $exception) {
             return [];
         }
     }

--- a/src/Model/AuditReader.php
+++ b/src/Model/AuditReader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Model;
 
 use SimpleThings\EntityAudit\AuditReader as SimpleThingsAuditReader;
+use SimpleThings\EntityAudit\Exception\AuditException;
 use Sonata\AdminBundle\Model\AuditReaderInterface;
 
 final class AuditReader implements AuditReaderInterface
@@ -30,7 +31,11 @@ final class AuditReader implements AuditReaderInterface
 
     public function find(string $className, $id, $revisionId): ?object
     {
-        return $this->auditReader->find($className, $id, $revisionId);
+        try {
+            return $this->auditReader->find($className, $id, $revisionId);
+        } catch (AuditException $exception) {
+            return null;
+        }
     }
 
     public function findRevisionHistory(string $className, ?int $limit = 20, ?int $offset = 0): array
@@ -40,16 +45,28 @@ final class AuditReader implements AuditReaderInterface
 
     public function findRevision(string $className, $revisionId): ?object
     {
-        return $this->auditReader->findRevision($revisionId);
+        try {
+            return $this->auditReader->findRevision($revisionId);
+        } catch (AuditException $exception) {
+            return null;
+        }
     }
 
     public function findRevisions(string $className, $id): array
     {
-        return $this->auditReader->findRevisions($className, $id);
+        try {
+            return $this->auditReader->findRevisions($className, $id);
+        } catch (AuditException $exception) {
+            return [];
+        }
     }
 
     public function diff(string $className, $id, $oldRevisionId, $newRevisionId): array
     {
-        return $this->auditReader->diff($className, $id, $oldRevisionId, $newRevisionId);
+        try {
+            return $this->auditReader->diff($className, $id, $oldRevisionId, $newRevisionId);
+        } catch (AuditException $exception) {
+            return [];
+        }
     }
 }

--- a/tests/Model/AuditReaderTest.php
+++ b/tests/Model/AuditReaderTest.php
@@ -42,6 +42,21 @@ class AuditReaderTest extends TestCase
         $this->auditReader->find($className, $id, $revision);
     }
 
+    public function testFindWithException(): void
+    {
+        $className = 'fakeClass';
+        $id = 1;
+        $revision = 2;
+
+        $this->simpleThingsAuditReader
+            ->expects($this->once())
+            ->method('find')
+            ->with($className, $id, $revision)
+            ->willThrowException(new \Exception());
+
+        $this->assertNull($this->auditReader->find($className, $id, $revision));
+    }
+
     public function testFindRevisionHistory(): void
     {
         $limit = 20;
@@ -65,6 +80,19 @@ class AuditReaderTest extends TestCase
         $this->auditReader->findRevision('class', $revision);
     }
 
+    public function testFindRevisionWithException(): void
+    {
+        $revision = 2;
+
+        $this->simpleThingsAuditReader
+            ->expects($this->once())
+            ->method('findRevision')
+            ->with($revision)
+            ->willThrowException(new \Exception());
+
+        $this->assertNull($this->auditReader->findRevision('class', $revision));
+    }
+
     public function testFindRevisions(): void
     {
         $className = 'fakeClass';
@@ -77,6 +105,20 @@ class AuditReaderTest extends TestCase
             ->willReturn([]);
 
         $this->auditReader->findRevisions($className, $id);
+    }
+
+    public function testFindRevisionsWithException(): void
+    {
+        $className = 'fakeClass';
+        $id = 2;
+
+        $this->simpleThingsAuditReader
+            ->expects($this->once())
+            ->method('findRevisions')
+            ->with($className, $id)
+            ->willThrowException(new \Exception());
+
+        $this->assertSame([], $this->auditReader->findRevisions($className, $id));
     }
 
     public function testDiff(): void
@@ -93,5 +135,21 @@ class AuditReaderTest extends TestCase
             ->willReturn([]);
 
         $this->auditReader->diff($className, $id, $oldRevision, $newRevision);
+    }
+
+    public function testDiffWithException(): void
+    {
+        $className = 'fakeClass';
+        $id = 1;
+        $oldRevision = 1;
+        $newRevision = 2;
+
+        $this->simpleThingsAuditReader
+            ->expects($this->once())
+            ->method('diff')
+            ->with($className, $id, $oldRevision, $newRevision)
+            ->willThrowException(new \Exception());
+
+        $this->assertSame([], $this->auditReader->diff($className, $id, $oldRevision, $newRevision));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC-break.

Closes #1085.