### PR TITLE
Avoid duplicate query with current page results

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Datagrid;
 
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sonata\AdminBundle\Datagrid\Pager as BasePager;
 
 /**
@@ -36,7 +37,16 @@ final class Pager extends BasePager
             throw new \TypeError(sprintf('The pager query MUST implement %s.', ProxyQueryInterface::class));
         }
 
-        return $query->execute();
+        $results = $query->execute();
+
+        // We're often both counting and iterating on the current page results.
+        // Doing this on the Paginator ends up with two executed queries instead of one.
+        // @see https://github.com/sonata-project/SonataAdminBundle/issues/7328#issuecomment-881373378
+        if ($results instanceof Paginator) {
+            return $results->getIterator();
+        }
+
+        return $results;
     }
 
     public function countResults(): int

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -13,16 +13,34 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Tests\Datagrid;
 
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\User;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Entity\ORM\UserBrowser;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\TestEntityManagerFactory;
 
 final class PagerTest extends TestCase
 {
+    public function testGetCurrentPageResults(): void
+    {
+        $iterator = new \ArrayIterator([new \stdClass()]);
+
+        $paginator = $this->createMock(Paginator::class);
+        $paginator->expects(self::once())->method('getIterator')->willReturn($iterator);
+
+        $pq = $this->createMock(ProxyQueryInterface::class);
+        $pq->method('execute')->willReturn($paginator);
+
+        $pager = new Pager();
+        $pager->setQuery($pq);
+
+        self::assertSame($iterator, $pager->getCurrentPageResults());
+    }
+
     /**
      * @phpstan-return iterable<array-key, array{class-string}>
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

See https://github.com/sonata-project/SonataAdminBundle/issues/7328

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
`Pager::getCurrentPageResults()` does not return `Paginator` anymore.
```