### PR TITLE
Use "BINARY()" DQL function for case sensitive MySQL pattern matching in `StringFilter::filter()`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,22 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Sonata\DoctrineORMAdminBundle\Filter\StringFilter
+
+* Omitting or not passing an instance of `Doctrine\ORM\EntityManagerInterface` as argument 1 to `StringFilter::__construct()`
+  is deprecated.
+
+* The default value for the "case_sensitive" option is changed from `true` to `null`, keeping the behavior of its previous value.
+
+* In order to perform real case sensitive comparisons along the MySQL platform, the `BINARY()` function
+  will be used when "case_sensitive" option is set to `true` and the [`DoctrineExtensions\Query\Mysql\Binary`](https://github.com/beberlei/DoctrineExtensions#doctrineextensions)
+  DQL extension is registered using the name "binary". This behavior requires the package "beberlei/doctrineextensions".
+  If you want to keep the previous behavior, you can use `null` as value for the "case_sensitive" option.
+  For more information, see https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like.
+
 UPGRADE FROM 3.31 to 3.32
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"
     },
     "require-dev": {
+        "beberlei/doctrineextensions": "^1.3",
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.52",
@@ -68,6 +69,7 @@
         "vimeo/psalm": "^4.1.1"
     },
     "suggest": {
+        "beberlei/doctrineextensions": "If you need case sensitive comparisons using MySQL.",
         "sonata-project/entity-audit-bundle": "If you want to support for versioning of entities and their associations."
     },
     "config": {

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -73,9 +73,17 @@ StringFilter
 
 The string filter has additional options:
 
-* ``case_sensitive`` - set to ``false`` to make the search case insensitive. By default ``true`` is used;
+* ``case_sensitive`` - set to ``false`` to make the search case insensitive. By default ``null`` is used;
 * ``trim`` - use one of ``Sonata\DoctrineORMAdminBundle\Filter\TRIM_*`` constants to control the clearing of blank spaces around in the value. By default ``Sonata\DoctrineORMAdminBundle\Filter\TRIM_BOTH`` is used;
 * ``allow_empty`` - set to ``true`` to enable search by empty value. By default ``false`` is used.
+
+.. versionadded:: 3.x
+
+    In order to perform real case sensitive comparisons along the MySQL platform, the ``BINARY()`` function
+    will be used when "case_sensitive" option is set to ``true`` and the `DoctrineExtensions\Query\Mysql\Binary <https://github.com/beberlei/DoctrineExtensions#doctrineextensions>`_
+    DQL extension is registered using the name "binary". This behavior requires the package "beberlei/doctrineextensions".
+    If you want to keep the previous behavior, you can use ``null`` as value for the ``case_sensitive`` option.
+    For more information, see https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like.
 
 StringListFilter
 ----------------

--- a/src/Resources/config/doctrine_orm_filter_types.xml
+++ b/src/Resources/config/doctrine_orm_filter_types.xml
@@ -41,6 +41,12 @@
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_number"/>
         </service>
         <service id="sonata.admin.orm.filter.type.string" class="Sonata\DoctrineORMAdminBundle\Filter\StringFilter">
+            <argument type="service">
+                <service class="Doctrine\ORM\EntityManager">
+                    <factory service="doctrine" method="getManager"/>
+                    <argument>%sonata_doctrine_orm_admin.entity_manager%</argument>
+                </service>
+            </argument>
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_string"/>
         </service>
         <service id="sonata.admin.orm.filter.type.string_list" class="Sonata\DoctrineORMAdminBundle\Filter\StringListFilter">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Use "BINARY()" DQL function for case sensitive MySQL pattern matching in `StringFilter::filter()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1387.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Call to `BINARY()` (`DoctrineExtensions\Query\Mysql\Binary`) DQL function for MySQL pattern matching when it is available and "case_sensitive" option is set to `true` in `StringFilter::filter()`.

### Changed
- Default value for the "case_sensitive" option from `true` to `null` in `StringFilter`.

### Fixed
- Respecting "case_sensitive" when it is set to `true` along MySQL columns using other collations than "utf8mb4_0900_as_cs" or "utf8mb4_bin".

### Deprecated
- Omitting or not passing an instance of `Doctrine\ORM\EntityManagerInterface` as argument 1 to `StringFilter::__construct()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Update the tests;
- [x] Update the documentation;
- [x] Add an upgrade note;
- [x] Determine if we must deprecate something;
- [x] Check if we can / should configure the DQL function automatically.

