### PR TITLE
Stop using SonataAdmin config in doctrineORMAdmin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.96",
+        "sonata-project/admin-bundle": "^3.98.2",
         "sonata-project/exporter": "^1.11.0 || ^2.0",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4 || ^5.2",

--- a/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * NEXT_MAJOR: Remove the "since" part of the internal annotation.
  *
- * @internal since sonata-project/admin-bundle version 4.0
+ * @internal since sonata-project/doctrine-orm-admin-bundle version 4.0
  *
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
  *

--- a/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -17,6 +17,10 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>

--- a/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * NEXT_MAJOR: Remove the "since" part of the internal annotation.
  *
- * @internal since sonata-project/admin-bundle version 4.0
+ * @internal since sonata-project/doctrine-orm-admin-bundle version 4.0
  *
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
  *

--- a/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
@@ -18,6 +18,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>

--- a/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Definition;
 /**
  * NEXT_MAJOR: Remove the "since" part of the internal annotation.
  *
- * @internal since sonata-project/admin-bundle version 4.0
+ * @internal since sonata-project/doctrine-orm-admin-bundle version 4.0
  *
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
  *

--- a/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
@@ -18,6 +18,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @final since sonata-project/doctrine-orm-admin-bundle 3.24
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -26,7 +30,7 @@ class AddTemplatesCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $overwrite = $container->getParameter('sonata.admin.configuration.admin_services');
+        // NEXT_MAJOR: Remove this line.
         $templates = $container->getParameter('sonata_doctrine_orm_admin.templates');
 
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
@@ -36,32 +40,30 @@ class AddTemplatesCompilerPass implements CompilerPassInterface
 
             $definition = $container->getDefinition($id);
 
-            if (!$definition->hasMethodCall('setFormTheme')) {
-                $definition->addMethodCall('setFormTheme', [$templates['form']]);
-            }
+            // NEXT_MAJOR: Remove this line and uncomment the following
+            $this->mergeMethodCall($definition, 'setFormTheme', $templates['form']);
+//          $this->mergeMethodCall($definition, 'setFormTheme', ['@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig']);
 
-            if (isset($overwrite[$id]['templates']['form'])) {
-                $this->mergeMethodCall($definition, 'setFormTheme', $overwrite[$id]['templates']['form']);
-            }
-
-            if (!$definition->hasMethodCall('setFilterTheme')) {
-                $definition->addMethodCall('setFilterTheme', [$templates['filter']]);
-            }
-
-            if (isset($overwrite[$id]['templates']['filter'])) {
-                $this->mergeMethodCall($definition, 'setFilterTheme', $overwrite[$id]['templates']['filter']);
-            }
+            // NEXT_MAJOR: Remove this line and uncomment the following
+            $this->mergeMethodCall($definition, 'setFilterTheme', $templates['filter']);
+//          $this->mergeMethodCall($definition, 'setFilterTheme', ['@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig']);
         }
     }
 
     /**
-     * @param string $name
-     * @param mixed  $value
+     * @param string       $name
+     * @param array<mixed> $value
      *
      * @return void
      */
     public function mergeMethodCall(Definition $definition, $name, $value)
     {
+        if (!$definition->hasMethodCall($name)) {
+            $definition->addMethodCall($name, [$value]);
+
+            return;
+        }
+
         $methodCalls = $definition->getMethodCalls();
 
         foreach ($methodCalls as &$calls) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -56,11 +56,15 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('templates')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        // NEXT_MAJOR: Remove this option.
                         ->arrayNode('form')
+                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/admin-bundle 3.x.')
                             ->prototype('scalar')->end()
                             ->defaultValue(['@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig'])
                         ->end()
+                        // NEXT_MAJOR: Remove this option.
                         ->arrayNode('filter')
+                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/admin-bundle 3.x.')
                             ->prototype('scalar')->end()
                             ->defaultValue(['@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig'])
                         ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -58,13 +58,13 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         // NEXT_MAJOR: Remove this option.
                         ->arrayNode('form')
-                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/admin-bundle 3.x.')
+                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x.')
                             ->prototype('scalar')->end()
                             ->defaultValue(['@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig'])
                         ->end()
                         // NEXT_MAJOR: Remove this option.
                         ->arrayNode('filter')
-                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/admin-bundle 3.x.')
+                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x.')
                             ->prototype('scalar')->end()
                             ->defaultValue(['@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig'])
                         ->end()

--- a/src/SonataDoctrineORMAdminBundle.php
+++ b/src/SonataDoctrineORMAdminBundle.php
@@ -16,6 +16,7 @@ namespace Sonata\DoctrineORMAdminBundle;
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddAuditEntityCompilerPass;
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddGuesserCompilerPass;
 use Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddTemplatesCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,7 +28,7 @@ class SonataDoctrineORMAdminBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new AddGuesserCompilerPass());
-        $container->addCompilerPass(new AddTemplatesCompilerPass());
+        $container->addCompilerPass(new AddTemplatesCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
         $container->addCompilerPass(new AddAuditEntityCompilerPass());
     }
 }

--- a/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
@@ -24,38 +24,25 @@ class AddTemplatesCompilerPassTest extends TestCase
     {
         $container = $this->createMock(ContainerBuilder::class);
 
+        // NEXT_MAJOR: Remove this.
         $container
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('getParameter')
-            ->willReturnCallback(static function ($value) {
-                if ('sonata.admin.configuration.admin_services' === $value) {
-                    return [
-                        'my.admin' => [
-                            'templates' => [
-                                'form' => ['myform.twig.html'],
-                                'filter' => ['myfilter.twig.html'],
-                            ],
-                        ],
-                    ];
-                }
-
-                if ('sonata_doctrine_orm_admin.templates' === $value) {
-                    return [
-                        'form' => ['default_form.twig.html'],
-                        'filter' => ['default_filter.twig.html'],
-                    ];
-                }
-            });
+            ->with('sonata_doctrine_orm_admin.templates')
+            ->willReturn([
+                'form' => ['default_form.twig.html'],
+                'filter' => ['default_filter.twig.html'],
+            ]);
 
         $container
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('findTaggedServiceIds')
             ->willReturn(['my.admin' => [['manager_type' => 'orm']]]);
 
         $definition = new Definition(null);
 
         $container
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('getDefinition')
             ->willReturn($definition);
 
@@ -65,8 +52,12 @@ class AddTemplatesCompilerPassTest extends TestCase
         $compilerPass->process($container);
 
         $expected = [
-            ['setFilterTheme', [['custom_call.twig.html', 'myfilter.twig.html']]],
-            ['setFormTheme', [['default_form.twig.html', 'myform.twig.html']]],
+            // NEXT_MAJOR: Uncomment the following line instead.
+            ['setFilterTheme', [['custom_call.twig.html', 'default_filter.twig.html']]],
+//            ['setFilterTheme', [['custom_call.twig.html', '@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig']]],
+            // NEXT_MAJOR: Uncomment the following line instead.
+            ['setFormTheme', [['default_form.twig.html']]],
+//            ['setFormTheme', [['@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig']]],
         ];
 
         $this->assertSame($expected, $definition->getMethodCalls());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `templates.form` and `templates.filter` config

### Fixed
- Always merge `SonataDoctrineORMAdmin` form and filter templates.
- Using `sonata_admin` configuration.
```