### PR TITLE
Add Empty filter

### DIFF
--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -48,6 +48,7 @@ For now, only `Doctrine ORM` filters are available:
 * ``Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType`` Form Type, renders a 2 datetime fields,
 * ``Sonata\DoctrineORMAdminBundle\Filter\ClassFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DefaultType`` Form type, renders a choice list field.
 * ``Sonata\DoctrineORMAdminBundle\Filter\NullFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DefaultType`` Form type, renders a choice list field.
+* ``Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter``: depends on the ``Sonata\AdminBundle\Form\Type\Filter\DefaultType`` Form type, renders a choice list field.
 
 Example
 -------
@@ -198,6 +199,28 @@ Empty
         {
             $filter
                 ->add('deleted', NullFilter::class, ['field_name' => 'deletedAt']);
+        }
+    }
+
+The ``inverse`` option can be used to filter values that are not empty.
+
+EmptyFilter
+-----------
+
+``Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter`` supports filtering for empty OneToMany relations::
+
+    namespace Sonata\NewsBundle\Admin;
+
+    use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminBundle\Filter\NullFilter;
+
+    final class PostAdmin extends AbstractAdmin
+    {
+        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+        {
+            $datagridMapper
+                ->add('tags', EmptyFilter::class);
         }
     }
 

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Filter;
+
+use Sonata\AdminBundle\Filter\Model\FilterData;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+
+final class EmptyFilter extends Filter
+{
+    public function filter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void
+    {
+        if (!$data->hasValue()) {
+            return;
+        }
+
+        $isYes = BooleanType::TYPE_YES === (int) $data->getValue();
+        $isNo = BooleanType::TYPE_NO === (int) $data->getValue();
+
+        if (!$this->getOption('inverse') && $isYes || $this->getOption('inverse') && $isNo) {
+            $this->applyWhere(
+                $query,
+                sprintf('%s.%s IS EMPTY', $alias, $field)
+            );
+        } elseif (!$this->getOption('inverse') && $isNo || $this->getOption('inverse') && $isYes) {
+            $this->applyWhere(
+                $query,
+                sprintf('%s.%s IS NOT EMPTY', $alias, $field)
+            );
+        }
+    }
+
+    public function getDefaultOptions(): array
+    {
+        return [
+            'field_type' => BooleanType::class,
+            'operator_type' => HiddenType::class,
+            'operator_options' => [],
+            'inverse' => false,
+        ];
+    }
+
+    public function getRenderSettings(): array
+    {
+        return [DefaultType::class, [
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
+            'label' => $this->getLabel(),
+        ]];
+    }
+}

--- a/tests/Filter/EmptyFilterTest.php
+++ b/tests/Filter/EmptyFilterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
+
+use Sonata\AdminBundle\Filter\Model\FilterData;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Filter\EmptyFilter;
+use Sonata\Form\Type\BooleanType;
+
+final class EmptyFilterTest extends FilterTestCase
+{
+    public function testEmpty(): void
+    {
+        $filter = new EmptyFilter();
+        $filter->initialize('field_name', [
+            'field_options' => ['class' => 'FooBar'],
+        ]);
+
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+
+        $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
+
+        $this->assertSameQuery([], $proxyQuery);
+        $this->assertFalse($filter->isActive());
+    }
+
+    /**
+     * @dataProvider valueDataProvider
+     */
+    public function testValue(bool $inverse, int $value, string $expectedQuery): void
+    {
+        $filter = new EmptyFilter();
+        $filter->initialize('field_name', [
+            'field_options' => ['class' => 'FooBar'],
+            'inverse' => $inverse,
+        ]);
+
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+        $this->assertSameQuery([], $proxyQuery);
+
+        $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value]));
+
+        $this->assertSameQuery([$expectedQuery], $proxyQuery);
+        $this->assertTrue($filter->isActive());
+    }
+
+    public function testRenderSettings(): void
+    {
+        $filter = new EmptyFilter();
+        $filter->initialize('field_name', [
+            'field_options' => ['class' => 'FooBar'],
+        ]);
+        $options = $filter->getRenderSettings()[1];
+
+        $this->assertSame(BooleanType::class, $options['field_type']);
+    }
+
+    /**
+     * @phpstan-return iterable<array{bool, int, string}>
+     */
+    public function valueDataProvider(): iterable
+    {
+        return [
+            [false, BooleanType::TYPE_YES, 'WHERE alias.field IS EMPTY'],
+            [false, BooleanType::TYPE_NO, 'WHERE alias.field IS NOT EMPTY'],
+            [true, BooleanType::TYPE_YES, 'WHERE alias.field IS NOT EMPTY'],
+            [true, BooleanType::TYPE_NO, 'WHERE alias.field IS EMPTY'],
+        ];
+    }
+}


### PR DESCRIPTION
## Subject

I am targeting this branch, because there is already an empty filter in 3.x.

Closes #1437.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `EmptyFilter`
```