### PR TITLE
Add functional test for simple pager

### DIFF
--- a/tests/App/Admin/AuthorAdmin.php
+++ b/tests/App/Admin/AuthorAdmin.php
@@ -26,7 +26,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 /**
  * @phpstan-extends AbstractAdmin<\Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author>
  */
-final class AuthorAdmin extends AbstractAdmin
+class AuthorAdmin extends AbstractAdmin
 {
     protected function configureListFields(ListMapper $list): void
     {

--- a/tests/App/Admin/AuthorWithSimplePagerAdmin.php
+++ b/tests/App/Admin/AuthorWithSimplePagerAdmin.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+final class AuthorWithSimplePagerAdmin extends AuthorAdmin
+{
+    protected $baseRoutePattern = 'author-with-simple-pager';
+    protected $baseRouteName = 'author_with_simple_pager';
+}

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorWithSimplePagerAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CarAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CategoryAdmin;
@@ -58,6 +60,20 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
                 'label' => 'Author',
+                'default' => true,
+            ])
+            ->args([
+                '',
+                Author::class,
+                null,
+            ])
+            ->call('setTemplate', ['outer_list_rows_list', 'author/list_outer_list_rows_list.html.twig'])
+
+        ->set(AuthorWithSimplePagerAdmin::class)
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'label' => 'Author with Simple Pager',
+                'pager_type' => Pager::TYPE_SIMPLE,
             ])
             ->args([
                 '',

--- a/tests/Functional/SimplePagerTest.php
+++ b/tests/Functional/SimplePagerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class SimplePagerTest extends BaseFunctionalTestCase
+{
+    public function testSimplePagerSameResultsAsPager(): void
+    {
+        $crawlerWithPager = $this->client->request(Request::METHOD_GET, '/admin/tests/app/author/list');
+
+        $numberOfAuthors = $crawlerWithPager->filter('.js-author-item')->count();
+
+        $crawlerWithSimplePager = $this->client->request(Request::METHOD_GET, '/admin/author-with-simple-pager/list');
+
+        $this->assertSame($numberOfAuthors, $crawlerWithSimplePager->filter('.js-author-item')->count());
+    }
+}


### PR DESCRIPTION
It checks that the number of results from Pager must be the same as using Simple Pager.

This test shows the BC break introduced in `3.31` ref: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1403