### PR TITLE
Fix binding arbitrary params as part of a value expression in the query filter at `Filter::applyWhere()` with PostgreSQL

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
+use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\Query\Expr\Orx;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter as BaseFilter;
@@ -189,8 +190,8 @@ abstract class Filter extends BaseFilter
 
                 $expressionParts = $expression->getParts();
 
-                if (isset($expressionParts[0]) && \is_string($expressionParts[0]) &&
-                    0 === strpos($expressionParts[0], ':sonata_admin_datagrid_filter_query_marker')
+                if (isset($expressionParts[0]) && $expressionParts[0] instanceof Comparison &&
+                    "'sonata_admin_datagrid_filter_query_marker_a'" === $expressionParts[0]->getLeftExpr()
                 ) {
                     $expression->add($parameter);
 
@@ -204,8 +205,7 @@ abstract class Filter extends BaseFilter
 
         if (null === $groupName) {
             // Add the ":sonata_admin_datagrid_filter_query_marker" parameter as marker for the `Orx` expression.
-            $orExpression->add($qb->expr()->isNull(':sonata_admin_datagrid_filter_query_marker'));
-            $qb->setParameter('sonata_admin_datagrid_filter_query_marker', 'sonata_admin.datagrid.filter_query.marker');
+            $orExpression->add($qb->expr()->neq("'sonata_admin_datagrid_filter_query_marker_a'", "'sonata_admin_datagrid_filter_query_marker_b'"));
         } else {
             self::$groupedOrExpressions[$groupName] = $orExpression;
         }

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -157,7 +157,7 @@ abstract class Filter extends BaseFilter
      * Adds the parameter to the corresponding `Orx` expression used in the `where` clause.
      * If it doesn't exist, a new one is created.
      * This method groups the filter "OR" conditions based on the "or_group" option. If this
-     * option is not set, it uses a marker (":sonata_admin_datagrid_filter_query_marker") in
+     * option is not set, it uses a marker ("sonata_admin_datagrid_filter_query_marker_left") in
      * the resulting DQL in order to identify the corresponding "WHERE (...)" condition
      * group each time it is required.
      * It allows to get queries like "WHERE previous_condition = previous_value AND (filter_1 = value OR filter_2 = value OR ...)",
@@ -180,7 +180,7 @@ abstract class Filter extends BaseFilter
         $qb = $query->getQueryBuilder();
         $where = $qb->getDQLPart('where');
 
-        // Search for the ":sonata_admin_datagrid_filter_query_marker" marker in order to
+        // Search for the "sonata_admin_datagrid_filter_query_marker_left" marker in order to
         // get the `Orx` expression.
         if (null === $groupName && null !== $where) {
             foreach ($where->getParts() as $expression) {
@@ -191,7 +191,7 @@ abstract class Filter extends BaseFilter
                 $expressionParts = $expression->getParts();
 
                 if (isset($expressionParts[0]) && $expressionParts[0] instanceof Comparison &&
-                    "'sonata_admin_datagrid_filter_query_marker_a'" === $expressionParts[0]->getLeftExpr()
+                    "'sonata_admin_datagrid_filter_query_marker_left'" === $expressionParts[0]->getLeftExpr()
                 ) {
                     $expression->add($parameter);
 
@@ -204,8 +204,8 @@ abstract class Filter extends BaseFilter
         $orExpression = $qb->expr()->orX();
 
         if (null === $groupName) {
-            // Add the ":sonata_admin_datagrid_filter_query_marker" parameter as marker for the `Orx` expression.
-            $orExpression->add($qb->expr()->neq("'sonata_admin_datagrid_filter_query_marker_a'", "'sonata_admin_datagrid_filter_query_marker_b'"));
+            // Add the "sonata_admin_datagrid_filter_query_marker_left" parameter as marker for the `Orx` expression.
+            $orExpression->add($qb->expr()->neq("'sonata_admin_datagrid_filter_query_marker_left'", "'sonata_admin_datagrid_filter_query_marker_right'"));
         } else {
             self::$groupedOrExpressions[$groupName] = $orExpression;
         }

--- a/tests/App/Admin/BookWithAuthorAutocompleteAdmin.php
+++ b/tests/App/Admin/BookWithAuthorAutocompleteAdmin.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+
+/**
+ * @phpstan-extends AbstractAdmin<\Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book>
+ */
+final class BookWithAuthorAutocompleteAdmin extends AbstractAdmin
+{
+    protected $baseRoutePattern = 'book-with-author-autocomplete';
+    protected $baseRouteName = 'book_with_author_autocomplete';
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+        $form
+            ->add('author', ModelAutocompleteType::class, [
+                'required' => false,
+                'property' => ['name'],
+                'minimum_input_length' => 0,
+            ]);
+    }
+}

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\AuthorWithSimplePagerAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookWithAuthorAutocompleteAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CarAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CategoryAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\ItemAdmin;
@@ -49,6 +50,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
                 'label' => 'Book',
+                'default' => true,
+            ])
+            ->args([
+                '',
+                Book::class,
+                null,
+            ])
+
+        ->set(BookWithAuthorAutocompleteAdmin::class)
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'label' => 'Book with Author autocomplete',
             ])
             ->args([
                 '',

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -169,7 +169,7 @@ final class FilterTest extends FilterTestCase
 
         yield 'Missing "or_group" option, fallback to DQL marker' => [
             'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
-            .' AND (:sonata_admin_datagrid_filter_query_marker IS NULL'
+            .' AND (\'sonata_admin_datagrid_filter_query_marker_a\' <> \'sonata_admin_datagrid_filter_query_marker_b\''
             .' OR e.project LIKE :project_0 OR e.version LIKE :version_1) AND 7 = 8',
             [
                 [

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -169,7 +169,7 @@ final class FilterTest extends FilterTestCase
 
         yield 'Missing "or_group" option, fallback to DQL marker' => [
             'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
-            .' AND (\'sonata_admin_datagrid_filter_query_marker_a\' <> \'sonata_admin_datagrid_filter_query_marker_b\''
+            .' AND (\'sonata_admin_datagrid_filter_query_marker_left\' <> \'sonata_admin_datagrid_filter_query_marker_right\''
             .' OR e.project LIKE :project_0 OR e.version LIKE :version_1) AND 7 = 8',
             [
                 [

--- a/tests/Functional/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Functional/RetrieveAutocompleteItemsActionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class RetrieveAutocompleteItemsActionTest extends BaseFunctionalTestCase
+{
+    public function testAutocomplete(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/admin/core/get-autocomplete-items?q=miguel&_per_page=10&_page=1&uniqid=s608eac968661e&admin_code=Sonata%5CDoctrineORMAdminBundle%5CTests%5CApp%5CAdmin%5CBookWithAuthorAutocompleteAdmin&field=author');
+
+        self::assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix binding arbitrary params as part of a value expression in the query filter at `Filter::applyWhere()` with PostgreSQL.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1389.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Bind arbitrary params as part of a value expression in the query filter at `Filter::applyWhere()` with PostgreSQL.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
