### PR TITLE
Try to fix Simple pager

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -220,9 +220,7 @@ class ProxyQuery implements ProxyQueryInterface
 
         // Paginator with fetchJoinCollection doesn't work with composite primary keys
         // https://github.com/doctrine/orm/issues/2910
-        $paginator = new Paginator($query, 1 === \count($identifierFieldNames));
-
-        return $paginator->getIterator();
+        return new Paginator($query, 1 === \count($identifierFieldNames));
     }
 
     /**

--- a/tests/App/Admin/AuthorAdmin.php
+++ b/tests/App/Admin/AuthorAdmin.php
@@ -26,7 +26,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 /**
  * @phpstan-extends AbstractAdmin<\Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author>
  */
-final class AuthorAdmin extends AbstractAdmin
+class AuthorAdmin extends AbstractAdmin
 {
     protected function configureListFields(ListMapper $list): void
     {

--- a/tests/App/Admin/AuthorWithSimplePagerAdmin.php
+++ b/tests/App/Admin/AuthorWithSimplePagerAdmin.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+final class AuthorWithSimplePagerAdmin extends AuthorAdmin
+{
+    protected $baseRoutePattern = 'author-with-simple-pager';
+    protected $baseRouteName = 'author_with_simple_pager';
+}

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorWithSimplePagerAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CarAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CategoryAdmin;
@@ -58,6 +60,20 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
                 'label' => 'Author',
+                'default' => true,
+            ])
+            ->args([
+                '',
+                Author::class,
+                null,
+            ])
+            ->call('setTemplate', ['outer_list_rows_list', 'author/list_outer_list_rows_list.html.twig'])
+
+        ->set(AuthorWithSimplePagerAdmin::class)
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'label' => 'Author with Simple Pager',
+                'pager_type' => Pager::TYPE_SIMPLE,
             ])
             ->args([
                 '',

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -142,7 +142,7 @@ class ProxyQueryTest extends TestCase
                 ['id' => 2],
                 ['id' => 3],
             ],
-            $query->execute()
+            iterator_to_array($query->execute())
         );
 
         $query2 = new ProxyQuery(
@@ -156,7 +156,7 @@ class ProxyQueryTest extends TestCase
                 ['id' => 1],
                 ['id' => 3],
             ],
-            $query2->execute()
+            iterator_to_array($query2->execute())
         );
     }
 }

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -83,7 +83,7 @@ class ProxyQueryTest extends TestCase
         );
         $pq->setHint('hint', 'value');
 
-        $result = $pq->execute();
+        $result = iterator_to_array($pq->execute());
 
         $this->assertSame(2, $result[0]['id']);
     }

--- a/tests/Functional/SimplePagerTest.php
+++ b/tests/Functional/SimplePagerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class SimplePagerTest extends BaseFunctionalTestCase
+{
+    public function testSimplePagerSameResultsAsPager(): void
+    {
+        $crawlerWithPager = $this->client->request(Request::METHOD_GET, '/admin/tests/app/author/list');
+
+        $numberOfAuthors = $crawlerWithPager->filter('.js-author-item')->count();
+
+        $crawlerWithSimplePager = $this->client->request(Request::METHOD_GET, '/admin/author-with-simple-pager/list');
+
+        $this->assertSame($numberOfAuthors, $crawlerWithSimplePager->filter('.js-author-item')->count());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because bugfix.
It could technically be considered as a BC-break since `execute` method is now returning a `Paginator` instead of an `array`. But the phpdoc were saying `mixed` so I don't think there is a real BC-promise about the returning value.
It's still Countable and Traversable, and this is the only solution I found.

Closes #1403.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `ProxyQuery::execute()` is now returning a Paginator instead of an array.

### Fixed
- Support for fetch join with simple pager.
```