### PR TITLE
Introduce "force_case_insensitivity" option and deprecate "case_sensitive" in `StringFilter`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,22 +1,6 @@
 UPGRADE 3.x
 ===========
 
-UPGRADE FROM 3.x to 3.x
-=======================
-
-### Sonata\DoctrineORMAdminBundle\Filter\StringFilter
-
-* Omitting or not passing an instance of `Doctrine\ORM\EntityManagerInterface` as argument 1 to `StringFilter::__construct()`
-  is deprecated.
-
-* The default value for the "case_sensitive" option is changed from `true` to `null`, keeping the behavior of its previous value.
-
-* In order to perform real case sensitive comparisons along the MySQL platform, the `BINARY()` function
-  will be used when "case_sensitive" option is set to `true` and the [`DoctrineExtensions\Query\Mysql\Binary`](https://github.com/beberlei/DoctrineExtensions#doctrineextensions)
-  DQL extension is registered using the name "binary". This behavior requires the package "beberlei/doctrineextensions".
-  If you want to keep the previous behavior, you can use `null` as value for the "case_sensitive" option.
-  For more information, see https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like.
-
 UPGRADE FROM 3.31 to 3.32
 =========================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,18 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Sonata\DoctrineORMAdminBundle\Filter\StringFilter
+
+The option "case_sensitive" is deprecated in favor of "force_case_insensitivity".
+You must pass `true` in this option when you need to force the matching criteria
+to avoid honoring the case sensitivity in the filter values. Any other values than
+`true` will cause the database to use its default behavior.
+The option "case_sensitive" will be respected only if "force_case_insensitivity"
+is not set.
+
 UPGRADE FROM 3.31 to 3.32
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,6 @@
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"
     },
     "require-dev": {
-        "beberlei/doctrineextensions": "^1.3",
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.52",
@@ -70,7 +69,6 @@
         "vimeo/psalm": "^4.1.1"
     },
     "suggest": {
-        "beberlei/doctrineextensions": "If you need case sensitive comparisons using MySQL.",
         "sonata-project/entity-audit-bundle": "If you want to support for versioning of entities and their associations."
     },
     "config": {

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -73,7 +73,8 @@ StringFilter
 
 The string filter has additional options:
 
-* ``case_sensitive`` - set to ``false`` to make the search case insensitive. By default ``true`` is used;
+* ``force_case_insensitivity`` - set to ``true`` to make the search case insensitive. By default ``false`` is used,
+  letting the database to apply its default behavior;
 * ``trim`` - use one of ``Sonata\DoctrineORMAdminBundle\Filter\TRIM_*`` constants to control the clearing of blank spaces around in the value. By default ``Sonata\DoctrineORMAdminBundle\Filter\TRIM_BOTH`` is used;
 * ``allow_empty`` - set to ``true`` to enable search by empty value. By default ``false`` is used.
 

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -73,17 +73,9 @@ StringFilter
 
 The string filter has additional options:
 
-* ``case_sensitive`` - set to ``false`` to make the search case insensitive. By default ``null`` is used;
+* ``case_sensitive`` - set to ``false`` to make the search case insensitive. By default ``true`` is used;
 * ``trim`` - use one of ``Sonata\DoctrineORMAdminBundle\Filter\TRIM_*`` constants to control the clearing of blank spaces around in the value. By default ``Sonata\DoctrineORMAdminBundle\Filter\TRIM_BOTH`` is used;
 * ``allow_empty`` - set to ``true`` to enable search by empty value. By default ``false`` is used.
-
-.. versionadded:: 3.x
-
-    In order to perform real case sensitive comparisons along the MySQL platform, the ``BINARY()`` function
-    will be used when "case_sensitive" option is set to ``true`` and the `DoctrineExtensions\Query\Mysql\Binary <https://github.com/beberlei/DoctrineExtensions#doctrineextensions>`_
-    DQL extension is registered using the name "binary". This behavior requires the package "beberlei/doctrineextensions".
-    If you want to keep the previous behavior, you can use ``null`` as value for the ``case_sensitive`` option.
-    For more information, see https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like.
 
 StringListFilter
 ----------------

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -87,13 +87,30 @@ class StringFilter extends Filter
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($query);
 
-        $or = $query->getQueryBuilder()->expr()->orX();
+        $forceCaseInsensitivity = true === $this->getOption('force_case_insensitivity', false);
 
-        if ($this->getOption('case_sensitive')) {
-            $or->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
-        } else {
-            $or->add(sprintf('LOWER(%s.%s) %s :%s', $alias, $field, $operator, $parameterName));
+        // NEXT_MAJOR: Remove the following condition and its body.
+        if (null !== $this->getOption('case_sensitive')) {
+            @trigger_error(
+                'Option "case_sensitive" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x'
+                .' and will be removed in version 4.x. Use the "force_case_insensitivity" option instead.',
+                \E_USER_DEPRECATED
+            );
+
+            if (null === $this->getOption('force_case_insensitivity')) {
+                $forceCaseInsensitivity = false === $this->getOption('case_sensitive', true);
+            }
         }
+
+        if ($forceCaseInsensitivity && '' !== $data['value']) {
+            $clause = 'LOWER(%s.%s) %s :%s';
+        } else {
+            $clause = '%s.%s %s :%s';
+        }
+
+        $or = $query->getQueryBuilder()->expr()->orX(
+            sprintf($clause, $alias, $field, $operator, $parameterName)
+        );
 
         if (StringOperatorType::TYPE_NOT_CONTAINS === $type || StringOperatorType::TYPE_NOT_EQUAL === $type) {
             $or->add($query->getQueryBuilder()->expr()->isNull(sprintf('%s.%s', $alias, $field)));
@@ -129,7 +146,7 @@ class StringFilter extends Filter
             $parameterName,
             sprintf(
                 $format,
-                $this->getOption('case_sensitive') ? $data['value'] : mb_strtolower($data['value'])
+                true !== $forceCaseInsensitivity || '' === $data['value'] ? $data['value'] : mb_strtolower($data['value'])
             )
         );
     }
@@ -137,9 +154,12 @@ class StringFilter extends Filter
     public function getDefaultOptions()
     {
         return [
-            // NEXT_MAJOR: Remove the format option.
+            // NEXT_MAJOR: Remove the "format" option.
             'format' => '%%%s%%',
-            'case_sensitive' => true,
+            // NEXT_MAJOR: Remove the "case_sensitive" option.
+            'case_sensitive' => null,
+            // NEXT_MAJOR: Use `false` as default value for the "force_case_insensitivity" option.
+            'force_case_insensitivity' => null,
             'trim' => self::TRIM_BOTH,
             'allow_empty' => false,
         ];

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
-use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManagerInterface;
-use DoctrineExtensions\Query\Mysql\Binary;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\AdminBundle\Form\Type\Operator\StringOperatorType;
@@ -49,29 +46,6 @@ class StringFilter extends Filter
         StringOperatorType::TYPE_ENDS_WITH,
         StringOperatorType::TYPE_NOT_CONTAINS,
     ];
-
-    /**
-     * @var Configuration|null
-     */
-    private $doctrineConfig;
-
-    /**
-     * NEXT_MAJOR: Do not accept null value in argument 1.
-     */
-    public function __construct(?EntityManagerInterface $em = null)
-    {
-        if (null === $em) {
-            @trigger_error(sprintf(
-                'Omitting or passing other type than "%s" as argument 1 to "%s()" is deprecated since'
-                .' sonata-project/doctrine-orm-admin-bundle 3.x and will be not allowed in version 4.0.',
-                EntityManagerInterface::class,
-                __METHOD__
-            ), \E_USER_DEPRECATED);
-        }
-        $this->doctrineConfig = $em ? $em->getConfiguration() : null;
-        // NEXT_MAJOR: Replace the previous line with the following one.
-        // $this->doctrineConfig = $em->getConfiguration();
-    }
 
     public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
@@ -113,23 +87,13 @@ class StringFilter extends Filter
         // c.name > '1' => c.name OPERATOR :FIELDNAME
         $parameterName = $this->getNewParameterName($query);
 
-        $caseSensitive = $this->getOption('case_sensitive');
+        $or = $query->getQueryBuilder()->expr()->orX();
 
-        if (false === $caseSensitive && '' !== $data['value']) {
-            $clause = 'LOWER(%s.%s) %s :%s';
-        } elseif (true === $caseSensitive && '' !== $data['value'] && null !== $this->doctrineConfig
-            && Binary::class === $this->doctrineConfig->getCustomStringFunction('binary')
-        ) {
-            // NEXT_MAJOR: Remove the type check against `$this->doctrineConfig` in the `elseif` condition.
-            // @see https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like.
-            $clause = '%s.%s %s BINARY(:%s)';
+        if ($this->getOption('case_sensitive')) {
+            $or->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
         } else {
-            $clause = '%s.%s %s :%s';
+            $or->add(sprintf('LOWER(%s.%s) %s :%s', $alias, $field, $operator, $parameterName));
         }
-
-        $or = $query->getQueryBuilder()->expr()->orX(
-            sprintf($clause, $alias, $field, $operator, $parameterName)
-        );
 
         if (StringOperatorType::TYPE_NOT_CONTAINS === $type || StringOperatorType::TYPE_NOT_EQUAL === $type) {
             $or->add($query->getQueryBuilder()->expr()->isNull(sprintf('%s.%s', $alias, $field)));
@@ -165,7 +129,7 @@ class StringFilter extends Filter
             $parameterName,
             sprintf(
                 $format,
-                false !== $caseSensitive || '' === $data['value'] ? $data['value'] : mb_strtolower($data['value'])
+                $this->getOption('case_sensitive') ? $data['value'] : mb_strtolower($data['value'])
             )
         );
     }
@@ -175,7 +139,7 @@ class StringFilter extends Filter
         return [
             // NEXT_MAJOR: Remove the format option.
             'format' => '%%%s%%',
-            'case_sensitive' => null,
+            'case_sensitive' => true,
             'trim' => self::TRIM_BOTH,
             'allow_empty' => false,
         ];

--- a/src/Resources/config/doctrine_orm_filter_types.xml
+++ b/src/Resources/config/doctrine_orm_filter_types.xml
@@ -41,12 +41,6 @@
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_number"/>
         </service>
         <service id="sonata.admin.orm.filter.type.string" class="Sonata\DoctrineORMAdminBundle\Filter\StringFilter">
-            <argument type="service">
-                <service class="Doctrine\ORM\EntityManager">
-                    <factory service="doctrine" method="getManager"/>
-                    <argument>%sonata_doctrine_orm_admin.entity_manager%</argument>
-                </service>
-            </argument>
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_string"/>
         </service>
         <service id="sonata.admin.orm.filter.type.string_list" class="Sonata\DoctrineORMAdminBundle\Filter\StringListFilter">

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
-use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -99,7 +98,8 @@ final class FilterTest extends FilterTestCase
 
         $proxyQuery = new ProxyQuery($queryBuilder);
 
-        foreach ($filterOptionsCollection as [$filter, $orGroup, $defaultOptions, $field, $options]) {
+        foreach ($filterOptionsCollection as [$type, $orGroup, $defaultOptions, $field, $options]) {
+            $filter = new $type();
             $filter->initialize($field, $defaultOptions);
             $filter->setCondition(Filter::CONDITION_OR);
             if (null !== $orGroup) {
@@ -117,21 +117,12 @@ final class FilterTest extends FilterTestCase
 
     public function orExpressionProvider(): iterable
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createStub(EntityManagerInterface::class);
-        $em->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
         yield 'Using "or_group" option' => [
             'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
             .' AND (e.project LIKE :project_0 OR e.version LIKE :version_1) AND 7 = 8',
             [
                 [
-                    new StringFilter($em),
+                    StringFilter::class,
                     'my_admin',
                     [
                         'field_name' => 'project',
@@ -143,7 +134,7 @@ final class FilterTest extends FilterTestCase
                     ],
                 ],
                 [
-                    new StringFilter($em),
+                    StringFilter::class,
                     'my_admin',
                     [
                         'field_name' => 'version',
@@ -162,7 +153,7 @@ final class FilterTest extends FilterTestCase
             .' AND e.project LIKE :project_0 AND 7 = 8',
             [
                 [
-                    new StringFilter($em),
+                    StringFilter::class,
                     'my_admin',
                     [
                         'field_name' => 'project',
@@ -182,7 +173,7 @@ final class FilterTest extends FilterTestCase
             .' OR e.project LIKE :project_0 OR e.version LIKE :version_1) AND 7 = 8',
             [
                 [
-                    new StringFilter($em),
+                    StringFilter::class,
                     null,
                     [
                         'field_name' => 'project',
@@ -194,7 +185,7 @@ final class FilterTest extends FilterTestCase
                     ],
                 ],
                 [
-                    new StringFilter($em),
+                    StringFilter::class,
                     null,
                     [
                         'field_name' => 'version',

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
-use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManagerInterface;
-use DoctrineExtensions\Query\Mysql\Binary;
 use Sonata\AdminBundle\Form\Type\Operator\StringOperatorType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
@@ -24,18 +21,7 @@ class StringFilterTest extends FilterTestCase
 {
     public function testEmpty(): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->expects($this->never())
-            ->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(Binary::class);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
@@ -46,102 +32,6 @@ class StringFilterTest extends FilterTestCase
 
         $this->assertSameQuery([], $proxyQuery);
         $this->assertFalse($filter->isActive());
-    }
-
-    public function getValuesForDefaultType(): iterable
-    {
-        yield 'filter by normal value' => [['WHERE alias.field LIKE :field_name_0'], 'asd', false];
-        yield 'filter by normal value without "case_sensitive" option' => [
-            ['WHERE alias.field LIKE :field_name_0'],
-            'asd',
-            false,
-            [],
-            ['binary' => Binary::class],
-        ];
-        yield 'filter by normal value using `null` at "case_sensitive" option' => [
-            ['WHERE alias.field LIKE :field_name_0'],
-            'asd',
-            false,
-            ['case_sensitive' => null],
-            ['binary' => Binary::class],
-        ];
-        yield 'filter by normal value using `false` at "case_sensitive" option' => [
-            ['WHERE LOWER(alias.field) LIKE :field_name_0'],
-            'asd',
-            false,
-            ['case_sensitive' => false],
-            ['binary' => Binary::class],
-        ];
-        yield 'filter by normal value using `true` at "case_sensitive" option' => [
-            ['WHERE alias.field LIKE BINARY(:field_name_0)'],
-            'asd',
-            false,
-            ['case_sensitive' => true],
-            ['binary' => Binary::class],
-        ];
-        yield 'filter by normal value using `true` at "case_sensitive" option and wrong filter name' => [
-            ['WHERE alias.field LIKE :field_name_0'],
-            'asd',
-            false,
-            ['case_sensitive' => true],
-            ['binary_extension' => Binary::class],
-        ];
-        yield 'filter by normal value using `true` at "case_sensitive" option and wrong filter value' => [
-            ['WHERE alias.field LIKE :field_name_0'],
-            'asd',
-            false,
-            ['case_sensitive' => true],
-            ['binary' => \stdClass::class],
-        ];
-        yield 'not filter by empty string' => [[], '', false];
-        yield 'filter by empty string' => [[], '', true];
-        yield 'not filter by null' => [[], null, false];
-        yield 'filter by null' => [[], null, true];
-        yield 'not filter by 0' => [['WHERE alias.field LIKE :field_name_0'], 0, false];
-        yield 'not filter by 0 with BINARY() function' => [
-            ['WHERE alias.field LIKE BINARY(:field_name_0)'],
-            0,
-            false,
-            ['case_sensitive' => true],
-            ['binary' => Binary::class],
-        ];
-        yield 'filter by 0' => [['WHERE alias.field LIKE :field_name_0'], 0, true];
-        yield 'not filter by \'0\'' => [['WHERE alias.field LIKE :field_name_0'], '0', false];
-        yield 'filter by \'0\'' => [['WHERE alias.field LIKE :field_name_0'], '0', true];
-    }
-
-    /**
-     * @dataProvider getValuesForDefaultType
-     */
-    public function testDefaultType(array $expected, $value, bool $allowEmpty, array $options = [], array $dqlExtensions = []): void
-    {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->expects($this->exactly(!($options['case_sensitive'] ?? null) || '' === (string) $value ? 0 : 1))
-            ->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn($dqlExtensions['binary'] ?? null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
-        $filter->initialize('field_name', ['allow_empty' => $allowEmpty] + $options);
-
-        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
-
-        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => null]);
-
-        $this->assertSameQuery($expected, $proxyQuery);
-
-        if ('' !== (string) $value) {
-            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value)], $proxyQuery);
-            $this->assertTrue($filter->isActive());
-        } else {
-            $this->assertFalse($filter->isActive());
-        }
     }
 
     public function getValues(): iterable
@@ -162,19 +52,32 @@ class StringFilterTest extends FilterTestCase
     /**
      * @dataProvider getValues
      */
+    public function testDefaultType($value, bool $allowEmpty): void
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
+
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
+
+        $filter->filter($proxyQuery, 'alias', 'field', ['value' => $value, 'type' => null]);
+
+        if ('' !== (string) $value) {
+            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value)], $proxyQuery);
+            $this->assertTrue($filter->isActive());
+        } else {
+            $this->assertSameQuery([], $proxyQuery);
+            $this->assertFalse($filter->isActive());
+        }
+    }
+
+    /**
+     * @dataProvider getValues
+     */
     public function testContains($value, bool $allowEmpty): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
@@ -197,17 +100,7 @@ class StringFilterTest extends FilterTestCase
      */
     public function testStartsWith($value, bool $allowEmpty): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
@@ -230,17 +123,7 @@ class StringFilterTest extends FilterTestCase
      */
     public function testEndsWith($value, bool $allowEmpty): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
@@ -263,17 +146,7 @@ class StringFilterTest extends FilterTestCase
      */
     public function testNotContains($value, bool $allowEmpty): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
@@ -296,17 +169,7 @@ class StringFilterTest extends FilterTestCase
      */
     public function testEquals($value, bool $allowEmpty): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
@@ -329,17 +192,7 @@ class StringFilterTest extends FilterTestCase
      */
     public function testNotEquals($value, bool $allowEmpty): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
@@ -359,17 +212,7 @@ class StringFilterTest extends FilterTestCase
 
     public function testEqualsWithValidParentAssociationMappings(): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', [
             'field_name' => 'field_name',
             'parent_association_mappings' => [
@@ -403,20 +246,9 @@ class StringFilterTest extends FilterTestCase
     /**
      * @dataProvider caseSensitiveDataProvider
      */
-    public function testCaseSensitive(?bool $caseSensitive, int $operatorType, string $expectedQuery, string $expectedParameter, array $dqlExtensions = []): void
+    public function testCaseSensitive(bool $caseSensitive, int $operatorType, string $expectedQuery, string $expectedParameter): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->expects($caseSensitive ? $this->once() : $this->never())
-            ->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn($dqlExtensions['binary'] ?? null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['case_sensitive' => $caseSensitive]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
@@ -428,10 +260,9 @@ class StringFilterTest extends FilterTestCase
         $this->assertTrue($filter->isActive());
     }
 
-    public function caseSensitiveDataProvider(): iterable
+    public function caseSensitiveDataProvider(): array
     {
         return [
-            [false, StringOperatorType::TYPE_CONTAINS, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar%', ['binary' => Binary::class]],
             [false, StringOperatorType::TYPE_CONTAINS, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar%'],
             [false, StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE LOWER(alias.field) NOT LIKE :field_name_0 OR alias.field IS NULL', '%foobar%'],
             [false, StringOperatorType::TYPE_EQUAL, 'WHERE LOWER(alias.field) = :field_name_0', 'foobar'],
@@ -439,16 +270,9 @@ class StringFilterTest extends FilterTestCase
             [false, StringOperatorType::TYPE_STARTS_WITH, 'WHERE LOWER(alias.field) LIKE :field_name_0', 'foobar%'],
             [false, StringOperatorType::TYPE_ENDS_WITH, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar'],
             [true, StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'],
-            [true, StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE BINARY(:field_name_0)', '%FooBar%', ['binary' => Binary::class]],
             [true, StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL', '%FooBar%'],
-            [true, StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE alias.field NOT LIKE BINARY(:field_name_0) OR alias.field IS NULL', '%FooBar%', ['binary' => Binary::class]],
             [true, StringOperatorType::TYPE_EQUAL, 'WHERE alias.field = :field_name_0', 'FooBar'],
             [true, StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> :field_name_0 OR alias.field IS NULL', 'FooBar'],
-            [null, StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> :field_name_0 OR alias.field IS NULL', 'FooBar'],
-            [null, StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> :field_name_0 OR alias.field IS NULL', 'FooBar', ['binary' => Binary::class]],
-            [true, StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> BINARY(:field_name_0) OR alias.field IS NULL', 'FooBar', ['binary' => Binary::class]],
-            [true, StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> :field_name_0 OR alias.field IS NULL', 'FooBar', ['binary' => \stdClass::class]],
-            [true, StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> :field_name_0 OR alias.field IS NULL', 'FooBar', ['binary_extension' => Binary::class]],
             [true, StringOperatorType::TYPE_STARTS_WITH, 'WHERE alias.field LIKE :field_name_0', 'FooBar%'],
             [true, StringOperatorType::TYPE_ENDS_WITH, 'WHERE alias.field LIKE :field_name_0', '%FooBar'],
         ];
@@ -463,17 +287,7 @@ class StringFilterTest extends FilterTestCase
      */
     public function testFormatOption(): void
     {
-        $doctrineConfig = $this->createMock(Configuration::class);
-        $doctrineConfig->method('getCustomStringFunction')
-            ->with('binary')
-            ->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->once())
-            ->method('getConfiguration')
-            ->willReturn($doctrineConfig);
-
-        $filter = new StringFilter($em);
+        $filter = new StringFilter();
         $filter->initialize('field_name', ['format' => '%s']);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -244,12 +244,18 @@ class StringFilterTest extends FilterTestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove the "legacy" group annotation.
+     *
+     * @group legacy
+     *
      * @dataProvider caseSensitiveDataProvider
+     *
+     * @param array<string, mixed> $options
      */
-    public function testCaseSensitive(bool $caseSensitive, int $operatorType, string $expectedQuery, string $expectedParameter): void
+    public function testCaseSensitive(array $options, int $operatorType, string $expectedQuery, string $expectedParameter): void
     {
         $filter = new StringFilter();
-        $filter->initialize('field_name', ['case_sensitive' => $caseSensitive]);
+        $filter->initialize('field_name', $options);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
         $this->assertSameQuery([], $proxyQuery);
@@ -260,22 +266,42 @@ class StringFilterTest extends FilterTestCase
         $this->assertTrue($filter->isActive());
     }
 
-    public function caseSensitiveDataProvider(): array
+    public function caseSensitiveDataProvider(): iterable
     {
-        return [
-            [false, StringOperatorType::TYPE_CONTAINS, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar%'],
-            [false, StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE LOWER(alias.field) NOT LIKE :field_name_0 OR alias.field IS NULL', '%foobar%'],
-            [false, StringOperatorType::TYPE_EQUAL, 'WHERE LOWER(alias.field) = :field_name_0', 'foobar'],
-            [false, StringOperatorType::TYPE_NOT_EQUAL, 'WHERE LOWER(alias.field) <> :field_name_0 OR alias.field IS NULL', 'foobar'],
-            [false, StringOperatorType::TYPE_STARTS_WITH, 'WHERE LOWER(alias.field) LIKE :field_name_0', 'foobar%'],
-            [false, StringOperatorType::TYPE_ENDS_WITH, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar'],
-            [true, StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'],
-            [true, StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL', '%FooBar%'],
-            [true, StringOperatorType::TYPE_EQUAL, 'WHERE alias.field = :field_name_0', 'FooBar'],
-            [true, StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> :field_name_0 OR alias.field IS NULL', 'FooBar'],
-            [true, StringOperatorType::TYPE_STARTS_WITH, 'WHERE alias.field LIKE :field_name_0', 'FooBar%'],
-            [true, StringOperatorType::TYPE_ENDS_WITH, 'WHERE alias.field LIKE :field_name_0', '%FooBar'],
-        ];
+        yield [[], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
+        yield [['force_case_insensitivity' => null], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
+        yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
+        yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL', '%FooBar%'];
+        yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_EQUAL, 'WHERE alias.field = :field_name_0', 'FooBar'];
+        yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> :field_name_0 OR alias.field IS NULL', 'FooBar'];
+        yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_STARTS_WITH, 'WHERE alias.field LIKE :field_name_0', 'FooBar%'];
+        yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_ENDS_WITH, 'WHERE alias.field LIKE :field_name_0', '%FooBar'];
+        yield [['force_case_insensitivity' => true], StringOperatorType::TYPE_CONTAINS, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar%'];
+        yield [['force_case_insensitivity' => true], StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE LOWER(alias.field) NOT LIKE :field_name_0 OR alias.field IS NULL', '%foobar%'];
+        yield [['force_case_insensitivity' => true], StringOperatorType::TYPE_EQUAL, 'WHERE LOWER(alias.field) = :field_name_0', 'foobar'];
+        yield [['force_case_insensitivity' => true], StringOperatorType::TYPE_NOT_EQUAL, 'WHERE LOWER(alias.field) <> :field_name_0 OR alias.field IS NULL', 'foobar'];
+        yield [['force_case_insensitivity' => true], StringOperatorType::TYPE_STARTS_WITH, 'WHERE LOWER(alias.field) LIKE :field_name_0', 'foobar%'];
+        yield [['force_case_insensitivity' => true], StringOperatorType::TYPE_ENDS_WITH, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar'];
+
+        // NEXT_MAJOR: Remove the following test cases.
+        yield [['force_case_insensitivity' => null, 'case_sensitive' => null], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
+        yield [['force_case_insensitivity' => null, 'case_sensitive' => false], StringOperatorType::TYPE_CONTAINS, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar%'];
+        yield [['force_case_insensitivity' => null, 'case_sensitive' => true], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
+        yield [['force_case_insensitivity' => false, 'case_sensitive' => false], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
+        yield [['force_case_insensitivity' => true, 'case_sensitive' => true], StringOperatorType::TYPE_CONTAINS, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar%'];
+
+        yield [['case_sensitive' => false], StringOperatorType::TYPE_CONTAINS, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar%'];
+        yield [['case_sensitive' => false], StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE LOWER(alias.field) NOT LIKE :field_name_0 OR alias.field IS NULL', '%foobar%'];
+        yield [['case_sensitive' => false], StringOperatorType::TYPE_EQUAL, 'WHERE LOWER(alias.field) = :field_name_0', 'foobar'];
+        yield [['case_sensitive' => false], StringOperatorType::TYPE_NOT_EQUAL, 'WHERE LOWER(alias.field) <> :field_name_0 OR alias.field IS NULL', 'foobar'];
+        yield [['case_sensitive' => false], StringOperatorType::TYPE_STARTS_WITH, 'WHERE LOWER(alias.field) LIKE :field_name_0', 'foobar%'];
+        yield [['case_sensitive' => false], StringOperatorType::TYPE_ENDS_WITH, 'WHERE LOWER(alias.field) LIKE :field_name_0', '%foobar'];
+        yield [['case_sensitive' => true], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
+        yield [['case_sensitive' => true], StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL', '%FooBar%'];
+        yield [['case_sensitive' => true], StringOperatorType::TYPE_EQUAL, 'WHERE alias.field = :field_name_0', 'FooBar'];
+        yield [['case_sensitive' => true], StringOperatorType::TYPE_NOT_EQUAL, 'WHERE alias.field <> :field_name_0 OR alias.field IS NULL', 'FooBar'];
+        yield [['case_sensitive' => true], StringOperatorType::TYPE_STARTS_WITH, 'WHERE alias.field LIKE :field_name_0', 'FooBar%'];
+        yield [['case_sensitive' => true], StringOperatorType::TYPE_ENDS_WITH, 'WHERE alias.field LIKE :field_name_0', '%FooBar'];
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Introduce "force_case_insensitivity" option and deprecate "case_sensitive" in `StringFilter`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1415.
Reverts #1395.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- "force_case_insensitivity" option to `StringFilter` in order to force the database to ignore the case sensitivity when matching filters.

### Deprecated
- "case_sensitive" option in `StringFilter`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
