### PR TITLE
Fix Revision instantiation

### DIFF
--- a/tests/Block/AuditBlockServiceTest.php
+++ b/tests/Block/AuditBlockServiceTest.php
@@ -58,7 +58,7 @@ class AuditBlockServiceTest extends BlockServiceTestCase
             ->expects($this->once())
             ->method('findRevisionHistory')
             ->with($limit, 0)
-            ->willReturn([$revision = new Revision('test', '123', 'test')]);
+            ->willReturn([$revision = new Revision('test', new \DateTime(), 'test')]);
 
         $this->simpleThingsAuditReader
             ->expects($this->once())


### PR DESCRIPTION
It fails because of https://github.com/sonata-project/EntityAuditBundle/pull/382, this PR fixes the fail, but I guess we introduced a BC break adding those type declarations.