### PR TITLE
Add a test for fetch join queries

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -253,18 +253,15 @@ class ProxyQuery implements ProxyQueryInterface
             }
         }
 
-        $queryBuilder->resetDQLPart('groupBy');
-
         foreach ($identifierFields as $identifierField) {
             $field = $rootAlias.'.'.$identifierField;
 
-            $queryBuilder->addGroupBy($field);
             if (!\in_array($field, $existingOrders, true)) {
                 $queryBuilder->addOrderBy($field, $this->getSortOrder());
             }
         }
 
-        return $queryBuilder->getQuery();
+        return $queryBuilder->distinct()->getQuery();
     }
 
     public function setSortBy($parentAssociationMappings, $fieldMapping)

--- a/tests/App/Admin/AuthorAdmin.php
+++ b/tests/App/Admin/AuthorAdmin.php
@@ -14,9 +14,13 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface as ORMProxyQueryInterface;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 final class AuthorAdmin extends AbstractAdmin
@@ -25,7 +29,17 @@ final class AuthorAdmin extends AbstractAdmin
     {
         $list
             ->add('id')
-            ->addIdentifier('name');
+            ->addIdentifier('name')
+            ->add('number_of_books', FieldDescriptionInterface::TYPE_INTEGER, [
+                'accessor' => static function (Author $author): int {
+                    return $author->getBooks()->count();
+                },
+                'template' => 'author/list_number_of_books_field.html.twig',
+            ])
+            ->add('numberOfReaders', FieldDescriptionInterface::TYPE_INTEGER, [
+                'template' => 'author/list_number_of_readers_field.html.twig',
+            ])
+            ;
     }
 
     protected function configureDatagridFilters(DatagridMapper $filter): void
@@ -38,6 +52,12 @@ final class AuthorAdmin extends AbstractAdmin
     protected function configureFormFields(FormMapper $form): void
     {
         $form
+            ->add('id', TextType::class, [
+                'attr' => [
+                    'class' => 'author_id',
+                ],
+                'empty_data' => '',
+            ])
             ->add('name', TextType::class, [
                 'attr' => [
                     'class' => 'author_name',
@@ -50,5 +70,20 @@ final class AuthorAdmin extends AbstractAdmin
                 ],
             ])
         ;
+    }
+
+    protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
+    {
+        \assert($query instanceof ORMProxyQueryInterface);
+
+        $alias = $query->getQueryBuilder()->getRootAliases()[0];
+
+        $query
+            ->addSelect('book')
+            ->addSelect('reader')
+            ->leftJoin(sprintf('%s.books', $alias), 'book')
+            ->leftJoin('book.readers', 'reader');
+
+        return $query;
     }
 }

--- a/tests/App/DataFixtures/AuthorFixtures.php
+++ b/tests/App/DataFixtures/AuthorFixtures.php
@@ -21,15 +21,22 @@ use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 final class AuthorFixtures extends Fixture
 {
     public const AUTHOR = 'author';
+    public const AUTHOR_WITH_TWO_BOOKS = 'author_with_two_books';
 
     public function load(ObjectManager $manager): void
     {
-        $author = new Author('Miguel de Cervantes');
+        $author = new Author('miguel_de_cervantes', 'Miguel de Cervantes');
         $author->setAddress(new Address('Somewhere in La Mancha, in a place whose name I do not care to remember'));
 
         $manager->persist($author);
+        $manager->persist(new Author('anonymous', 'Anonymous'));
+
+        $authorWithTwoBooks = new Author('author_with_two_books', 'Author with 2 books');
+        $manager->persist($authorWithTwoBooks);
+
         $manager->flush();
 
         $this->addReference(self::AUTHOR, $author);
+        $this->addReference(self::AUTHOR_WITH_TWO_BOOKS, $authorWithTwoBooks);
     }
 }

--- a/tests/App/DataFixtures/BookFixtures.php
+++ b/tests/App/DataFixtures/BookFixtures.php
@@ -17,6 +17,7 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Reader;
 
 final class BookFixtures extends Fixture implements DependentFixtureInterface
 {
@@ -28,6 +29,19 @@ final class BookFixtures extends Fixture implements DependentFixtureInterface
         $book->addCategory($this->getReference(CategoryFixtures::CATEGORY));
 
         $manager->persist($book);
+
+        $book1 = new Book('book_1', 'Book 1', $this->getReference(AuthorFixtures::AUTHOR_WITH_TWO_BOOKS));
+        $book1->addCategory($this->getReference(CategoryFixtures::CATEGORY));
+
+        $this->addReaders($book1, 100);
+
+        $book2 = new Book('book_2', 'Book 2', $this->getReference(AuthorFixtures::AUTHOR_WITH_TWO_BOOKS));
+        $book2->addCategory($this->getReference(CategoryFixtures::CATEGORY));
+
+        $this->addReaders($book2, 100);
+
+        $manager->persist($book1);
+        $manager->persist($book2);
         $manager->flush();
 
         $this->addReference(self::BOOK, $book);
@@ -42,5 +56,12 @@ final class BookFixtures extends Fixture implements DependentFixtureInterface
             CategoryFixtures::class,
             AuthorFixtures::class,
         ];
+    }
+
+    private function addReaders(Book $book, int $readers): void
+    {
+        for ($i = 0; $i < $readers; ++$i) {
+            $book->addReader(new Reader());
+        }
     }
 }

--- a/tests/App/Entity/Author.php
+++ b/tests/App/Entity/Author.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /** @ORM\Entity */
@@ -20,10 +22,10 @@ class Author
 {
     /**
      * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Column(type="string")
+     * @ORM\GeneratedValue(strategy="NONE")
      *
-     * @var int|null
+     * @var string
      */
     private $id;
 
@@ -35,16 +37,25 @@ class Author
     private $name;
 
     /**
+     * @ORM\OneToMany(targetEntity=Book::class, mappedBy="author")
+     *
+     * @var Collection<array-key, Book>
+     */
+    private $books;
+
+    /**
      * @ORM\Embedded(class="Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Address")
      *
      * @var Address
      */
     private $address;
 
-    public function __construct(string $name = '')
+    public function __construct(string $id = '', string $name = '')
     {
+        $this->id = $id;
         $this->name = $name;
         $this->address = new Address();
+        $this->books = new ArrayCollection();
     }
 
     public function __toString(): string
@@ -52,9 +63,14 @@ class Author
         return $this->name;
     }
 
-    public function getId(): ?int
+    public function getId(): string
     {
         return $this->id;
+    }
+
+    public function setId(string $id): void
+    {
+        $this->id = $id;
     }
 
     public function getName(): string
@@ -75,5 +91,20 @@ class Author
     public function setAddress(?Address $address): void
     {
         $this->address = $address;
+    }
+
+    /**
+     * @return Collection<array-key, Book>
+     */
+    public function getBooks(): Collection
+    {
+        return $this->books;
+    }
+
+    public function getNumberOfReaders(): int
+    {
+        return array_sum($this->books->map(static function (Book $book) {
+            return $book->getReaders()->count();
+        })->toArray());
     }
 }

--- a/tests/App/Entity/Book.php
+++ b/tests/App/Entity/Book.php
@@ -37,11 +37,18 @@ class Book
     private $name;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Author")
+     * @ORM\ManyToOne(targetEntity="Author", inversedBy="books")
      *
      * @var Author|null
      */
     private $author;
+
+    /**
+     * @ORM\ManyToMany(targetEntity=Reader::class, cascade="persist")
+     *
+     * @var Collection<array-key, Reader>
+     */
+    private $readers;
 
     /**
      * @ORM\ManyToMany(targetEntity="Category")
@@ -59,6 +66,7 @@ class Book
         $this->name = $name;
         $this->author = $author;
         $this->categories = new ArrayCollection();
+        $this->readers = new ArrayCollection();
     }
 
     public function __toString(): string
@@ -109,5 +117,15 @@ class Book
     public function getCategories(): Collection
     {
         return $this->categories;
+    }
+
+    public function addReader(Reader $reader): void
+    {
+        $this->readers->add($reader);
+    }
+
+    public function getReaders(): Collection
+    {
+        return $this->readers;
     }
 }

--- a/tests/App/Entity/Reader.php
+++ b/tests/App/Entity/Reader.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class Reader
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null
+     */
+    private $id;
+
+    public function __construct()
+    {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/App/Entity/Reader.php
+++ b/tests/App/Entity/Reader.php
@@ -27,10 +27,6 @@ class Reader
      */
     private $id;
 
-    public function __construct()
-    {
-    }
-
     public function getId(): ?int
     {
         return $this->id;

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -65,6 +65,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 Author::class,
                 null,
             ])
+            ->call('setTemplate', ['outer_list_rows_list', 'author/list_outer_list_rows_list.html.twig'])
 
         ->set(CarAdmin::class)
             ->public()

--- a/tests/App/templates/author/list_number_of_books_field.html.twig
+++ b/tests/App/templates/author/list_number_of_books_field.html.twig
@@ -1,0 +1,5 @@
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
+
+{% block field %}
+    <span class="js-number-of-books">{{ value }}</span>
+{% endblock %}

--- a/tests/App/templates/author/list_number_of_readers_field.html.twig
+++ b/tests/App/templates/author/list_number_of_readers_field.html.twig
@@ -1,0 +1,5 @@
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
+
+{% block field %}
+    <span class="js-number-of-readers">{{ value }}</span>
+{% endblock %}

--- a/tests/App/templates/author/list_outer_list_rows_list.html.twig
+++ b/tests/App/templates/author/list_outer_list_rows_list.html.twig
@@ -1,0 +1,5 @@
+{% for object in admin.datagrid.results %}
+    <tr class="js-author-item" data-author-id="{{ object.id }}">
+        {% include get_admin_template('inner_list_row', admin.code) %}
+    </tr>
+{% endfor %}

--- a/tests/Functional/EmbeddedMappingTest.php
+++ b/tests/Functional/EmbeddedMappingTest.php
@@ -35,10 +35,12 @@ final class EmbeddedMappingTest extends BasePantherTestCase
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/author/create');
 
+        $attributeId = $crawler->filter('.author_id')->attr('name');
         $attributeName = $crawler->filter('.author_name')->attr('name');
         $attributeAddressStreet = $crawler->filter('.author_address')->attr('name');
 
         $form = $crawler->selectButton('Create and return to list')->form();
+        $form[$attributeId] = 'new_id';
         $form[$attributeName] = 'A wonderful author';
         $form[$attributeAddressStreet] = 'A wonderful street to live';
 

--- a/tests/Functional/FetchJoinListTest.php
+++ b/tests/Functional/FetchJoinListTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class FetchJoinListTest extends BasePantherTestCase
+{
+    public function testCountFetchJoined(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/author/list');
+
+        self::assertSelectorTextContains('tr[data-author-id="author_with_two_books"] .js-number-of-books', '2');
+        self::assertSelectorTextContains('tr[data-author-id="author_with_two_books"] .js-number-of-readers', '200');
+        self::assertSelectorExists('tr[data-author-id="author_with_two_books"]');
+        self::assertSelectorExists('tr[data-author-id="miguel_de_cervantes"]');
+        self::assertSelectorExists('tr[data-author-id="anonymous"]');
+    }
+}

--- a/tests/Functional/ManyToOneMappingTest.php
+++ b/tests/Functional/ManyToOneMappingTest.php
@@ -48,10 +48,12 @@ final class ManyToOneMappingTest extends BasePantherTestCase
 
     private function createAuthorForm(Crawler $crawler): Form
     {
+        $authorAttributeId = $crawler->filter('.author_id')->attr('name');
         $authorAttributeName = $crawler->filter('.author_name')->attr('name');
         $addressAttributeName = $crawler->filter('.author_address')->attr('name');
 
         $authorForm = $crawler->filter('.modal-content button[name="btn_create"]')->form();
+        $authorForm[$authorAttributeId] = 'Wonderful Id';
         $authorForm[$authorAttributeName] = 'Wonderful Author';
         $authorForm[$addressAttributeName] = 'Wonderful street';
 


### PR DESCRIPTION
This test works on `3.30`, I haven't check why, but looking at the changelog I guess it's because of the changes introduced in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1319.

It is produced when using a fetch-join query in `AdminInterface::configureQuery `, in this case the author has two books, but now it returns just 1.

Basically, the number of books should be 2:

![image](https://user-images.githubusercontent.com/720690/111551080-b14ad580-877f-11eb-84f8-c8ff4cad8c23.png)
