### PR TITLE
Add forward compatibility with FilterData

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,15 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter
+
+Not adding `Sonata\AdminBundle\Filter\Model\FilterData` as type declaration of argument 4 of the callable passed to
+`Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter` is deprecated. In version 4.0 this argument will be an instance
+of `Sonata\AdminBundle\Filter\Model\FilterData`.
+
 UPGRADE FROM 3.32 to 3.33
 =========================
 

--- a/tests/Fixtures/Util/CallbackClass.php
+++ b/tests/Fixtures/Util/CallbackClass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util;
+
+/**
+ * NEXT_MAJOR: Remove this class.
+ */
+final class CallbackClass
+{
+    public function __invoke($query, $alias, $field, array $data): bool
+    {
+        return \is_array($data);
+    }
+
+    public static function staticCallback($query, $alias, $field, $data): bool
+    {
+        return \is_array($data);
+    }
+
+    public static function callback($query, $alias, $field, $data): bool
+    {
+        return \is_array($data);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`FilterData` will be introduced in version 4.0 as type declaration of argument 4 of `Filter::apply()`.

This adds an upgrade path when using `CallbackFilter` which receives a `callable` instance in order to filter.

If this `callable` does not use a type declaration for argument 4 or uses `array` (current type), it triggers a deprecation.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated not adding `FilterData` as type declaration of argument 4 in the callable passed to `CallbackFilter`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
