### PR TITLE
remove EmptyFilter service

### DIFF
--- a/src/Resources/config/doctrine_orm_filter_types.xml
+++ b/src/Resources/config/doctrine_orm_filter_types.xml
@@ -40,8 +40,5 @@
         <service id="sonata.admin.orm.filter.type.class" class="Sonata\DoctrineORMAdminBundle\Filter\ClassFilter">
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_class"/>
         </service>
-        <service id="Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter">
-            <tag name="sonata.admin.filter.type" alias="doctrine_orm_empty"/>
-        </service>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1375

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

Does it need a changelog? File was removed in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1293

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- removed the deprecated `Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter` service
```

