### PR TITLE
Remove extra argument separator in `sprintf()` calls at `ProxyQuery`

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -159,7 +159,7 @@ class ProxyQuery implements ProxyQueryInterface
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.32'
             .' and will be removed in version 4.0.',
-            __METHOD__,
+            __METHOD__
         ), \E_USER_DEPRECATED);
 
         if (!\is_bool($distinct)) {
@@ -183,7 +183,7 @@ class ProxyQuery implements ProxyQueryInterface
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.32'
             .' and will be removed in version 4.0.',
-            __METHOD__,
+            __METHOD__
         ), \E_USER_DEPRECATED);
 
         return $this->distinct;
@@ -195,7 +195,7 @@ class ProxyQuery implements ProxyQueryInterface
         if (\func_num_args() > 0) {
             @trigger_error(sprintf(
                 'Passing arguments to "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.31.',
-                __METHOD__,
+                __METHOD__
             ), \E_USER_DEPRECATED);
         }
 
@@ -304,7 +304,7 @@ class ProxyQuery implements ProxyQueryInterface
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.31'
             .' and will be removed in version 4.0.',
-            __METHOD__,
+            __METHOD__
         ), \E_USER_DEPRECATED);
 
         $query = $this->queryBuilder->getQuery();
@@ -417,7 +417,7 @@ class ProxyQuery implements ProxyQueryInterface
         @trigger_error(sprintf(
             'The method "%s()" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.31'
             .' and will be removed in version 4.0.',
-            __METHOD__,
+            __METHOD__
         ), \E_USER_DEPRECATED);
 
         $queryBuilderId = clone $queryBuilder;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
