### PR TITLE
Make property public

### DIFF
--- a/tests/App/Admin/SubAdmin.php
+++ b/tests/App/Admin/SubAdmin.php
@@ -21,7 +21,7 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
  */
 final class SubAdmin extends AbstractAdmin
 {
-    protected function configureListFields(ListMapper $list)
+    protected function configureListFields(ListMapper $list): void
     {
         $list->addIdentifier('id');
         $list->add('otherField');

--- a/tests/App/Entity/Sub.php
+++ b/tests/App/Entity/Sub.php
@@ -25,5 +25,5 @@ class Sub extends Base
      *
      * @var string
      */
-    private $otherField = 'HELLO WORLD';
+    public $otherField = 'HELLO WORLD';
 }


### PR DESCRIPTION
Tests failed [when merging with `master`](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1400) because `SubAdmin` is listing `$list->add('otherField');` and `otherField` is private.

In `3.x` it shows a blank space, but in `4.x` will throw an exception, in tests it showed:

```
32x: Accessing a non existing value for the field "otherField" is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
    32x in EntityInheritanceTest::testList from Sonata\DoctrineORMAdminBundle\Tests\Functional
```