### PR TITLE
Test on different platforms

### DIFF
--- a/.github/workflows/test-platforms.yaml
+++ b/.github/workflows/test-platforms.yaml
@@ -54,7 +54,7 @@ jobs:
               run: make test
 
     test-postgres:
-        name: PHP 8.0 + highest + PostgreSQL
+        name: PHP 8.0 + PostgreSQL + highest
 
         runs-on: ubuntu-latest
 

--- a/.github/workflows/test-platforms.yaml
+++ b/.github/workflows/test-platforms.yaml
@@ -1,0 +1,123 @@
+name: Test on platforms
+
+on:
+    push:
+        branches:
+            - 3.x
+            - master
+    pull_request:
+
+jobs:
+    test-mysql:
+        name: PHP ${{ matrix.php-version }} + MySQL + ${{ matrix.dependencies }} + ${{ matrix.variant }}
+
+        runs-on: ubuntu-latest
+
+        continue-on-error: ${{ matrix.allowed-to-fail }}
+
+        env:
+            DATABASE_URL: "mysql://root@127.0.0.1:3306/sonata_tests"
+
+        strategy:
+            matrix:
+                php-version:
+                    - '8.0'
+                dependencies: [highest]
+                allowed-to-fail: [false]
+                variant: [normal]
+
+        services:
+            mysql:
+                image: "mysql:8.0"
+
+                options: >-
+                    --health-cmd "mysqladmin ping --silent"
+                    -e MYSQL_ALLOW_EMPTY_PASSWORD=yes
+                    -e MYSQL_DATABASE=sonata_tests
+                ports:
+                    - "3306:3306"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Install PHP with extensions
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-version }}
+                  coverage: pcov
+                  tools: composer:v2
+                  extensions: zip, mysqli, pdo_mysql
+
+            - name: Add PHPUnit matcher
+              run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            - name: Install variant
+              if: matrix.variant != 'normal'
+              run: composer require ${{ matrix.variant }} --no-update
+
+            - name: "Install Composer dependencies (${{ matrix.dependencies }})"
+              uses: "ramsey/composer-install@v1"
+              with:
+                  dependency-versions: "${{ matrix.dependencies }}"
+                  composer-options: "--prefer-dist --prefer-stable"
+
+            - name: Run Tests
+              run: make test
+
+    test-postgres:
+        name: PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + Postgres + ${{ matrix.variant }}
+
+        runs-on: ubuntu-latest
+
+        continue-on-error: ${{ matrix.allowed-to-fail }}
+
+        env:
+            DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/postgres?serverVersion=13&charset=utf8"
+
+        strategy:
+            matrix:
+                php-version:
+                    - '8.0'
+                dependencies: [highest]
+                allowed-to-fail: [false]
+                variant: [normal]
+
+        services:
+            postgres:
+                image: "postgres:13"
+                env:
+                    POSTGRES_PASSWORD: "postgres"
+
+                options: >-
+                    --health-cmd "pg_isready"
+                ports:
+                    - "5432:5432"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Install PHP with extensions
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-version }}
+                  coverage: pcov
+                  tools: composer:v2
+                  extensions: zip
+
+            - name: Add PHPUnit matcher
+              run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            - name: Install variant
+              if: matrix.variant != 'normal'
+              run: composer require ${{ matrix.variant }} --no-update
+
+            - name: "Install Composer dependencies (${{ matrix.dependencies }})"
+              uses: "ramsey/composer-install@v1"
+              with:
+                  dependency-versions: "${{ matrix.dependencies }}"
+                  composer-options: "--prefer-dist --prefer-stable"
+
+            - name: Run Tests
+              run: make test

--- a/.github/workflows/test-platforms.yaml
+++ b/.github/workflows/test-platforms.yaml
@@ -9,22 +9,14 @@ on:
 
 jobs:
     test-mysql:
-        name: PHP ${{ matrix.php-version }} + MySQL + ${{ matrix.dependencies }} + ${{ matrix.variant }}
+        name: PHP 8.0 + MySQL + highest
 
         runs-on: ubuntu-latest
 
-        continue-on-error: ${{ matrix.allowed-to-fail }}
+        continue-on-error: false
 
         env:
             DATABASE_URL: "mysql://root@127.0.0.1:3306/sonata_tests"
-
-        strategy:
-            matrix:
-                php-version:
-                    - '8.0'
-                dependencies: [highest]
-                allowed-to-fail: [false]
-                variant: [normal]
 
         services:
             mysql:
@@ -44,7 +36,7 @@ jobs:
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.php-version }}
+                  php-version: 8.0
                   coverage: pcov
                   tools: composer:v2
                   extensions: zip, mysqli, pdo_mysql
@@ -52,36 +44,24 @@ jobs:
             - name: Add PHPUnit matcher
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            - name: Install variant
-              if: matrix.variant != 'normal'
-              run: composer require ${{ matrix.variant }} --no-update
-
-            - name: "Install Composer dependencies (${{ matrix.dependencies }})"
+            - name: "Install Composer dependencies (highest)"
               uses: "ramsey/composer-install@v1"
               with:
-                  dependency-versions: "${{ matrix.dependencies }}"
+                  dependency-versions: "highest"
                   composer-options: "--prefer-dist --prefer-stable"
 
             - name: Run Tests
               run: make test
 
     test-postgres:
-        name: PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + Postgres + ${{ matrix.variant }}
+        name: PHP 8.0 + highest + Postgres
 
         runs-on: ubuntu-latest
 
-        continue-on-error: ${{ matrix.allowed-to-fail }}
+        continue-on-error: false
 
         env:
             DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/postgres?serverVersion=13&charset=utf8"
-
-        strategy:
-            matrix:
-                php-version:
-                    - '8.0'
-                dependencies: [highest]
-                allowed-to-fail: [false]
-                variant: [normal]
 
         services:
             postgres:
@@ -101,7 +81,7 @@ jobs:
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.php-version }}
+                  php-version: 8.0
                   coverage: pcov
                   tools: composer:v2
                   extensions: zip
@@ -109,14 +89,10 @@ jobs:
             - name: Add PHPUnit matcher
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            - name: Install variant
-              if: matrix.variant != 'normal'
-              run: composer require ${{ matrix.variant }} --no-update
-
-            - name: "Install Composer dependencies (${{ matrix.dependencies }})"
+            - name: "Install Composer dependencies (highest)"
               uses: "ramsey/composer-install@v1"
               with:
-                  dependency-versions: "${{ matrix.dependencies }}"
+                  dependency-versions: "highest"
                   composer-options: "--prefer-dist --prefer-stable"
 
             - name: Run Tests

--- a/.github/workflows/test-platforms.yaml
+++ b/.github/workflows/test-platforms.yaml
@@ -54,7 +54,7 @@ jobs:
               run: make test
 
     test-postgres:
-        name: PHP 8.0 + highest + Postgres
+        name: PHP 8.0 + highest + PostgreSQL
 
         runs-on: ubuntu-latest
 

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -15,10 +15,12 @@ twig:
     exception_controller: null
     strict_variables: false
 
+parameters:
+    env(DATABASE_URL): 'sqlite:////%kernel.cache_dir%/test_database.db'
+
 doctrine:
     dbal:
-        driver: pdo_sqlite
-        path: "%kernel.cache_dir%/test_database.db"
+        url: "%env(resolve:DATABASE_URL)%"
     orm:
         auto_generate_proxy_classes: true
         auto_mapping: true


### PR DESCRIPTION
This is just copy-pasting the job we have and execute it for `MySQL` and `Postgres`. I created another file so I guess there is no need to modify `dev-kit`. 

We could maybe test just with one variant and do not test lower versions.

Ref: https://github.com/sonata-project/dev-kit/issues/1477