### PR TITLE
remove usages of deprecated DoctrineTestHelper

### DIFF
--- a/tests/Datagrid/OrderByToSelectWalkerTest.php
+++ b/tests/Datagrid/OrderByToSelectWalkerTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\OrderByToSelectWalker;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\Menu;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\StoreProduct;
-use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\TestEntityManagerFactory;
 
 /**
  * NEXT_MAJOR: Remove this test.
@@ -37,7 +37,7 @@ final class OrderByToSelectWalkerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->em = DoctrineTestHelper::createTestEntityManager();
+        $this->em = TestEntityManagerFactory::create();
     }
 
     protected function tearDown(): void

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -19,7 +19,7 @@ use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\User;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\UserBrowser;
-use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\TestEntityManagerFactory;
 
 class PagerTest extends TestCase
 {
@@ -36,7 +36,7 @@ class PagerTest extends TestCase
      */
     public function testCountResults(string $className): void
     {
-        $em = DoctrineTestHelper::createTestEntityManager();
+        $em = TestEntityManagerFactory::create();
         $schemaTool = new SchemaTool($em);
         $schemaTool->createSchema([
             $em->getClassMetadata($className),

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -22,7 +22,7 @@ use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\DoctrineType\UuidType;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\DoubleNameEntity;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Query\FooWalker;
-use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\TestEntityManagerFactory;
 
 class ProxyQueryTest extends TestCase
 {
@@ -40,7 +40,7 @@ class ProxyQueryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->em = DoctrineTestHelper::createTestEntityManager();
+        $this->em = TestEntityManagerFactory::create();
 
         $schemaTool = new SchemaTool($this->em);
         $classes = [

--- a/tests/Fixtures/TestEntityManagerFactory.php
+++ b/tests/Fixtures/TestEntityManagerFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Fixtures;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use PHPUnit\Framework\TestCase;
+
+final class TestEntityManagerFactory
+{
+    public static function create(): EntityManagerInterface
+    {
+        if (!\extension_loaded('pdo_sqlite')) {
+            TestCase::markTestSkipped('Extension pdo_sqlite is required.');
+        }
+
+        return EntityManager::create(
+            [
+                'driver' => 'pdo_sqlite',
+                'memory' => true,
+            ],
+            self::createConfiguration()
+        );
+    }
+
+    private static function createConfiguration(): Configuration
+    {
+        $config = new Configuration();
+        $config->setAutoGenerateProxyClasses(true);
+        $config->setProxyDir(sys_get_temp_dir());
+        $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
+        $config->setProxyNamespace('Sonata\DoctrineORMAdminBundle\Tests');
+
+        return $config;
+    }
+}

--- a/tests/Util/SmartPaginatorFactoryTest.php
+++ b/tests/Util/SmartPaginatorFactoryTest.php
@@ -19,8 +19,8 @@ use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Item;
+use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\TestEntityManagerFactory;
 use Sonata\DoctrineORMAdminBundle\Util\SmartPaginatorFactory;
-use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 
 final class SmartPaginatorFactoryTest extends TestCase
 {
@@ -49,14 +49,14 @@ final class SmartPaginatorFactoryTest extends TestCase
     public function getQueriesForFetchJoinedCollection(): iterable
     {
         yield 'Without joins' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Author::class, 'author'),
             false,
         ];
 
         yield 'With joins and simple identifier' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Author::class, 'author')
                 ->leftJoin('author.books', 'book'),
@@ -64,7 +64,7 @@ final class SmartPaginatorFactoryTest extends TestCase
         ];
 
         yield 'With joins and composite identifier' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Item::class, 'item')
                 ->leftJoin('item.product', 'product'),
@@ -99,14 +99,14 @@ final class SmartPaginatorFactoryTest extends TestCase
     public function getQueriesForOutputWalker(): iterable
     {
         yield 'Simple query without joins' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Author::class, 'author'),
             false,
         ];
 
         yield 'Simple query with having' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Author::class, 'author')
                 ->groupBy('author.name')
@@ -115,7 +115,7 @@ final class SmartPaginatorFactoryTest extends TestCase
         ];
 
         yield 'With joins and simple identifier' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Author::class, 'author')
                 ->leftJoin('author.books', 'book'),
@@ -123,7 +123,7 @@ final class SmartPaginatorFactoryTest extends TestCase
         ];
 
         yield 'With joins and composite identifier' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Item::class, 'item')
                 ->leftJoin('item.product', 'product'),
@@ -159,7 +159,7 @@ final class SmartPaginatorFactoryTest extends TestCase
     public function getQueriesForCountWalkerDistinct(): iterable
     {
         yield 'Simple query without joins' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Author::class, 'author'),
             true,
@@ -167,7 +167,7 @@ final class SmartPaginatorFactoryTest extends TestCase
         ];
 
         yield 'With joins and simple identifier' => [
-            DoctrineTestHelper::createTestEntityManager()
+            TestEntityManagerFactory::create()
                 ->createQueryBuilder()
                 ->from(Author::class, 'author')
                 ->leftJoin('author.books', 'book'),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1460

I investigated a bit. Mocking the EntityManager seems not doable easily for those tests. So took the functionality from `DoctrineTestHelper` and reduced it to a minimum for what we need.

Technically we only need this on master... but I thought it can't hurt to do it on 3.x already?
