### PR TITLE
Add `GroupableConditionAwareInterface`

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -178,7 +178,6 @@ abstract class Filter extends BaseFilter implements GroupableConditionAwareInter
     /**
      * Adds the parameter to the corresponding `Orx` expression used in the `where` clause.
      * If it doesn't exist, a new one is created.
-     * This method groups the filter "OR" conditions based on the "or_group" option.
      * It allows to get queries like "WHERE previous_condition = previous_value AND (filter_1 = value OR filter_2 = value OR ...)",
      * where the logical "OR" operators added by the filters are grouped inside a condition,
      * instead of having unfolded "WHERE ..." clauses like "WHERE previous_condition = previous_value OR filter_1 = value OR filter_2 = value OR ...",
@@ -203,8 +202,8 @@ abstract class Filter extends BaseFilter implements GroupableConditionAwareInter
             }
         }
 
+        // NEXT_MAJOR: Remove the next assignment and the next conditional block.
         $groupName = $this->getOption('or_group');
-        // NEXT_MAJOR: Remove the previous assignment and the next conditional block.
         if (null !== $groupName) {
             @trigger_error(sprintf(
                 'Option "or_group" is deprecated since sonata-project/doctrine-orm-admin-bundle 3.x and will be removed in version 4.0.'

--- a/src/Filter/GroupableConditionAwareInterface.php
+++ b/src/Filter/GroupableConditionAwareInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Doctrine\ORM\Query\Expr\Composite;
-use Sonata\AdminBundle\Filter\ChainableFilterInterface;
+use Sonata\AdminBundle\Search\ChainableFilterInterface;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>

--- a/src/Filter/GroupableConditionAwareInterface.php
+++ b/src/Filter/GroupableConditionAwareInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Filter;
+
+use Doctrine\ORM\Query\Expr\Composite;
+use Sonata\AdminBundle\Filter\ChainableFilterInterface;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+interface GroupableConditionAwareInterface extends ChainableFilterInterface
+{
+    public function setConditionGroup(Composite $conditionGroup): void;
+
+    public function getConditionGroup(): ?Composite;
+
+    public function hasConditionGroup(): bool;
+}

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -73,6 +73,10 @@ final class FilterTest extends FilterTestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove the group legacy.
+     *
+     * @group legacy
+     *
      * @dataProvider orExpressionProvider
      */
     public function testOrExpression(string $expected, array $filterOptionsCollection = []): void
@@ -117,7 +121,8 @@ final class FilterTest extends FilterTestCase
 
     public function orExpressionProvider(): iterable
     {
-        yield 'Using "or_group" option' => [
+        // NEXT_MAJOR: Remove this case.
+        yield 'Using deprecated "or_group" option' => [
             'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
             .' AND (e.project LIKE :project_0 OR e.version LIKE :version_1) AND 7 = 8',
             [
@@ -148,7 +153,8 @@ final class FilterTest extends FilterTestCase
             ],
         ];
 
-        yield 'Using "or_group" option with single filter' => [
+        // NEXT_MAJOR: Remove this case.
+        yield 'Using deprecated "or_group" option with single filter' => [
             'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
             .' AND e.project LIKE :project_0 AND 7 = 8',
             [
@@ -167,10 +173,9 @@ final class FilterTest extends FilterTestCase
             ],
         ];
 
-        yield 'Missing "or_group" option, fallback to DQL marker' => [
+        yield 'Default behavior' => [
             'SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)'
-            .' AND (\'sonata_admin_datagrid_filter_query_marker_left\' = \'sonata_admin_datagrid_filter_query_marker_right\''
-            .' OR e.project LIKE :project_0 OR e.version LIKE :version_1) AND 7 = 8',
+            .' AND e.project LIKE :project_0 AND e.version LIKE :version_1 AND 7 = 8',
             [
                 [
                     StringFilter::class,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add `GroupableConditionAwareInterface`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

I tried to finish the PR #1466

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `GroupableConditionAwareInterface`.

### Deprecated
- "or_group" option in `Filter` objects;
- `Filter::$groupedOrExpressions`.

### Fixed
- Not resetting `Filter::$groupedOrExpressions` static property (see sonata-project/SonataAdminBundle#7096).
```
