### PR TITLE
Fix return type for `ModelManager::getModelIdentifier()`

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -439,7 +439,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     public function getModelIdentifier($class)
     {
         // NEXT_MAJOR: Remove `sonata_deprecation_mute`.
-        return $this->getMetadata($class, 'sonata_deprecation_mute')->identifier;
+        return implode(',', $this->getMetadata($class, 'sonata_deprecation_mute')->identifier);
     }
 
     public function getIdentifierValues($entity)
@@ -765,7 +765,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
 
         return [
             '_sort_order' => 'ASC',
-            '_sort_by' => implode(',', $this->getModelIdentifier($class)),
+            '_sort_by' => $this->getModelIdentifier($class),
             '_page' => 1,
             '_per_page' => 25,
         ];

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -439,7 +439,7 @@ class ModelManager implements ModelManagerInterface, LockInterface
     public function getModelIdentifier($class)
     {
         // NEXT_MAJOR: Remove `sonata_deprecation_mute`.
-        return implode(',', $this->getMetadata($class, 'sonata_deprecation_mute')->identifier);
+        return implode(self::ID_SEPARATOR, $this->getMetadata($class, 'sonata_deprecation_mute')->identifier);
     }
 
     public function getIdentifierValues($entity)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix return type for `ModelManager::getModelIdentifier()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are fixing what the [`ModelManagerInterface`](https://github.com/sonata-project/SonataAdminBundle/blob/627e79d2dd24bf77ffd3f33865b7dab007199389/src/Model/ModelManagerInterface.php#L136-L149) declares.

Additionally, the character "," was replaced with `ModelManager::ID_SEPARATOR` in the call to `implode()`, as that seems to be the proper character if you see other methods:
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/6238cbe02103edb66b3a02750920405626fbd5a1/src/Model/ModelManager.php#L333
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/6238cbe02103edb66b3a02750920405626fbd5a1/src/Model/ModelManager.php#L521
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/6238cbe02103edb66b3a02750920405626fbd5a1/src/Model/ModelManager.php#L576

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Return type for `ModelManager::getModelIdentifier()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
