### PR TITLE
Add stability alpha to sonata-project/admin-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^2.0",
-        "sonata-project/admin-bundle": "^4.0",
+        "sonata-project/admin-bundle": "^4.0@alpha",
         "sonata-project/exporter": "^2.0",
         "sonata-project/form-extensions": "^1.4",
         "symfony/config": "^4.4 || ^5.2",
@@ -91,7 +91,6 @@
             "Sonata\\DoctrineORMAdminBundle\\Tests\\": "tests/"
         }
     },
-    "minimum-stability": "alpha",
     "scripts": {
         "post-install-cmd": [
             "[ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/simple-phpunit install"

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "conflict": {
         "simplethings/entity-audit-bundle": ">=2.0",
-        "sonata-project/block-bundle": "<3.11",
+        "sonata-project/block-bundle": "<4.2",
         "sonata-project/core-bundle": "<3.20"
     },
     "provide": {

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,7 @@
     },
     "conflict": {
         "simplethings/entity-audit-bundle": ">=2.0",
-        "sonata-project/block-bundle": "<4.2",
-        "sonata-project/core-bundle": "<3.20"
+        "sonata-project/block-bundle": "<4.2"
     },
     "provide": {
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"


### PR DESCRIPTION
It also updates the conflict section removing `sonata-project/core-bundle` and updating `sonata-project/block-bundle` to the version required in `require-dev` section.