### PR TITLE
Fix phpstan issue with tests

### DIFF
--- a/tests/Filter/BooleanFilterTest.php
+++ b/tests/Filter/BooleanFilterTest.php
@@ -35,17 +35,17 @@ class BooleanFilterTest extends FilterTestCase
         $filter = new BooleanFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
-        $filter->filter($builder, 'alias', 'field', 'test');
-        $filter->filter($builder, 'alias', 'field', false);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', '');
+        $filter->filter($proxyQuery, 'alias', 'field', 'test');
+        $filter->filter($proxyQuery, 'alias', 'field', false);
 
-        $filter->filter($builder, 'alias', 'field', []);
-        $filter->filter($builder, 'alias', 'field', [null, 'test']);
+        $filter->filter($proxyQuery, 'alias', 'field', []);
+        $filter->filter($proxyQuery, 'alias', 'field', [null, 'test']);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -54,12 +54,12 @@ class BooleanFilterTest extends FilterTestCase
         $filter = new BooleanFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => null, 'value' => BooleanType::TYPE_NO]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => null, 'value' => BooleanType::TYPE_NO]);
 
-        $this->assertSame(['WHERE alias.field = :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => 0], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -68,12 +68,12 @@ class BooleanFilterTest extends FilterTestCase
         $filter = new BooleanFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => null, 'value' => BooleanType::TYPE_YES]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => null, 'value' => BooleanType::TYPE_YES]);
 
-        $this->assertSame(['WHERE alias.field = :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => 1], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => 1], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -82,11 +82,11 @@ class BooleanFilterTest extends FilterTestCase
         $filter = new BooleanFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => null, 'value' => [BooleanType::TYPE_NO]]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => null, 'value' => [BooleanType::TYPE_NO]]);
 
-        $this->assertSame(['WHERE alias.field IN ("0")'], $builder->query);
+        $this->assertSameQuery(['WHERE alias.field IN ("0")'], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/ChoiceFilterTest.php
+++ b/tests/Filter/ChoiceFilterTest.php
@@ -34,13 +34,13 @@ class ChoiceFilterTest extends FilterTestCase
         $filter = new ChoiceFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', 'all');
-        $filter->filter($builder, 'alias', 'field', []);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', 'all');
+        $filter->filter($proxyQuery, 'alias', 'field', []);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -49,20 +49,20 @@ class ChoiceFilterTest extends FilterTestCase
         $filter = new ChoiceFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => ['1', '2']]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => ['1', '2']]);
 
-        $this->assertSame(['WHERE alias.field IN :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => ['1', '2']], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field IN :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
         $this->assertTrue($filter->isActive());
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', '2']]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', '2']]);
 
-        $this->assertSame(['WHERE alias.field NOT IN :field_name_0 OR alias.field IS NULL'], $builder->query);
-        $this->assertSame(['field_name_0' => ['1', '2']], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field NOT IN :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -71,20 +71,20 @@ class ChoiceFilterTest extends FilterTestCase
         $filter = new ChoiceFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => ['1', null]]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => ['1', null]]);
 
-        $this->assertSame(['WHERE alias.field IN :field_name_0 OR alias.field IS NULL'], $builder->query);
-        $this->assertSame(['field_name_0' => ['1', null]], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field IN :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => ['1', null]], $proxyQuery);
         $this->assertTrue($filter->isActive());
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', null]]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', null]]);
 
-        $this->assertSame(['WHERE alias.field NOT IN :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => ['1', null]], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field NOT IN :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => ['1', null]], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -93,20 +93,20 @@ class ChoiceFilterTest extends FilterTestCase
         $filter = new ChoiceFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => '1']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => '1']);
 
-        $this->assertSame(['WHERE alias.field = :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => '1'], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => '1'], $proxyQuery);
         $this->assertTrue($filter->isActive());
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => '1']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => '1']);
 
-        $this->assertSame(['WHERE alias.field != :field_name_0 OR alias.field IS NULL'], $builder->query);
-        $this->assertSame(['field_name_0' => '1'], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field != :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => '1'], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -115,20 +115,20 @@ class ChoiceFilterTest extends FilterTestCase
         $filter = new ChoiceFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => null]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => null]);
 
-        $this->assertSame(['WHERE alias.field IS NULL'], $builder->query);
-        $this->assertSame([], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field IS NULL'], $proxyQuery);
+        $this->assertSameQueryParameters([], $proxyQuery);
         $this->assertTrue($filter->isActive());
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => null]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => null]);
 
-        $this->assertSame(['WHERE alias.field IS NOT NULL'], $builder->query);
-        $this->assertSame([], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field IS NOT NULL'], $proxyQuery);
+        $this->assertSameQueryParameters([], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -137,12 +137,12 @@ class ChoiceFilterTest extends FilterTestCase
         $filter = new ChoiceFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 0]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 0]);
 
-        $this->assertSame(['WHERE alias.field = :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => 0], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/ClassFilterTest.php
+++ b/tests/Filter/ClassFilterTest.php
@@ -34,13 +34,13 @@ class ClassFilterTest extends FilterTestCase
         $filter = new ClassFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', 'asds');
-        $filter->filter($builder, 'alias', 'field', ['value' => '']);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', 'asds');
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => '']);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -49,11 +49,11 @@ class ClassFilterTest extends FilterTestCase
         $filter = new ClassFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => 'foo']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => 'foo']);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -62,11 +62,11 @@ class ClassFilterTest extends FilterTestCase
         $filter = new ClassFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 'type']);
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => 'type']);
-        $filter->filter($builder, 'alias', 'field', ['value' => 'type']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 'type']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => 'type']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => 'type']);
 
         $expected = [
             'WHERE alias INSTANCE OF type',
@@ -74,7 +74,7 @@ class ClassFilterTest extends FilterTestCase
             'WHERE alias INSTANCE OF type',
         ];
 
-        $this->assertSame($expected, $builder->query);
+        $this->assertSameQuery($expected, $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/CountFilterTest.php
+++ b/tests/Filter/CountFilterTest.php
@@ -24,12 +24,12 @@ class CountFilterTest extends FilterTestCase
         $filter = new CountFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', 'asds');
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', 'asds');
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -38,11 +38,11 @@ class CountFilterTest extends FilterTestCase
         $filter = new CountFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => 'foo']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => 'foo']);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -54,11 +54,11 @@ class CountFilterTest extends FilterTestCase
         $filter = new CountFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => $type, 'value' => 42]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => $type, 'value' => 42]);
 
-        $this->assertSame(['GROUP BY o', $expected], $builder->query);
+        $this->assertSameQuery(['GROUP BY o', $expected], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 

--- a/tests/Filter/DateFilterTest.php
+++ b/tests/Filter/DateFilterTest.php
@@ -27,12 +27,12 @@ class DateFilterTest extends FilterTestCase
         $filter = new DateFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', '');
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -46,10 +46,17 @@ class DateFilterTest extends FilterTestCase
         $filter = new DateFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $filter->filter($builder, 'alias', 'field', ['value' => new \DateTime()]);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => new \DateTime()]);
 
+        $this->assertSameQuery([
+            'WHERE alias.field >= :field_name_0',
+            'WHERE alias.field < :field_name_1',
+        ], $proxyQuery);
+        $this->assertTrue($filter->isActive());
+
+        $builder = $proxyQuery->getQueryBuilder();
+        \assert($builder instanceof TestQueryBuilder);
         $this->assertCount(2, $builder->queryParameters);
-        $this->assertCount(2, $builder->query);
     }
 }

--- a/tests/Filter/DateRangeFilterTest.php
+++ b/tests/Filter/DateRangeFilterTest.php
@@ -26,26 +26,26 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter = new DateRangeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
-        $filter->filter($builder, 'alias', 'field', 'test');
-        $filter->filter($builder, 'alias', 'field', false);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', '');
+        $filter->filter($proxyQuery, 'alias', 'field', 'test');
+        $filter->filter($proxyQuery, 'alias', 'field', false);
 
-        $filter->filter($builder, 'alias', 'field', []);
-        $filter->filter($builder, 'alias', 'field', [null, 'test']);
-        $filter->filter($builder, 'alias', 'field', ['type' => null, 'value' => []]);
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', []);
+        $filter->filter($proxyQuery, 'alias', 'field', [null, 'test']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => null, 'value' => []]);
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => null,
             'value' => ['start' => null, 'end' => null],
         ]);
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => null,
             'value' => ['start' => '', 'end' => ''],
         ]);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -54,12 +54,12 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter = new DateRangeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
         $startDateTime = new \DateTime('2016-08-01');
         $endDateTime = new \DateTime('2016-08-31');
 
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => null,
             'value' => [
                 'start' => $startDateTime,
@@ -67,11 +67,11 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]);
 
-        $this->assertSame(['WHERE alias.field >= :field_name_0', 'WHERE alias.field <= :field_name_1'], $builder->query);
-        $this->assertSame([
+        $this->assertSameQuery(['WHERE alias.field >= :field_name_0', 'WHERE alias.field <= :field_name_1'], $proxyQuery);
+        $this->assertSameQueryParameters([
             'field_name_0' => $startDateTime,
             'field_name_1' => $endDateTime,
-        ], $builder->queryParameters);
+        ], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -80,11 +80,11 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter = new DateRangeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
         $startDateTime = new \DateTime('2016-08-01');
 
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => null,
             'value' => [
                 'start' => $startDateTime,
@@ -92,8 +92,8 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]);
 
-        $this->assertSame(['WHERE alias.field >= :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => $startDateTime], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field >= :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => $startDateTime], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -102,11 +102,11 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter = new DateRangeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
         $endDateTime = new \DateTime('2016-08-31');
 
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => null,
             'value' => [
                 'start' => '',
@@ -114,8 +114,8 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]);
 
-        $this->assertSame(['WHERE alias.field <= :field_name_1'], $builder->query);
-        $this->assertSame(['field_name_1' => $endDateTime], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_1' => $endDateTime], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -130,7 +130,7 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter = new DateRangeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
         $modelEndDateTime = clone $viewEndDateTime;
         $modelEndDateTime->setTimezone($modelTimeZone);
@@ -138,7 +138,7 @@ final class DateRangeFilterTest extends FilterTestCase
         $this->assertSame($modelTimeZone->getName(), $modelEndDateTime->getTimezone()->getName());
         $this->assertNotSame($modelTimeZone->getName(), $viewEndDateTime->getTimezone()->getName());
 
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => null,
             'value' => [
                 'start' => '',
@@ -147,8 +147,8 @@ final class DateRangeFilterTest extends FilterTestCase
         ]);
 
         $this->assertTrue($filter->isActive());
-        $this->assertSame(['WHERE alias.field <= :field_name_1'], $builder->query);
-        $this->assertSame(['field_name_1' => $modelEndDateTime], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_1' => $modelEndDateTime], $proxyQuery);
         $this->assertSame($expectedEndDateTime->getTimestamp(), $modelEndDateTime->getTimestamp());
     }
 
@@ -193,11 +193,11 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter = new DateRangeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
         $endDateTime = new \DateTimeImmutable('2016-08-31');
 
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => null,
             'value' => [
                 'start' => '',
@@ -205,12 +205,15 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]);
 
-        $this->assertSame(['WHERE alias.field <= :field_name_1'], $builder->query);
+        $this->assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
+        $this->assertTrue($filter->isActive());
+
+        $builder = $proxyQuery->getQueryBuilder();
+        \assert($builder instanceof TestQueryBuilder);
         $this->assertCount(1, $builder->queryParameters);
         $this->assertSame(
             $endDateTime->modify('+23 hours 59 minutes 59 seconds')->getTimestamp(),
             $builder->queryParameters['field_name_1']->getTimestamp()
         );
-        $this->assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/DateTimeFilterTest.php
+++ b/tests/Filter/DateTimeFilterTest.php
@@ -27,13 +27,13 @@ class DateTimeFilterTest extends FilterTestCase
         $filter = new DateTimeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
-        $filter->filter($builder, 'alias', 'field', ['value' => '']);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', '');
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => '']);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 

--- a/tests/Filter/DateTimeRangeFilterTest.php
+++ b/tests/Filter/DateTimeRangeFilterTest.php
@@ -27,12 +27,12 @@ class DateTimeRangeFilterTest extends FilterTestCase
         $filter = new DateTimeRangeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', '');
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 

--- a/tests/Filter/EmptyFilterTest.php
+++ b/tests/Filter/EmptyFilterTest.php
@@ -31,11 +31,11 @@ final class EmptyFilterTest extends FilterTestCase
             'field_options' => ['class' => 'FooBar'],
         ]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -50,12 +50,12 @@ final class EmptyFilterTest extends FilterTestCase
             'inverse' => $inverse,
         ]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value]);
 
-        $this->assertSame([$expectedQuery], $builder->query);
+        $this->assertSameQuery([$expectedQuery], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 

--- a/tests/Filter/FilterTestCase.php
+++ b/tests/Filter/FilterTestCase.php
@@ -44,7 +44,6 @@ abstract class FilterTestCase extends TestCase
 
     final protected function createQueryBuilderStub(): TestQueryBuilder
     {
-        $testCase = $this;
         $queryBuilder = $this->createStub(TestQueryBuilder::class);
 
         $queryBuilder->method('setParameter')->willReturnCallback(
@@ -72,8 +71,8 @@ abstract class FilterTestCase extends TestCase
         );
 
         $queryBuilder->method('expr')->willReturnCallback(
-            static function () use ($testCase): Expr {
-                return $testCase->createExprStub();
+            function (): Expr {
+                return $this->createExprStub();
             }
         );
 

--- a/tests/Filter/FilterTestCase.php
+++ b/tests/Filter/FilterTestCase.php
@@ -18,17 +18,34 @@ use Doctrine\ORM\Query\Expr\Andx;
 use Doctrine\ORM\Query\Expr\Orx;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 
-class FilterTestCase extends TestCase
+abstract class FilterTestCase extends TestCase
 {
-    public function createQueryBuilderStub(): QueryBuilder
+    final protected function assertSameQuery(array $expected, ProxyQuery $proxyQuery): void
+    {
+        $queryBuilder = $proxyQuery->getQueryBuilder();
+        if (!$queryBuilder instanceof TestQueryBuilder) {
+            throw new \InvalidArgumentException('The query builder should be build with "createQueryBuilderStub()".');
+        }
+
+        $this->assertSame($expected, $queryBuilder->query);
+    }
+
+    final protected function assertSameQueryParameters(array $expected, ProxyQuery $proxyQuery): void
+    {
+        $queryBuilder = $proxyQuery->getQueryBuilder();
+        if (!$queryBuilder instanceof TestQueryBuilder) {
+            throw new \InvalidArgumentException('The query builder should be build with "createQueryBuilderStub()".');
+        }
+
+        $this->assertSame($expected, $queryBuilder->queryParameters);
+    }
+
+    final protected function createQueryBuilderStub(): TestQueryBuilder
     {
         $testCase = $this;
-
-        $queryBuilder = $this->createStub(QueryBuilder::class);
-
-        $queryBuilder->queryParameters = [];
-        $queryBuilder->query = [];
+        $queryBuilder = $this->createStub(TestQueryBuilder::class);
 
         $queryBuilder->method('setParameter')->willReturnCallback(
             static function (string $name, $value) use ($queryBuilder): void {
@@ -131,4 +148,13 @@ class FilterTestCase extends TestCase
 
         return $expr;
     }
+}
+
+class TestQueryBuilder extends QueryBuilder
+{
+    /** @var string[] */
+    public $query = [];
+
+    /** @var string[] */
+    public $queryParameters = [];
 }

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -25,12 +25,12 @@ class ModelFilterTest extends FilterTestCase
         $filter = new ModelFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', []);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', []);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -39,16 +39,16 @@ class ModelFilterTest extends FilterTestCase
         $filter = new ModelFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => EqualOperatorType::TYPE_EQUAL,
             'value' => ['1', '2'],
         ]);
 
         // the alias is now computer by the entityJoin method
-        $this->assertSame(['WHERE alias IN :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => ['1', '2']], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias IN :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -57,19 +57,19 @@ class ModelFilterTest extends FilterTestCase
         $filter = new ModelFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar'], 'field_name' => 'field_name']);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->filter($proxyQuery, 'alias', 'field', [
             'type' => EqualOperatorType::TYPE_NOT_EQUAL,
             'value' => ['1', '2'],
         ]);
 
         // the alias is now computer by the entityJoin method
-        $this->assertSame(
-            'WHERE alias NOT IN :field_name_0 OR IDENTITY('.current(($builder->getRootAliases())).'.field_name) IS NULL',
-            $builder->query[0]
+        $this->assertSameQuery(
+            ['WHERE alias NOT IN :field_name_0 OR IDENTITY('.current(($proxyQuery->getRootAliases())).'.field_name) IS NULL'],
+            $proxyQuery
         );
-        $this->assertSame(['field_name_0' => ['1', '2']], $builder->queryParameters);
+        $this->assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -78,12 +78,12 @@ class ModelFilterTest extends FilterTestCase
         $filter = new ModelFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 2]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 2]);
 
-        $this->assertSame(['WHERE alias IN :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => [2]], $builder->queryParameters);
+        $this->assertSameQuery(['WHERE alias IN :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => [2]], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -92,16 +92,16 @@ class ModelFilterTest extends FilterTestCase
         $filter = new ModelFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar'], 'field_name' => 'field_name']);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => 2]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => 2]);
 
-        $this->assertSame(
-            'WHERE alias NOT IN :field_name_0 OR IDENTITY('.current(($builder->getRootAliases())).'.field_name) IS NULL',
-            $builder->query[0]
+        $this->assertSameQuery(
+            ['WHERE alias NOT IN :field_name_0 OR IDENTITY('.current(($proxyQuery->getRootAliases())).'.field_name) IS NULL'],
+            $proxyQuery
         );
 
-        $this->assertSame(['field_name_0' => [2]], $builder->queryParameters);
+        $this->assertSameQueryParameters(['field_name_0' => [2]], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -112,9 +112,9 @@ class ModelFilterTest extends FilterTestCase
         $filter = new ModelFilter();
         $filter->initialize('field_name', ['mapping_type' => 'foo']);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->apply($builder, ['value' => 'asd']);
+        $filter->apply($proxyQuery, ['value' => 'asd']);
     }
 
     public function testAssociationWithValidMappingAndEmptyFieldName(): void
@@ -124,9 +124,9 @@ class ModelFilterTest extends FilterTestCase
         $filter = new ModelFilter();
         $filter->initialize('field_name', ['mapping_type' => ClassMetadata::ONE_TO_ONE]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->apply($builder, ['value' => 'asd']);
+        $filter->apply($proxyQuery, ['value' => 'asd']);
         $this->assertTrue($filter->isActive());
     }
 
@@ -141,14 +141,14 @@ class ModelFilterTest extends FilterTestCase
             ],
         ]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->apply($builder, ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 'asd']);
+        $filter->apply($proxyQuery, ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 'asd']);
 
-        $this->assertSame([
+        $this->assertSameQuery([
             'LEFT JOIN o.association_mapping AS s_association_mapping',
             'WHERE s_association_mapping IN :field_name_0',
-        ], $builder->query);
+        ], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -171,16 +171,16 @@ class ModelFilterTest extends FilterTestCase
             ],
         ]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->apply($builder, ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 'asd']);
+        $filter->apply($proxyQuery, ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 'asd']);
 
-        $this->assertSame([
+        $this->assertSameQuery([
             'LEFT JOIN o.association_mapping AS s_association_mapping',
             'LEFT JOIN s_association_mapping.sub_association_mapping AS s_association_mapping_sub_association_mapping',
             'LEFT JOIN s_association_mapping_sub_association_mapping.sub_sub_association_mapping AS s_association_mapping_sub_association_mapping_sub_sub_association_mapping',
             'WHERE s_association_mapping_sub_association_mapping_sub_sub_association_mapping IN :field_name_0',
-        ], $builder->query);
+        ], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/NullFilterTest.php
+++ b/tests/Filter/NullFilterTest.php
@@ -26,11 +26,11 @@ final class NullFilterTest extends FilterTestCase
             'field_options' => ['class' => 'FooBar'],
         ]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -45,12 +45,12 @@ final class NullFilterTest extends FilterTestCase
             'inverse' => $inverse,
         ]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value]);
 
-        $this->assertSame([$expectedQuery], $builder->query);
+        $this->assertSameQuery([$expectedQuery], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 

--- a/tests/Filter/NumberFilterTest.php
+++ b/tests/Filter/NumberFilterTest.php
@@ -24,12 +24,12 @@ class NumberFilterTest extends FilterTestCase
         $filter = new NumberFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', 'asds');
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', 'asds');
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -38,11 +38,11 @@ class NumberFilterTest extends FilterTestCase
         $filter = new NumberFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => 'foo']);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => 'foo']);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -51,14 +51,14 @@ class NumberFilterTest extends FilterTestCase
         $filter = new NumberFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', ['type' => NumberOperatorType::TYPE_EQUAL, 'value' => 42]);
-        $filter->filter($builder, 'alias', 'field', ['type' => NumberOperatorType::TYPE_GREATER_EQUAL, 'value' => 42]);
-        $filter->filter($builder, 'alias', 'field', ['type' => NumberOperatorType::TYPE_GREATER_THAN, 'value' => 42]);
-        $filter->filter($builder, 'alias', 'field', ['type' => NumberOperatorType::TYPE_LESS_EQUAL, 'value' => 42]);
-        $filter->filter($builder, 'alias', 'field', ['type' => NumberOperatorType::TYPE_LESS_THAN, 'value' => 42]);
-        $filter->filter($builder, 'alias', 'field', ['value' => 42]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => NumberOperatorType::TYPE_EQUAL, 'value' => 42]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => NumberOperatorType::TYPE_GREATER_EQUAL, 'value' => 42]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => NumberOperatorType::TYPE_GREATER_THAN, 'value' => 42]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => NumberOperatorType::TYPE_LESS_EQUAL, 'value' => 42]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['type' => NumberOperatorType::TYPE_LESS_THAN, 'value' => 42]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => 42]);
 
         $expected = [
             'WHERE alias.field = :field_name_0',
@@ -69,7 +69,7 @@ class NumberFilterTest extends FilterTestCase
             'WHERE alias.field = :field_name_5',
         ];
 
-        $this->assertSame($expected, $builder->query);
+        $this->assertSameQuery($expected, $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -24,13 +24,13 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
-        $filter->filter($builder, 'alias', 'field', []);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', '');
+        $filter->filter($proxyQuery, 'alias', 'field', []);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -57,17 +57,17 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => null]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => null]);
 
         if ('' !== (string) $value) {
-            $this->assertSame(['WHERE alias.field LIKE :field_name_0'], $builder->query);
-            $this->assertSame(['field_name_0' => sprintf('%%%s%%', $value)], $builder->queryParameters);
+            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value)], $proxyQuery);
             $this->assertTrue($filter->isActive());
         } else {
-            $this->assertSame([], $builder->query);
+            $this->assertSameQuery([], $proxyQuery);
             $this->assertFalse($filter->isActive());
         }
     }
@@ -80,17 +80,17 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_CONTAINS]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_CONTAINS]);
 
         if ('' !== (string) $value) {
-            $this->assertSame(['WHERE alias.field LIKE :field_name_0'], $builder->query);
-            $this->assertSame(['field_name_0' => sprintf('%%%s%%', $value)], $builder->queryParameters);
+            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value)], $proxyQuery);
             $this->assertTrue($filter->isActive());
         } else {
-            $this->assertSame([], $builder->query);
+            $this->assertSameQuery([], $proxyQuery);
             $this->assertFalse($filter->isActive());
         }
     }
@@ -103,17 +103,17 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_STARTS_WITH]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_STARTS_WITH]);
 
         if ('' !== (string) $value) {
-            $this->assertSame(['WHERE alias.field LIKE :field_name_0'], $builder->query);
-            $this->assertSame(['field_name_0' => sprintf('%s%%', $value)], $builder->queryParameters);
+            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            $this->assertSameQueryParameters(['field_name_0' => sprintf('%s%%', $value)], $proxyQuery);
             $this->assertTrue($filter->isActive());
         } else {
-            $this->assertSame([], $builder->query);
+            $this->assertSameQuery([], $proxyQuery);
             $this->assertFalse($filter->isActive());
         }
     }
@@ -126,17 +126,17 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_ENDS_WITH]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_ENDS_WITH]);
 
         if ('' !== (string) $value) {
-            $this->assertSame(['WHERE alias.field LIKE :field_name_0'], $builder->query);
-            $this->assertSame(['field_name_0' => sprintf('%%%s', $value)], $builder->queryParameters);
+            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s', $value)], $proxyQuery);
             $this->assertTrue($filter->isActive());
         } else {
-            $this->assertSame([], $builder->query);
+            $this->assertSameQuery([], $proxyQuery);
             $this->assertFalse($filter->isActive());
         }
     }
@@ -149,17 +149,17 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_NOT_CONTAINS]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_NOT_CONTAINS]);
 
         if ('' !== (string) $value) {
-            $this->assertSame(['WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL'], $builder->query);
-            $this->assertSame(['field_name_0' => sprintf('%%%s%%', $value)], $builder->queryParameters);
+            $this->assertSameQuery(['WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value)], $proxyQuery);
             $this->assertTrue($filter->isActive());
         } else {
-            $this->assertSame([], $builder->query);
+            $this->assertSameQuery([], $proxyQuery);
             $this->assertFalse($filter->isActive());
         }
     }
@@ -172,17 +172,17 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_EQUAL]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_EQUAL]);
 
         if ('' !== (string) $value || $allowEmpty) {
-            $this->assertSame(['WHERE alias.field = :field_name_0'], $builder->query);
-            $this->assertSame(['field_name_0' => (string) ($value ?? '')], $builder->queryParameters);
+            $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+            $this->assertSameQueryParameters(['field_name_0' => (string) ($value ?? '')], $proxyQuery);
             $this->assertTrue($filter->isActive());
         } else {
-            $this->assertSame([], $builder->query);
+            $this->assertSameQuery([], $proxyQuery);
             $this->assertFalse($filter->isActive());
         }
     }
@@ -195,17 +195,17 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_NOT_EQUAL]);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => StringOperatorType::TYPE_NOT_EQUAL]);
 
         if ('' !== (string) $value || $allowEmpty) {
-            $this->assertSame(['WHERE alias.field <> :field_name_0 OR alias.field IS NULL'], $builder->query);
-            $this->assertSame(['field_name_0' => (string) ($value ?? '')], $builder->queryParameters);
+            $this->assertSameQuery(['WHERE alias.field <> :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+            $this->assertSameQueryParameters(['field_name_0' => (string) ($value ?? '')], $proxyQuery);
             $this->assertTrue($filter->isActive());
         } else {
-            $this->assertSame([], $builder->query);
+            $this->assertSameQuery([], $proxyQuery);
             $this->assertFalse($filter->isActive());
         }
     }
@@ -228,28 +228,18 @@ class StringFilterTest extends FilterTestCase
             ],
         ]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->apply($builder, ['type' => StringOperatorType::TYPE_EQUAL, 'value' => 'asd']);
+        $filter->apply($proxyQuery, ['type' => StringOperatorType::TYPE_EQUAL, 'value' => 'asd']);
 
-        $this->assertSame(
+        $this->assertSameQuery([
             'LEFT JOIN o.association_mapping AS s_association_mapping',
-            $builder->query[0]
-        );
-        $this->assertSame(
             'LEFT JOIN s_association_mapping.sub_association_mapping AS s_association_mapping_sub_association_mapping',
-            $builder->query[1]
-        );
-        $this->assertSame(
             'LEFT JOIN s_association_mapping_sub_association_mapping.sub_sub_association_mapping AS s_association_mapping_sub_association_mapping_sub_sub_association_mapping',
-            $builder->query[2]
-        );
-        $this->assertSame(
             'WHERE s_association_mapping_sub_association_mapping_sub_sub_association_mapping.field_name = :field_name_0',
-            $builder->query[3]
-        );
-        $this->assertSame(['field_name_0' => 'asd'], $builder->queryParameters);
+        ], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => 'asd'], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -261,12 +251,12 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['case_sensitive' => $caseSensitive]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'FooBar', 'type' => $operatorType]);
-        $this->assertSame([$expectedQuery], $builder->query);
-        $this->assertSame(['field_name_0' => $expectedParameter], $builder->queryParameters);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => 'FooBar', 'type' => $operatorType]);
+        $this->assertSameQuery([$expectedQuery], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => $expectedParameter], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -300,11 +290,11 @@ class StringFilterTest extends FilterTestCase
         $filter = new StringFilter();
         $filter->initialize('field_name', ['format' => '%s']);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_CONTAINS]);
-        $this->assertSame(['WHERE alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => 'asd'], $builder->queryParameters);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => 'asd', 'type' => StringOperatorType::TYPE_CONTAINS]);
+        $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => 'asd'], $proxyQuery);
     }
 }

--- a/tests/Filter/StringListFilterTest.php
+++ b/tests/Filter/StringListFilterTest.php
@@ -24,12 +24,12 @@ class StringListFilterTest extends FilterTestCase
         $filter = new StringListFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', '');
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 
@@ -38,12 +38,12 @@ class StringListFilterTest extends FilterTestCase
         $filter = new StringListFilter();
         $filter->initialize('field_name');
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => null, 'type' => null]);
-        $this->assertSame(['WHERE alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => '%N;%'], $builder->queryParameters);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => null, 'type' => null]);
+        $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => '%N;%'], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -55,12 +55,12 @@ class StringListFilterTest extends FilterTestCase
         $filter = new StringListFilter();
         $filter->initialize('field_name');
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => $type]);
-        $this->assertSame(['WHERE alias.field LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => '%s:3:"asd";%'], $builder->queryParameters);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => 'asd', 'type' => $type]);
+        $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -75,12 +75,12 @@ class StringListFilterTest extends FilterTestCase
         $filter = new StringListFilter();
         $filter->initialize('field_name');
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_NOT_CONTAINS]);
-        $this->assertSame(['WHERE alias.field NOT LIKE :field_name_0'], $builder->query);
-        $this->assertSame(['field_name_0' => '%s:3:"asd";%'], $builder->queryParameters);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_NOT_CONTAINS]);
+        $this->assertSameQuery(['WHERE alias.field NOT LIKE :field_name_0'], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -89,12 +89,12 @@ class StringListFilterTest extends FilterTestCase
         $filter = new StringListFilter();
         $filter->initialize('field_name');
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_EQUAL]);
-        $this->assertSame(['WHERE alias.field LIKE :field_name_0 AND alias.field LIKE \'a:1:%\''], $builder->query);
-        $this->assertSame(['field_name_0' => '%s:3:"asd";%'], $builder->queryParameters);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_EQUAL]);
+        $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0 AND alias.field LIKE \'a:1:%\''], $proxyQuery);
+        $this->assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 
@@ -110,12 +110,12 @@ class StringListFilterTest extends FilterTestCase
         $filter = new StringListFilter();
         $filter->initialize('field_name');
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSame([], $builder->query);
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
 
-        $filter->filter($builder, 'alias', 'field', ['value' => $value, 'type' => $type]);
-        $this->assertSame($query, $builder->query);
-        $this->assertSame($parameters, $builder->queryParameters);
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => $type]);
+        $this->assertSameQuery($query, $proxyQuery);
+        $this->assertSameQueryParameters($parameters, $proxyQuery);
         $this->assertTrue($filter->isActive());
     }
 

--- a/tests/Filter/TimeFilterTest.php
+++ b/tests/Filter/TimeFilterTest.php
@@ -27,13 +27,13 @@ class TimeFilterTest extends FilterTestCase
         $filter = new TimeFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
-        $builder = new ProxyQuery($this->createQueryBuilderStub());
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
-        $filter->filter($builder, 'alias', 'field', ['value' => '']);
+        $filter->filter($proxyQuery, 'alias', 'field', null);
+        $filter->filter($proxyQuery, 'alias', 'field', '');
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => '']);
 
-        $this->assertSame([], $builder->query);
+        $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
     }
 


### PR DESCRIPTION
This provide a way to fix phpstan error with filters in test directory, because `query` and `queryParameters` doesn't exist on both `ProxyQuery` and `QueryBuilder`.