### PR TITLE
Tag AuditReader

### DIFF
--- a/src/Resources/config/audit.xml
+++ b/src/Resources/config/audit.xml
@@ -2,6 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.admin.audit.orm.reader" class="Sonata\DoctrineORMAdminBundle\Model\AuditReader" public="true">
+            <tag name="sonata.admin.audit_reader"/>
             <argument type="service" id="simplethings_entityaudit.reader" on-invalid="ignore"/>
         </service>
         <service id="sonata.admin_doctrine_orm.block.audit" class="Sonata\DoctrineORMAdminBundle\Block\AuditBlockService">

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -322,7 +322,7 @@ class FieldDescriptionTest extends TestCase
      */
     public function testDescribesSingleValuedAssociation($mappingType, bool $expected): void
     {
-        $fd = new FieldDescription();
+        $fd = new FieldDescription('foo');
         $fd->setAssociationMapping([
             'fieldName' => 'foo',
             'type' => $mappingType,
@@ -349,7 +349,7 @@ class FieldDescriptionTest extends TestCase
      */
     public function testDescribesCollectionValuedAssociation($mappingType, bool $expected)
     {
-        $fd = new FieldDescription();
+        $fd = new FieldDescription('foo');
         $fd->setAssociationMapping([
             'fieldName' => 'foo',
             'type' => $mappingType,

--- a/tests/Fixtures/Entity/AssociatedEntity.php
+++ b/tests/Fixtures/Entity/AssociatedEntity.php
@@ -30,10 +30,10 @@ class AssociatedEntity
      *
      * @param int $plainField
      */
-    public function __construct($plainField = null, Embeddable\EmbeddedEntity $embeddedEntity)
+    public function __construct(Embeddable\EmbeddedEntity $embeddedEntity, ?int $plainField = null)
     {
-        $this->plainField = $plainField;
         $this->embeddedEntity = $embeddedEntity;
+        $this->plainField = $plainField;
     }
 
     /**

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -616,7 +616,7 @@ final class ModelManagerTest extends TestCase
 
     public function testAssociationIdentifierType(): void
     {
-        $entity = new ContainerEntity(new AssociatedEntity(42, new EmbeddedEntity()), new EmbeddedEntity());
+        $entity = new ContainerEntity(new AssociatedEntity(new EmbeddedEntity(), 42), new EmbeddedEntity());
 
         $meta = $this->createMock(ClassMetadata::class);
         $meta->expects($this->any())
@@ -743,6 +743,11 @@ final class ModelManagerTest extends TestCase
         }
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testModelReverseTransform(): void
     {
         $class = SimpleEntity::class;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Adds the tag introduced in https://github.com/sonata-project/SonataAdminBundle/pull/6983 to the audit reader.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed triggering deprecation because audit reader is not tagged.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
