### PR TITLE
Fix dataSource when fetch join are used

### DIFF
--- a/src/Exporter/DataSource.php
+++ b/src/Exporter/DataSource.php
@@ -55,6 +55,7 @@ class DataSource implements DataSourceInterface
             // Distinct is needed to iterate, even if group by is used
             // @see https://github.com/doctrine/orm/issues/5868
             $query->getQueryBuilder()->distinct();
+            $query->getQueryBuilder()->select(current($query->getQueryBuilder()->getRootAliases()));
             $query->setFirstResult(null);
             $query->setMaxResults(null);
 

--- a/tests/Exporter/DataSourceTest.php
+++ b/tests/Exporter/DataSourceTest.php
@@ -100,6 +100,8 @@ final class DataSourceTest extends TestCase
         $query = new Query($em);
 
         $queryBuilder->expects($this->once())->method('distinct');
+        $queryBuilder->expects($this->once())->method('getRootAliases')->willReturn(['o', 'a', 'e']);
+        $queryBuilder->expects($this->once())->method('select')->with('o');
 
         $proxyQuery = $this->getMockBuilder(ProxyQueryInterface::class)
             ->addMethods(['getDoctrineQuery'])


### PR DESCRIPTION
## Subject

Related to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1360#issuecomment-854648936

## Changelog

```markdown
### Fixed
- Export for admin with fetch join in the `configureQuery()` method.
```