### PR TITLE
Fix "OR" condition used as marker at `Filter::addOrParameter()`

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -205,7 +205,7 @@ abstract class Filter extends BaseFilter
 
         if (null === $groupName) {
             // Add the "sonata_admin_datagrid_filter_query_marker_left" parameter as marker for the `Orx` expression.
-            $orExpression->add($qb->expr()->neq("'sonata_admin_datagrid_filter_query_marker_left'", "'sonata_admin_datagrid_filter_query_marker_right'"));
+            $orExpression->add($qb->expr()->eq("'sonata_admin_datagrid_filter_query_marker_left'", "'sonata_admin_datagrid_filter_query_marker_right'"));
         } else {
             self::$groupedOrExpressions[$groupName] = $orExpression;
         }

--- a/tests/App/DataFixtures/AuthorFixtures.php
+++ b/tests/App/DataFixtures/AuthorFixtures.php
@@ -34,6 +34,9 @@ final class AuthorFixtures extends Fixture
         $authorWithTwoBooks = new Author('author_with_two_books', 'Author with 2 books');
         $manager->persist($authorWithTwoBooks);
 
+        $authorForAutocompletion = new Author('autocompletion_author', 'autocompletion author');
+        $manager->persist($authorForAutocompletion);
+
         $manager->flush();
 
         $this->addReference(self::AUTHOR, $author);

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -169,7 +169,7 @@ final class FilterTest extends FilterTestCase
 
         yield 'Missing "or_group" option, fallback to DQL marker' => [
             'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
-            .' AND (\'sonata_admin_datagrid_filter_query_marker_left\' <> \'sonata_admin_datagrid_filter_query_marker_right\''
+            .' AND (\'sonata_admin_datagrid_filter_query_marker_left\' = \'sonata_admin_datagrid_filter_query_marker_right\''
             .' OR e.project LIKE :project_0 OR e.version LIKE :version_1) AND 7 = 8',
             [
                 [

--- a/tests/Functional/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Functional/RetrieveAutocompleteItemsActionTest.php
@@ -19,7 +19,17 @@ final class RetrieveAutocompleteItemsActionTest extends BaseFunctionalTestCase
 {
     public function testAutocomplete(): void
     {
-        $this->client->request(Request::METHOD_GET, '/admin/core/get-autocomplete-items?q=miguel&_per_page=10&_page=1&uniqid=s608eac968661e&admin_code=Sonata%5CDoctrineORMAdminBundle%5CTests%5CApp%5CAdmin%5CBookWithAuthorAutocompleteAdmin&field=author');
+        $this->client->request(Request::METHOD_GET, '/admin/core/get-autocomplete-items?q=autocompletion&_per_page=10&_page=1&uniqid=s608eac968661e&admin_code=Sonata%5CDoctrineORMAdminBundle%5CTests%5CApp%5CAdmin%5CBookWithAuthorAutocompleteAdmin&field=author');
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        self::assertIsArray($response['items']);
+        self::assertCount(1, $response['items']);
+
+        $author = reset($response['items']);
+
+        self::assertArrayHasKey('id', $author);
+        self::assertSame('autocompletion_author', $author['id']);
 
         self::assertResponseIsSuccessful();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix "OR" condition used as marker at `Filter::addOrParameter()`.
The assertion in this clause must be false.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.
Changelog is not required since the fixed issue is not released yet.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1446.

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Add tests.