### PR TITLE
Fix missing argument 2 for `trigger_error()`

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -61,7 +61,7 @@ class Pager extends BasePager
         if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
                 'The %s() method is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27 and will be removed in 4.0.',
-                __METHOD__,
+                __METHOD__
             ), \E_USER_DEPRECATED);
         }
 
@@ -82,7 +82,7 @@ class Pager extends BasePager
     {
         @trigger_error(sprintf(
             'The %s() method is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27 and will be removed in 4.0. Use "getCurrentPageResults()" instead.',
-            __METHOD__,
+            __METHOD__
         ), \E_USER_DEPRECATED);
 
         return $this->getQuery()->execute([], $hydrationMode);
@@ -104,7 +104,7 @@ class Pager extends BasePager
 
         @trigger_error(sprintf(
             'Relying on the protected property "%s::$nbResults" and its getter/setter is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27 and will fail 4.0. Use "countResults()" and "setResultsCount()" instead.',
-            self::class,
+            self::class
         ), \E_USER_DEPRECATED);
 
         return $deprecatedCount;
@@ -122,7 +122,7 @@ class Pager extends BasePager
         if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
                 'The %s() method is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27 and will be removed in 4.0. Use "countResults()" instead.',
-                __METHOD__,
+                __METHOD__
             ), \E_USER_DEPRECATED);
         }
 
@@ -170,7 +170,7 @@ class Pager extends BasePager
         if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
             @trigger_error(sprintf(
                 'The %s() method is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27 and will be removed in 4.0. Use "setResultsCount()" instead.',
-                __METHOD__,
+                __METHOD__
             ), \E_USER_DEPRECATED);
         }
 

--- a/src/Exporter/DataSource.php
+++ b/src/Exporter/DataSource.php
@@ -32,11 +32,12 @@ class DataSource implements DataSourceInterface
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
 
             $query->select('DISTINCT '.current($query->getRootAliases()));
             $query->setFirstResult(null);

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -54,11 +54,12 @@ abstract class AbstractDateFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         // check data sanity

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -65,11 +65,12 @@ abstract class Filter extends BaseFilter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         $alias = $query->entityJoin($this->getParentAssociationMappings());
@@ -86,11 +87,12 @@ abstract class Filter extends BaseFilter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (self::CONDITION_OR === $this->getCondition()) {
@@ -127,11 +129,12 @@ abstract class Filter extends BaseFilter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         // dots are not accepted in a DQL identifier so replace them

--- a/src/Filter/ModelAutocompleteFilter.php
+++ b/src/Filter/ModelAutocompleteFilter.php
@@ -31,11 +31,12 @@ class ModelAutocompleteFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (!$data || !\is_array($data) || !\array_key_exists('value', $data)) {
@@ -90,9 +91,10 @@ class ModelAutocompleteFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
             ), \E_USER_DEPRECATED);
         }
@@ -124,11 +126,12 @@ class ModelAutocompleteFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (empty($data['value'])) {
@@ -159,11 +162,12 @@ class ModelAutocompleteFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         $associationMappings = $this->getParentAssociationMappings();

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -32,9 +32,10 @@ class ModelFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
             ), \E_USER_DEPRECATED);
         }
@@ -92,11 +93,12 @@ class ModelFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (0 === \count($data['value'])) {
@@ -141,11 +143,12 @@ class ModelFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         $types = [
@@ -176,11 +179,12 @@ class ModelFilter extends Filter
         if (!$query instanceof ProxyQueryInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-orm-admin-bundle 3.27'
-                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
                 \get_class($query),
                 __METHOD__,
+                \TypeError::class,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         $parentAlias = $rootAlias = current($query->getQueryBuilder()->getRootAliases());

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -76,10 +76,11 @@ class StringFilter extends Filter
 
         // NEXT_MAJOR: Remove this if and the (int) cast.
         if (!\is_int($type)) {
-            @trigger_error(
+            @trigger_error(sprintf(
                 'Passing a non integer type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.30'
-                .' and will throw a \TypeError error in version 4.0.',
-            );
+                .' and will throw a %s error in version 4.0.',
+                \TypeError::class
+            ), \E_USER_DEPRECATED);
         }
         $operator = $this->getOperator((int) $type);
 
@@ -157,10 +158,11 @@ class StringFilter extends Filter
     {
         if (!isset(self::CHOICES[$type])) {
             // NEXT_MAJOR: Throw an \OutOfRangeException instead.
-            @trigger_error(
+            @trigger_error(sprintf(
                 'Passing a non supported type is deprecated since sonata-project/doctrine-orm-admin-bundle 3.30'
-                .' and will throw an \OutOfRangeException error in version 4.0.',
-            );
+                .' and will throw an %s exception in version 4.0.',
+                \OutOfRangeException::class
+            ), \E_USER_DEPRECATED);
 //            throw new \OutOfRangeException(sprintf(
 //                'The type "%s" is not supported, allowed one are "%s".',
 //                $type,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix missing argument 2 for `trigger_error()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Missing argument 2 in calls to `trigger_error()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
