### PR TITLE
Fix filter query when using "OR" conditions

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
+use Doctrine\ORM\Query\Expr\Orx;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter as BaseFilter;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
@@ -23,6 +24,15 @@ abstract class Filter extends BaseFilter
      * @var bool
      */
     protected $active = false;
+
+    /**
+     * Holds an array of `orX` expressions used by each admin when the condition
+     * equals the value on `FilterInterface::CONDITION_OR`, using the admin code
+     * as index.
+     *
+     * @var array<string, Orx>
+     */
+    private static $orExpressionsByAdmin = [];
 
     /**
      * NEXT_MAJOR change $query type for Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface.
@@ -96,7 +106,7 @@ abstract class Filter extends BaseFilter
         }
 
         if (self::CONDITION_OR === $this->getCondition()) {
-            $query->getQueryBuilder()->orWhere($parameter);
+            $this->addOrParameter($query, $parameter);
         } else {
             $query->getQueryBuilder()->andWhere($parameter);
         }
@@ -140,5 +150,72 @@ abstract class Filter extends BaseFilter
         // dots are not accepted in a DQL identifier so replace them
         // by underscores.
         return str_replace('.', '_', $this->getName()).'_'.$query->getUniqueParameterId();
+    }
+
+    /**
+     * Adds the parameter to the corresponding `Orx` expression used in the `where` clause.
+     * If it doesn't exist, a new one is created.
+     * This method groups the filter "OR" conditions based on the "admin_code" option. If this
+     * option is not set, it uses a marker (":sonata_admin_datagrid_filter_query_marker") in
+     * the resulting DQL in order to identify the corresponding "WHERE (...)" condition
+     * group each time it is required.
+     * It allows to get queries like "WHERE previous_condition = previous_value AND (filter_1 = value OR filter_2 = value OR ...)",
+     * where the logical "OR" operators added by the filters are grouped inside a condition,
+     * instead of having unfolded "WHERE ..." clauses like "WHERE previous_condition = previous_value OR filter_1 = value OR filter_2 = value OR ...",
+     * which will produce undesired results.
+     *
+     * TODO: Remove the logic related to the ":sonata_admin_datagrid_filter_query_marker" marker when
+     * the constraint for "sonata-project/admin-bundle" guarantees that the "admin_code" option is set.
+     *
+     * @param mixed $parameter
+     */
+    private function addOrParameter(BaseProxyQueryInterface $query, $parameter): void
+    {
+        $adminCode = $this->getOption('admin_code');
+        $orExpression = self::$orExpressionsByAdmin[$adminCode] ?? null;
+        if ($orExpression instanceof Orx) {
+            $orExpression->add($parameter);
+
+            return;
+        }
+
+        $qb = $query->getQueryBuilder();
+        $where = $qb->getDQLPart('where');
+
+        // Search for the ":sonata_admin_datagrid_filter_query_marker" marker in order to
+        // get the `Orx` expression.
+        if (null === $adminCode && null !== $where) {
+            foreach ($where->getParts() as $expression) {
+                if (!$expression instanceof Orx) {
+                    continue;
+                }
+
+                $expressionParts = $expression->getParts();
+
+                if (isset($expressionParts[0]) && \is_string($expressionParts[0]) &&
+                    0 === strpos($expressionParts[0], ':sonata_admin_datagrid_filter_query_marker')
+                ) {
+                    $expression->add($parameter);
+
+                    return;
+                }
+            }
+        }
+
+        // Create a new `Orx` expression.
+        $orExpression = $qb->expr()->orX();
+
+        if (null === $adminCode) {
+            // Add the ":sonata_admin_datagrid_filter_query_marker" parameter as marker for the `Orx` expression.
+            $orExpression->add($qb->expr()->isNull(':sonata_admin_datagrid_filter_query_marker'));
+            $qb->setParameter('sonata_admin_datagrid_filter_query_marker', 'sonata_admin.datagrid.filter_query.marker');
+        } else {
+            self::$orExpressionsByAdmin[$adminCode] = $orExpression;
+        }
+
+        $orExpression->add($parameter);
+
+        // Add the `Orx` expression to the `where` clause.
+        $qb->andWhere($orExpression);
     }
 }

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
-use PHPUnit\Framework\TestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\Filter;
+use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
 
-final class FilterTest extends TestCase
+final class FilterTest extends FilterTestCase
 {
     /**
      * @var Filter
@@ -56,6 +59,70 @@ final class FilterTest extends TestCase
     public function testIsActive(): void
     {
         $this->assertFalse($this->filter->isActive());
+    }
+
+    /**
+     * @dataProvider orExpressionProvider
+     */
+    public function testOrExpression(string $expected, array $filterOptions = []): void
+    {
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getExpressionBuilder')->willReturn(new Expr());
+        $queryBuilder = new TestQueryBuilder($entityManager);
+
+        $queryBuilder->select('e')->from('MyEntity', 'e');
+
+        // Some custom conditions set previous to the filters.
+        $queryBuilder
+            ->where($queryBuilder->expr()->eq(1, 2))
+            ->andWhere(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->eq(':parameter_1', 4),
+                    $queryBuilder->expr()->eq(5, 6)
+                )
+            )
+            ->setParameter('parameter_1', 3);
+
+        $proxyQuery = new ProxyQuery($queryBuilder);
+        $this->assertSameQuery([], $proxyQuery);
+
+        $filter1 = new StringFilter();
+        $filter1->setCondition(Filter::CONDITION_OR);
+        $filter1->initialize('field_name', $filterOptions);
+
+        $filter1->filter($proxyQuery, 'e', 'project', ['value' => 'sonata-project']);
+
+        $filter2 = new StringFilter();
+        $filter2->setCondition(Filter::CONDITION_OR);
+        $filter2->initialize('field_name', $filterOptions);
+
+        $filter2->filter($proxyQuery, 'e', 'version', ['value' => '3.x']);
+
+        // More custom conditions set after the filters.
+        $queryBuilder->andWhere($queryBuilder->expr()->eq(7, 8));
+
+        $this->assertSame($expected, $queryBuilder->getDQL());
+    }
+
+    public function orExpressionProvider(): iterable
+    {
+        yield 'Using "admin_code" option' => [
+            'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
+            .' AND (e.project LIKE :field_name_0 OR e.version LIKE :field_name_1) AND 7 = 8',
+            [
+                'allow_empty' => false,
+                'admin_code' => 'my_admin',
+            ],
+        ];
+
+        yield 'Missing "admin_code" option, fallback to DQL marker' => [
+            'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
+            .' AND (:sonata_admin_datagrid_filter_query_marker IS NULL'
+            .' OR e.project LIKE :field_name_0 OR e.version LIKE :field_name_1) AND 7 = 8',
+            [
+                'allow_empty' => false,
+            ],
+        ];
     }
 
     private function createFilter(): Filter


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix filter query when using "OR" conditions.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rework of #925, keeping BC.
Fixes sonata-project/SonataAdminBundle#2850.
Fixes sonata-project/SonataAdminBundle#3368.
Fixes sonata-project/SonataAdminBundle#5569.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Resulting `WHERE` clause from `Filter::applyWhere()` when using `OR` conditions on queries that already have previous conditions.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do

- [x] Find a way to tell the filter it must add the `AND WHERE` clause for first time without using a static variable;
- [x] Add tests.