### PR TITLE
Add phpstan strict rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.52",
         "phpstan/phpstan-phpunit": "^0.12.18",
+        "phpstan/phpstan-strict-rules": "^0.12.10",
         "phpstan/phpstan-symfony": "^0.12.10",
         "psalm/plugin-phpunit": "^0.15.1",
         "psalm/plugin-symfony": "^2.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,13 @@
 parameters:
     ignoreErrors:
+        - # Disallow VariableMethodCallRule and VariablePropertyFetchRule
+            message: '#^Variable (method call|property access)#'
+            path: .
         - # https://github.com/phpstan/phpstan-phpunit/issues/87
             message: '#^Trying to mock an undefined method [a-zA-Z]*\(\) on class stdClass\.$#'
+            path: tests/
+        - # https://github.com/phpstan/phpstan-strict-rules/issues/130
+            message: '#^Call to static method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
             path: tests/
         - # https://github.com/doctrine/orm/pull/8767
             message: '#Method Sonata\\DoctrineORMAdminBundle\\FieldDescription\\FieldDescriptionFactory::getMetadata\(\) should return Doctrine\\ORM\\Mapping\\ClassMetadata\<TObject of object\> but returns Doctrine\\ORM\\Mapping\\ClassMetadata\<object\>\.$#'
@@ -9,3 +15,6 @@ parameters:
         - # https://github.com/doctrine/orm/pull/8767
             message: '#Method Sonata\\DoctrineORMAdminBundle\\Model\\ModelManager::getMetadata\(\) should return Doctrine\\ORM\\Mapping\\ClassMetadata\<TObject of object\> but returns Doctrine\\ORM\\Mapping\\ClassMetadata\<object\>\.$#'
             path: src/Model/ModelManager.php
+        - # https://github.com/phpstan/phpstan-strict-rules/issues/131
+            message: '#^Call to function in_array\(\) with arguments (0|1), array<int, 0\|1>&nonEmpty and true will always evaluate to true\.$#'
+            path: src/Filter/BooleanFilter.php

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -76,7 +76,7 @@ final class ListBuilder implements ListBuilderInterface
     public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void
     {
         $type = $fieldDescription->getType();
-        if (!$type) {
+        if (null === $type) {
             throw new \RuntimeException(sprintf(
                 'Please define a type for field `%s` in `%s`',
                 $fieldDescription->getName(),
@@ -98,10 +98,10 @@ final class ListBuilder implements ListBuilderInterface
             $fieldDescription->setOption('_sort_order', $fieldDescription->getOption('_sort_order', 'ASC'));
         }
 
-        if (!$fieldDescription->getTemplate()) {
+        if (null === $fieldDescription->getTemplate()) {
             $fieldDescription->setTemplate($this->getTemplate($type));
 
-            if (!$fieldDescription->getTemplate()) {
+            if (null === $fieldDescription->getTemplate()) {
                 switch ($fieldDescription->getMappingType()) {
                     case ClassMetadata::MANY_TO_ONE:
                         $fieldDescription->setTemplate(

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -69,7 +69,7 @@ final class ShowBuilder implements ShowBuilderInterface
     public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void
     {
         $type = $fieldDescription->getType();
-        if (!$type) {
+        if (null === $type) {
             throw new \RuntimeException(sprintf(
                 'Please define a type for field `%s` in `%s`',
                 $fieldDescription->getName(),
@@ -77,7 +77,7 @@ final class ShowBuilder implements ShowBuilderInterface
             ));
         }
 
-        if (!$fieldDescription->getTemplate()) {
+        if (null === $fieldDescription->getTemplate()) {
             $fieldDescription->setTemplate($this->getTemplate($type));
         }
 

--- a/src/FieldDescription/FieldDescription.php
+++ b/src/FieldDescription/FieldDescription.php
@@ -20,11 +20,7 @@ final class FieldDescription extends BaseFieldDescription
 {
     public function getTargetModel(): ?string
     {
-        if ($this->associationMapping) {
-            return $this->associationMapping['targetEntity'];
-        }
-
-        return null;
+        return $this->associationMapping['targetEntity'] ?? null;
     }
 
     public function isIdentifier(): bool
@@ -55,16 +51,16 @@ final class FieldDescription extends BaseFieldDescription
     {
         $this->fieldMapping = $fieldMapping;
 
-        $this->type = $this->type ?: (string) $fieldMapping['type'];
-        $this->mappingType = $this->mappingType ?: $fieldMapping['type'];
+        $this->type = $this->type ?? (string) $fieldMapping['type'];
+        $this->mappingType = $this->mappingType ?? $fieldMapping['type'];
     }
 
     protected function setAssociationMapping(array $associationMapping): void
     {
         $this->associationMapping = $associationMapping;
 
-        $this->type = $this->type ?: (string) $associationMapping['type'];
-        $this->mappingType = $this->mappingType ?: $associationMapping['type'];
+        $this->type = $this->type ?? (string) $associationMapping['type'];
+        $this->mappingType = $this->mappingType ?? $associationMapping['type'];
     }
 
     protected function setParentAssociationMappings(array $parentAssociationMappings): void

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -30,12 +30,15 @@ final class EmptyFilter extends Filter
         $isYes = BooleanType::TYPE_YES === (int) $data->getValue();
         $isNo = BooleanType::TYPE_NO === (int) $data->getValue();
 
-        if (!$this->getOption('inverse') && $isYes || $this->getOption('inverse') && $isNo) {
+        $inverse = $this->getOption('inverse', false);
+        \assert(\is_bool($inverse));
+
+        if (!$inverse && $isYes || $inverse && $isNo) {
             $this->applyWhere(
                 $query,
                 sprintf('%s.%s IS EMPTY', $alias, $field)
             );
-        } elseif (!$this->getOption('inverse') && $isNo || $this->getOption('inverse') && $isYes) {
+        } else {
             $this->applyWhere(
                 $query,
                 sprintf('%s.%s IS NOT EMPTY', $alias, $field)

--- a/src/Filter/ModelAutocompleteFilter.php
+++ b/src/Filter/ModelAutocompleteFilter.php
@@ -86,10 +86,6 @@ final class ModelAutocompleteFilter extends Filter
 
     protected function handleModel(ProxyQueryInterface $query, string $alias, FilterData $data): void
     {
-        if (empty($data->getValue())) {
-            return;
-        }
-
         $parameterName = $this->getNewParameterName($query);
 
         if ($data->isType(EqualOperatorType::TYPE_NOT_EQUAL)) {

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -25,7 +25,7 @@ final class ModelFilter extends Filter
 {
     public function filter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void
     {
-        if (!$data->hasValue() || empty($data->getValue())) {
+        if (!$data->hasValue()) {
             return;
         }
 

--- a/src/Filter/NullFilter.php
+++ b/src/Filter/NullFilter.php
@@ -30,12 +30,15 @@ final class NullFilter extends Filter
         $isYes = BooleanType::TYPE_YES === (int) $data->getValue();
         $isNo = BooleanType::TYPE_NO === (int) $data->getValue();
 
-        if (!$this->getOption('inverse') && $isYes || $this->getOption('inverse') && $isNo) {
+        $inverse = $this->getOption('inverse', false);
+        \assert(\is_bool($inverse));
+
+        if (!$inverse && $isYes || $inverse && $isNo) {
             $this->applyWhere(
                 $query,
                 $query->getQueryBuilder()->expr()->isNull(sprintf('%s.%s', $alias, $field))
             );
-        } elseif (!$this->getOption('inverse') && $isNo || $this->getOption('inverse') && $isYes) {
+        } else {
             $this->applyWhere(
                 $query,
                 $query->getQueryBuilder()->expr()->isNotNull(sprintf('%s.%s', $alias, $field))

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -54,10 +54,11 @@ final class StringFilter extends Filter implements SearchableFilterInterface
         $value = $this->trim((string) ($data->getValue() ?? ''));
         $type = $data->getType() ?? StringOperatorType::TYPE_CONTAINS;
 
+        $allowEmpty = $this->getOption('allow_empty', false);
+        \assert(\is_bool($allowEmpty));
+
         // ignore empty value if it doesn't make sense
-        if ('' === $value &&
-            (!$this->getOption('allow_empty') || \in_array($type, self::MEANINGLESS_TYPES, true))
-        ) {
+        if ('' === $value && (!$allowEmpty || \in_array($type, self::MEANINGLESS_TYPES, true))) {
             return;
         }
 
@@ -67,6 +68,7 @@ final class StringFilter extends Filter implements SearchableFilterInterface
         $parameterName = $this->getNewParameterName($query);
 
         $forceCaseInsensitivity = $this->getOption('force_case_insensitivity', false);
+        \assert(\is_bool($forceCaseInsensitivity));
 
         if ($forceCaseInsensitivity && '' !== $value) {
             $clause = 'LOWER(%s.%s) %s :%s';
@@ -147,13 +149,13 @@ final class StringFilter extends Filter implements SearchableFilterInterface
 
     private function trim(string $string): string
     {
-        $trimMode = $this->getOption('trim');
+        $trimMode = $this->getOption('trim', self::TRIM_BOTH);
 
-        if ($trimMode & self::TRIM_LEFT) {
+        if (0 !== ($trimMode & self::TRIM_LEFT)) {
             $string = ltrim($string);
         }
 
-        if ($trimMode & self::TRIM_RIGHT) {
+        if (0 !== ($trimMode & self::TRIM_RIGHT)) {
             $string = rtrim($string);
         }
 

--- a/tests/Block/AuditBlockServiceTest.php
+++ b/tests/Block/AuditBlockServiceTest.php
@@ -51,25 +51,25 @@ final class AuditBlockServiceTest extends BlockServiceTestCase
     {
         $blockContext = $this->createMock(BlockContextInterface::class);
 
-        $blockContext->expects($this->once())->method('getBlock')->willReturn($block = new Block());
-        $blockContext->expects($this->once())->method('getSetting')->with('limit')->willReturn($limit = 10);
+        $blockContext->expects(self::once())->method('getBlock')->willReturn($block = new Block());
+        $blockContext->expects(self::once())->method('getSetting')->with('limit')->willReturn($limit = 10);
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('findRevisionHistory')
             ->with($limit, 0)
             ->willReturn([$revision = new Revision('test', new \DateTime(), 'test')]);
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('findEntitiesChangedAtRevision')
             ->willReturn([]);
 
-        $blockContext->expects($this->once())->method('getTemplate')->willReturn('template');
-        $blockContext->expects($this->once())->method('getSettings')->willReturn([]);
+        $blockContext->expects(self::once())->method('getTemplate')->willReturn('template');
+        $blockContext->expects(self::once())->method('getSettings')->willReturn([]);
 
         $this->twig
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('render')
             ->with('template', [
                 'block' => $block,
@@ -80,14 +80,14 @@ final class AuditBlockServiceTest extends BlockServiceTestCase
 
         $response = $this->blockService->execute($blockContext);
 
-        $this->assertSame('content', $response->getContent());
+        self::assertSame('content', $response->getContent());
     }
 
     public function testDefaultSettings(): void
     {
         $blockContext = $this->getBlockContext($this->blockService);
 
-        $this->assertSettings([
+        self::assertSettings([
             'attr' => [],
             'extra_cache_keys' => [],
             'limit' => 10,

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -99,8 +99,8 @@ final class DatagridBuilderTest extends TestCase
 
         $datagrid = $this->datagridBuilder->getBaseDatagrid($this->admin);
 
-        $this->assertInstanceOf(Datagrid::class, $datagrid);
-        $this->assertInstanceOf($pager, $datagrid->getPager());
+        self::assertInstanceOf(Datagrid::class, $datagrid);
+        self::assertInstanceOf($pager, $datagrid->getPager());
     }
 
     /**
@@ -134,7 +134,7 @@ final class DatagridBuilderTest extends TestCase
         $fieldDescription = new FieldDescription('test', [], ['type' => ClassMetadata::ONE_TO_MANY]);
         $fieldDescription->setAdmin($this->admin);
 
-        $this->admin->expects($this->once())->method('attachAdminClass');
+        $this->admin->expects(self::once())->method('attachAdminClass');
 
         $this->datagridBuilder->fixFieldDescription($fieldDescription);
     }
@@ -146,7 +146,7 @@ final class DatagridBuilderTest extends TestCase
 
         $this->datagridBuilder->fixFieldDescription($fieldDescription);
 
-        $this->assertSame('fieldName', $fieldDescription->getOption('field_name'));
+        self::assertSame('fieldName', $fieldDescription->getOption('field_name'));
     }
 
     public function testAddFilterNoType(): void
@@ -157,7 +157,7 @@ final class DatagridBuilderTest extends TestCase
         $fieldDescription = new FieldDescription('test');
         $fieldDescription->setAdmin($this->admin);
 
-        $this->admin->expects($this->once())->method('addFilterFieldDescription');
+        $this->admin->expects(self::once())->method('addFilterFieldDescription');
         $this->admin->method('getCode')->willReturn('someFakeCode');
         $this->admin->method('getLabelTranslatorStrategy')->willReturn(new FormLabelTranslatorStrategy());
         $this->typeGuesser->method('guess')->willReturn($guessType);
@@ -165,7 +165,7 @@ final class DatagridBuilderTest extends TestCase
 
         $guessType->method('getOptions')->willReturn(['name' => 'value']);
         $guessType->method('getType')->willReturn(ModelAutocompleteFilter::class);
-        $datagrid->method('addFilter')->with($this->isInstanceOf(ModelAutocompleteFilter::class));
+        $datagrid->method('addFilter')->with(self::isInstanceOf(ModelAutocompleteFilter::class));
 
         $this->datagridBuilder->addFilter($datagrid, null, $fieldDescription);
     }

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -58,7 +58,7 @@ final class ListBuilderTest extends TestCase
 
     public function testAddListActionField(): void
     {
-        $this->admin->expects($this->once())->method('addListFieldDescription');
+        $this->admin->expects(self::once())->method('addListFieldDescription');
 
         $fieldDescription = new FieldDescription('foo');
         $fieldDescription->setAdmin($this->admin);
@@ -66,7 +66,7 @@ final class ListBuilderTest extends TestCase
         $list = $this->listBuilder->getBaseList();
         $this->listBuilder->addField($list, 'actions', $fieldDescription);
 
-        $this->assertSame(
+        self::assertSame(
             '@SonataAdmin/CRUD/list__action.html.twig',
             $list->get('foo')->getTemplate(),
             'Custom list action field has a default list action template assigned'
@@ -75,7 +75,7 @@ final class ListBuilderTest extends TestCase
 
     public function testCorrectFixedActionsFieldType(): void
     {
-        $this->admin->expects($this->once())->method('addListFieldDescription');
+        $this->admin->expects(self::once())->method('addListFieldDescription');
         $this->typeGuesser->method('guess')->willReturn(new TypeGuess(ListMapper::TYPE_ACTIONS, [], Guess::LOW_CONFIDENCE));
 
         $fieldDescription = new FieldDescription('_action');
@@ -85,18 +85,18 @@ final class ListBuilderTest extends TestCase
         $list = $this->listBuilder->getBaseList();
         $this->listBuilder->addField($list, null, $fieldDescription);
 
-        $this->assertSame(
+        self::assertSame(
             ListMapper::TYPE_ACTIONS,
             $list->get('_action')->getType(),
             'Standard list _action field has "actions" type'
         );
 
         $actions = $fieldDescription->getOption('actions');
-        $this->assertIsArray($actions);
-        $this->assertArrayHasKey('test', $actions);
-        $this->assertIsArray($actions['test']);
-        $this->assertArrayHasKey('template', $actions['test']);
-        $this->assertSame(
+        self::assertIsArray($actions);
+        self::assertArrayHasKey('test', $actions);
+        self::assertIsArray($actions['test']);
+        self::assertArrayHasKey('template', $actions['test']);
+        self::assertSame(
             '@SonataAdmin/CRUD/list__action_test.html.twig',
             $fieldDescription->getOption('actions')['test']['template']
         );
@@ -107,7 +107,7 @@ final class ListBuilderTest extends TestCase
      */
     public function testFixFieldDescription(int $type, string $template): void
     {
-        $this->admin->expects($this->once())->method('attachAdminClass');
+        $this->admin->expects(self::once())->method('attachAdminClass');
 
         $fieldDescription = new FieldDescription('test', [], ['type' => $type]);
         $fieldDescription->setOption('sortable', true);
@@ -116,7 +116,7 @@ final class ListBuilderTest extends TestCase
 
         $this->listBuilder->fixFieldDescription($fieldDescription);
 
-        $this->assertSame($template, $fieldDescription->getTemplate());
+        self::assertSame($template, $fieldDescription->getTemplate());
     }
 
     /**

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -67,7 +67,7 @@ final class ShowBuilderTest extends TestCase
 
     public function testGetBaseList(): void
     {
-        $this->assertInstanceOf(FieldDescriptionCollection::class, $this->showBuilder->getBaseList());
+        self::assertInstanceOf(FieldDescriptionCollection::class, $this->showBuilder->getBaseList());
     }
 
     public function testAddFieldNoType(): void
@@ -77,8 +77,8 @@ final class ShowBuilderTest extends TestCase
         $fieldDescription = new FieldDescription('FakeName', [], ['type' => ClassMetadata::MANY_TO_ONE]);
         $fieldDescription->setAdmin($this->admin);
 
-        $this->admin->expects($this->once())->method('attachAdminClass');
-        $this->admin->expects($this->once())->method('addShowFieldDescription');
+        $this->admin->expects(self::once())->method('attachAdminClass');
+        $this->admin->expects(self::once())->method('addShowFieldDescription');
 
         $typeGuess->method('getType')->willReturn('fakeType');
 
@@ -96,7 +96,7 @@ final class ShowBuilderTest extends TestCase
         $fieldDescription = new FieldDescription('FakeName');
         $fieldDescription->setAdmin($this->admin);
 
-        $this->admin->expects($this->once())->method('addShowFieldDescription');
+        $this->admin->expects(self::once())->method('addShowFieldDescription');
 
         $this->showBuilder->addField(
             new FieldDescriptionCollection(),
@@ -114,11 +114,11 @@ final class ShowBuilderTest extends TestCase
         $fieldDescription->setType($type);
         $fieldDescription->setAdmin($this->admin);
 
-        $this->admin->expects($this->once())->method('attachAdminClass');
+        $this->admin->expects(self::once())->method('attachAdminClass');
 
         $this->showBuilder->fixFieldDescription($fieldDescription);
 
-        $this->assertSame($template, $fieldDescription->getTemplate());
+        self::assertSame($template, $fieldDescription->getTemplate());
     }
 
     /**

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -72,6 +72,6 @@ final class PagerTest extends TestCase
         $pager->setQuery($pq);
         $pager->init();
 
-        $this->assertSame(0, $pager->countResults());
+        self::assertSame(0, $pager->countResults());
     }
 }

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -83,7 +83,7 @@ final class ProxyQueryTest extends TestCase
 
         $result = iterator_to_array($pq->execute());
 
-        $this->assertSame([$entity2, $entity1], $result);
+        self::assertSame([$entity2, $entity1], $result);
     }
 
     public function testSortOrderValidatesItsInput(): void
@@ -118,7 +118,7 @@ final class ProxyQueryTest extends TestCase
     {
         $query = new ProxyQuery($this->em->createQueryBuilder());
         $query->setSortOrder($validValue);
-        $this->assertSame($validValue, $query->getSortOrder());
+        self::assertSame($validValue, $query->getSortOrder());
     }
 
     public function testExecuteWithOrderBy(): void
@@ -137,13 +137,13 @@ final class ProxyQueryTest extends TestCase
         );
         $query->setSortBy([], ['fieldName' => 'name2'])->setSortOrder('ASC');
 
-        $this->assertSame([$entity1, $entity2, $entity3], iterator_to_array($query->execute()));
+        self::assertSame([$entity1, $entity2, $entity3], iterator_to_array($query->execute()));
 
         $query2 = new ProxyQuery(
             $this->em->createQueryBuilder()->select('o')->from(DoubleNameEntity::class, 'o')->addOrderBy('o.name')
         );
         $query2->setSortBy([], ['fieldName' => 'name2'])->setSortOrder('ASC');
 
-        $this->assertSame([$entity2, $entity1, $entity3], iterator_to_array($query2->execute()));
+        self::assertSame([$entity2, $entity1, $entity3], iterator_to_array($query2->execute()));
     }
 }

--- a/tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddAuditEntityCompilerPassTest.php
@@ -49,14 +49,14 @@ final class AddAuditEntityCompilerPassTest extends TestCase
         $container = $this->createMock(ContainerBuilder::class);
 
         $container
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('hasDefinition')
             ->willReturnCallback(static function (string $id): bool {
                 return 'simplethings_entityaudit.config' === $id;
             });
 
         $container
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getParameter')
             ->willReturnCallback(static function (string $id) use ($force) {
                 if ('sonata_doctrine_orm_admin.audit.force' === $id) {
@@ -71,7 +71,7 @@ final class AddAuditEntityCompilerPassTest extends TestCase
             });
 
         $container
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('findTaggedServiceIds')
             ->willReturnCallback(static function (string $id) use ($services): array {
                 if ('sonata.admin' !== $id) {
@@ -79,21 +79,22 @@ final class AddAuditEntityCompilerPassTest extends TestCase
                 }
 
                 $tags = [];
-                foreach ($services as $id => $service) {
+                foreach ($services as $serviceId => $service) {
                     $attributes = ['manager_type' => 'orm'];
 
-                    if (null !== $audit = $service['audit']) {
+                    $audit = $service['audit'];
+                    if (null !== $audit) {
                         $attributes['audit'] = $audit;
                     }
 
-                    $tags[$id] = [0 => $attributes];
+                    $tags[$serviceId] = [0 => $attributes];
                 }
 
                 return $tags;
             });
 
         $container
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getDefinition')
             ->willReturnCallback(static function (string $id): Definition {
                 return new Definition(null, [null, $id]);
@@ -108,7 +109,7 @@ final class AddAuditEntityCompilerPassTest extends TestCase
         }
 
         $container
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('setParameter')
             ->with('simplethings.entityaudit.audited_entities', $expectedAuditedEntities);
 

--- a/tests/DependencyInjection/Compiler/AddGuesserCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddGuesserCompilerPassTest.php
@@ -25,7 +25,7 @@ final class AddGuesserCompilerPassTest extends TestCase
     {
         $containerBuilder = $this->createMock(ContainerBuilder::class);
         $definition = $this->createMock(Definition::class);
-        $definition->expects($this->exactly(3))->method('replaceArgument')->with(0, [new Reference('some.id')]);
+        $definition->expects(self::exactly(3))->method('replaceArgument')->with(0, [new Reference('some.id')]);
 
         $containerBuilder->method('getDefinition')->withConsecutive(
             ['sonata.admin.guesser.orm_list_chain'],

--- a/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
@@ -25,14 +25,14 @@ final class AddTemplatesCompilerPassTest extends TestCase
         $container = $this->createMock(ContainerBuilder::class);
 
         $container
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('findTaggedServiceIds')
             ->willReturn(['my.admin' => [['manager_type' => 'orm']]]);
 
         $definition = new Definition(null);
 
         $container
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getDefinition')
             ->willReturn($definition);
 
@@ -46,6 +46,6 @@ final class AddTemplatesCompilerPassTest extends TestCase
             ['setFormTheme', [['@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig']]],
         ];
 
-        $this->assertSame($expected, $definition->getMethodCalls());
+        self::assertSame($expected, $definition->getMethodCalls());
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -25,17 +25,17 @@ final class ConfigurationTest extends TestCase
     {
         $config = $this->process([]);
 
-        $this->assertArrayHasKey('entity_manager', $config);
-        $this->assertNull($config['entity_manager']);
+        self::assertArrayHasKey('entity_manager', $config);
+        self::assertNull($config['entity_manager']);
 
-        $this->assertArrayHasKey('audit', $config);
-        $this->assertIsArray($config['audit']);
-        $this->assertArrayHasKey('force', $config['audit']);
-        $this->assertTrue($config['audit']['force']);
+        self::assertArrayHasKey('audit', $config);
+        self::assertIsArray($config['audit']);
+        self::assertArrayHasKey('force', $config['audit']);
+        self::assertTrue($config['audit']['force']);
 
-        $this->assertArrayHasKey('templates', $config);
-        $this->assertIsArray($config['templates']);
-        $this->assertArrayNotHasKey('types', $config['templates']);
+        self::assertArrayHasKey('templates', $config);
+        self::assertIsArray($config['templates']);
+        self::assertArrayNotHasKey('types', $config['templates']);
     }
 
     public function testAuditForceWithInvalidFormat(): void
@@ -64,10 +64,10 @@ final class ConfigurationTest extends TestCase
             ],
         ]]);
 
-        $this->assertArrayHasKey('templates', $config);
-        $this->assertIsArray($config['templates']);
-        $this->assertArrayHasKey('types', $config['templates']);
-        $this->assertSame([
+        self::assertArrayHasKey('templates', $config);
+        self::assertIsArray($config['templates']);
+        self::assertArrayHasKey('types', $config['templates']);
+        self::assertSame([
             'list' => [
                 'array' => 'list_array.twig.html',
             ],

--- a/tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataDoctrineORMAdminExtensionTest.php
@@ -28,7 +28,7 @@ final class SonataDoctrineORMAdminExtensionTest extends TestCase
 
         $definition = $configuration->getDefinition('sonata.admin.entity_manager');
 
-        $this->assertNotNull($definition->getFactory());
-        $this->assertNotFalse($configuration->getParameter('sonata_doctrine_orm_admin.audit.force'));
+        self::assertNotNull($definition->getFactory());
+        self::assertNotFalse($configuration->getParameter('sonata_doctrine_orm_admin.audit.force'));
     }
 }

--- a/tests/Exporter/DataSourceTest.php
+++ b/tests/Exporter/DataSourceTest.php
@@ -29,7 +29,7 @@ final class DataSourceTest extends TestCase
      */
     private $dataSource;
 
-    protected function setup(): void
+    protected function setUp(): void
     {
         $this->dataSource = new DataSource();
     }
@@ -47,18 +47,18 @@ final class DataSourceTest extends TestCase
             ->getMock();
         $query = new Query($em);
 
-        $queryBuilder->expects($this->once())->method('distinct');
-        $queryBuilder->expects($this->once())->method('getRootAliases')->willReturn(['o', 'a', 'e']);
-        $queryBuilder->expects($this->once())->method('select')->with('o');
+        $queryBuilder->expects(self::once())->method('distinct');
+        $queryBuilder->expects(self::once())->method('getRootAliases')->willReturn(['o', 'a', 'e']);
+        $queryBuilder->expects(self::once())->method('select')->with('o');
 
         $proxyQuery = $this->createMock(ProxyQueryInterface::class);
 
         $proxyQuery->method('getQueryBuilder')->willReturn($queryBuilder);
         $proxyQuery->method('getDoctrineQuery')->willReturn($query);
-        $proxyQuery->expects($this->once())->method('setFirstResult')->with(null);
-        $proxyQuery->expects($this->once())->method('setMaxResults')->with(null);
+        $proxyQuery->expects(self::once())->method('setFirstResult')->with(null);
+        $proxyQuery->expects(self::once())->method('setMaxResults')->with(null);
 
         $iterator = $this->dataSource->createIterator($proxyQuery, []);
-        $this->assertInstanceOf(DoctrineORMQuerySourceIterator::class, $iterator);
+        self::assertInstanceOf(DoctrineORMQuerySourceIterator::class, $iterator);
     }
 }

--- a/tests/FieldDescription/FieldDescriptionTest.php
+++ b/tests/FieldDescription/FieldDescriptionTest.php
@@ -31,30 +31,30 @@ final class FieldDescriptionTest extends TestCase
         ]);
 
         // test method shortcut
-        $this->assertNull($field->getOption('template'));
-        $this->assertNull($field->getOption('type'));
+        self::assertNull($field->getOption('template'));
+        self::assertNull($field->getOption('type'));
 
-        $this->assertSame('foo', $field->getTemplate());
-        $this->assertSame('bar', $field->getType());
+        self::assertSame('foo', $field->getTemplate());
+        self::assertSame('bar', $field->getType());
 
         // test the default value option
-        $this->assertSame('default', $field->getOption('template', 'default'));
+        self::assertSame('default', $field->getOption('template', 'default'));
 
         // test the merge options
         $field->setOption('array', ['key1' => 'val1']);
         $field->mergeOption('array', ['key1' => 'key_1', 'key2' => 'key_2']);
 
-        $this->assertSame(['key1' => 'key_1', 'key2' => 'key_2'], $field->getOption('array'));
+        self::assertSame(['key1' => 'key_1', 'key2' => 'key_2'], $field->getOption('array'));
 
         $field->mergeOption('non_existent', ['key1' => 'key_1', 'key2' => 'key_2']);
 
-        $this->assertSame(['key1' => 'key_1', 'key2' => 'key_2'], $field->getOption('array'));
+        self::assertSame(['key1' => 'key_1', 'key2' => 'key_2'], $field->getOption('array'));
 
         $field->setOption('integer', 1);
 
         try {
             $field->mergeOption('integer', []);
-            $this->fail('no exception raised !!');
+            self::fail('no exception raised !!');
         } catch (\RuntimeException $e) {
         }
 
@@ -71,7 +71,7 @@ final class FieldDescriptionTest extends TestCase
             'integer' => 1,
         ];
 
-        $this->assertSame($expected, $field->getOptions());
+        self::assertSame($expected, $field->getOptions());
     }
 
     public function testGetParent(): void
@@ -80,7 +80,7 @@ final class FieldDescriptionTest extends TestCase
         $field = new FieldDescription('name');
         $field->setParent($adminMock);
 
-        $this->assertSame($adminMock, $field->getParent());
+        self::assertSame($adminMock, $field->getParent());
     }
 
     public function testGetAdmin(): void
@@ -89,36 +89,36 @@ final class FieldDescriptionTest extends TestCase
         $field = new FieldDescription('name');
         $field->setAdmin($adminMock);
 
-        $this->assertSame($adminMock, $field->getAdmin());
+        self::assertSame($adminMock, $field->getAdmin());
     }
 
     public function testGetAssociationAdmin(): void
     {
         $adminMock = $this->createMock(AdminInterface::class);
-        $adminMock->expects($this->once())
+        $adminMock->expects(self::once())
             ->method('setParentFieldDescription')
-            ->with($this->isInstanceOf(FieldDescriptionInterface::class));
+            ->with(self::isInstanceOf(FieldDescriptionInterface::class));
 
         $field = new FieldDescription('name');
         $field->setAssociationAdmin($adminMock);
 
-        $this->assertSame($adminMock, $field->getAssociationAdmin());
+        self::assertSame($adminMock, $field->getAssociationAdmin());
     }
 
     public function testHasAssociationAdmin(): void
     {
         $adminMock = $this->createMock(AdminInterface::class);
-        $adminMock->expects($this->once())
+        $adminMock->expects(self::once())
             ->method('setParentFieldDescription')
-            ->with($this->isInstanceOf(FieldDescriptionInterface::class));
+            ->with(self::isInstanceOf(FieldDescriptionInterface::class));
 
         $field = new FieldDescription('name');
 
-        $this->assertFalse($field->hasAssociationAdmin());
+        self::assertFalse($field->hasAssociationAdmin());
 
         $field->setAssociationAdmin($adminMock);
 
-        $this->assertTrue($field->hasAssociationAdmin());
+        self::assertTrue($field->hasAssociationAdmin());
     }
 
     public function testSetFieldMapping(): void
@@ -127,9 +127,9 @@ final class FieldDescriptionTest extends TestCase
 
         $field = new FieldDescription('position', [], $fieldMapping);
 
-        $this->assertSame('integer', $field->getType());
-        $this->assertSame('integer', $field->getMappingType());
-        $this->assertSame($fieldMapping, $field->getFieldMapping());
+        self::assertSame('integer', $field->getType());
+        self::assertSame('integer', $field->getMappingType());
+        self::assertSame($fieldMapping, $field->getFieldMapping());
     }
 
     public function testSetAssociationMapping(): void
@@ -138,9 +138,9 @@ final class FieldDescriptionTest extends TestCase
 
         $field = new FieldDescription('name', [], [], $associationMapping);
 
-        $this->assertSame('integer', $field->getType());
-        $this->assertSame('integer', $field->getMappingType());
-        $this->assertSame($associationMapping, $field->getAssociationMapping());
+        self::assertSame('integer', $field->getType());
+        self::assertSame('integer', $field->getMappingType());
+        self::assertSame($associationMapping, $field->getAssociationMapping());
     }
 
     public function testSetParentAssociationMappings(): void
@@ -149,7 +149,7 @@ final class FieldDescriptionTest extends TestCase
 
         $field = new FieldDescription('name', [], [], [], $parentAssociationMappings);
 
-        $this->assertSame($parentAssociationMappings, $field->getParentAssociationMappings());
+        self::assertSame($parentAssociationMappings, $field->getParentAssociationMappings());
     }
 
     public function testSetInvalidParentAssociationMappings(): void
@@ -170,7 +170,7 @@ final class FieldDescriptionTest extends TestCase
 
         $field = new FieldDescription('position', [], [], $associationMapping);
 
-        $this->assertSame(\stdClass::class, $field->getTargetModel());
+        self::assertSame(\stdClass::class, $field->getTargetModel());
     }
 
     public function testIsIdentifierFromFieldMapping(): void
@@ -183,30 +183,30 @@ final class FieldDescriptionTest extends TestCase
 
         $field = new FieldDescription('position', [], $fieldMapping);
 
-        $this->assertTrue($field->isIdentifier());
+        self::assertTrue($field->isIdentifier());
     }
 
     public function testGetValue(): void
     {
         $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getFoo'])->getMock();
-        $mockedObject->expects($this->once())->method('getFoo')->willReturn('myMethodValue');
+        $mockedObject->expects(self::once())->method('getFoo')->willReturn('myMethodValue');
 
         $field = new FieldDescription('name', ['accessor' => 'foo']);
 
-        $this->assertSame('myMethodValue', $field->getValue($mockedObject));
+        self::assertSame('myMethodValue', $field->getValue($mockedObject));
     }
 
     public function testGetValueWithParentAssociationMappings(): void
     {
         $mockedSubObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getFieldName'])->getMock();
-        $mockedSubObject->expects($this->once())->method('getFieldName')->willReturn('value');
+        $mockedSubObject->expects(self::once())->method('getFieldName')->willReturn('value');
 
         $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getSubObject'])->getMock();
-        $mockedObject->expects($this->once())->method('getSubObject')->willReturn($mockedSubObject);
+        $mockedObject->expects(self::once())->method('getSubObject')->willReturn($mockedSubObject);
 
         $field = new FieldDescription('name', [], [], [], [['fieldName' => 'subObject']], 'fieldName');
 
-        $this->assertSame('value', $field->getValue($mockedObject));
+        self::assertSame('value', $field->getValue($mockedObject));
     }
 
     public function testGetValueWhenCannotRetrieve(): void
@@ -214,40 +214,40 @@ final class FieldDescriptionTest extends TestCase
         $this->expectException(NoValueException::class);
 
         $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
-        $mockedObject->expects($this->never())->method('myMethod')->willReturn('myMethodValue');
+        $mockedObject->expects(self::never())->method('myMethod')->willReturn('myMethodValue');
 
         $field = new FieldDescription('name');
 
-        $this->assertSame('myMethodValue', $field->getValue($mockedObject));
+        self::assertSame('myMethodValue', $field->getValue($mockedObject));
     }
 
     public function testGetValueForEmbeddedObject(): void
     {
         $mockedEmbeddedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getMyMethod'])->getMock();
-        $mockedEmbeddedObject->expects($this->once())->method('getMyMethod')->willReturn('myMethodValue');
+        $mockedEmbeddedObject->expects(self::once())->method('getMyMethod')->willReturn('myMethodValue');
 
         $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getMyEmbeddedObject'])->getMock();
-        $mockedObject->expects($this->once())->method('getMyEmbeddedObject')->willReturn($mockedEmbeddedObject);
+        $mockedObject->expects(self::once())->method('getMyEmbeddedObject')->willReturn($mockedEmbeddedObject);
 
         $field = new FieldDescription('myMethod', [], [], [], [], 'myEmbeddedObject.myMethod');
 
-        $this->assertSame('myMethodValue', $field->getValue($mockedObject));
+        self::assertSame('myMethodValue', $field->getValue($mockedObject));
     }
 
     public function testGetValueForMultiLevelEmbeddedObject(): void
     {
         $mockedChildEmbeddedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getMyMethod'])->getMock();
-        $mockedChildEmbeddedObject->expects($this->once())->method('getMyMethod')->willReturn('myMethodValue');
+        $mockedChildEmbeddedObject->expects(self::once())->method('getMyMethod')->willReturn('myMethodValue');
 
         $mockedEmbeddedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getChild'])->getMock();
-        $mockedEmbeddedObject->expects($this->once())->method('getChild')->willReturn($mockedChildEmbeddedObject);
+        $mockedEmbeddedObject->expects(self::once())->method('getChild')->willReturn($mockedChildEmbeddedObject);
 
         $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getMyEmbeddedObject'])->getMock();
-        $mockedObject->expects($this->once())->method('getMyEmbeddedObject')->willReturn($mockedEmbeddedObject);
+        $mockedObject->expects(self::once())->method('getMyEmbeddedObject')->willReturn($mockedEmbeddedObject);
 
         $field = new FieldDescription('myMethod', [], [], [], [], 'myEmbeddedObject.child.myMethod');
 
-        $this->assertSame('myMethodValue', $field->getValue($mockedObject));
+        self::assertSame('myMethodValue', $field->getValue($mockedObject));
     }
 
     /**
@@ -261,7 +261,7 @@ final class FieldDescriptionTest extends TestCase
             'fieldName' => 'foo',
             'type' => $mappingType,
         ]);
-        $this->assertSame($expected, $fd->describesSingleValuedAssociation());
+        self::assertSame($expected, $fd->describesSingleValuedAssociation());
     }
 
     /**
@@ -287,7 +287,7 @@ final class FieldDescriptionTest extends TestCase
             'fieldName' => 'foo',
             'type' => $mappingType,
         ]);
-        $this->assertSame($expected, $fd->describesCollectionValuedAssociation());
+        self::assertSame($expected, $fd->describesCollectionValuedAssociation());
     }
 
     /**

--- a/tests/FieldDescription/FilterTypeGuesserTest.php
+++ b/tests/FieldDescription/FilterTypeGuesserTest.php
@@ -63,9 +63,9 @@ final class FilterTypeGuesserTest extends TestCase
 
         $guess = $this->guesser->guess($fieldDescription);
 
-        $this->assertSame($expectedType, $guess->getType());
-        $this->assertSame($expectedOptions, $guess->getOptions());
-        $this->assertSame($expectedConfidence, $guess->getConfidence());
+        self::assertSame($expectedType, $guess->getType());
+        self::assertSame($expectedOptions, $guess->getOptions());
+        self::assertSame($expectedConfidence, $guess->getConfidence());
     }
 
     /**

--- a/tests/FieldDescription/TypeGuesserTest.php
+++ b/tests/FieldDescription/TypeGuesserTest.php
@@ -52,9 +52,9 @@ final class TypeGuesserTest extends TestCase
 
         $guess = $this->guesser->guess($fieldDescription);
 
-        $this->assertSame($expectedType, $guess->getType());
-        $this->assertSame($expectedOptions, $guess->getOptions());
-        $this->assertSame($expectedConfidence, $guess->getConfidence());
+        self::assertSame($expectedType, $guess->getType());
+        self::assertSame($expectedOptions, $guess->getOptions());
+        self::assertSame($expectedConfidence, $guess->getConfidence());
     }
 
     /**

--- a/tests/Filter/BooleanFilterTest.php
+++ b/tests/Filter/BooleanFilterTest.php
@@ -27,8 +27,8 @@ final class BooleanFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
         $options = $filter->getRenderSettings()[1];
 
-        $this->assertSame(HiddenType::class, $options['operator_type']);
-        $this->assertSame([], $options['operator_options']);
+        self::assertSame(HiddenType::class, $options['operator_type']);
+        self::assertSame([], $options['operator_options']);
     }
 
     public function testFilterEmpty(): void
@@ -41,8 +41,8 @@ final class BooleanFilterTest extends FilterTestCase
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([null, 'test']));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilterNo(): void
@@ -54,9 +54,9 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => BooleanType::TYPE_NO]));
 
-        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterNoWithTreatNullAsTrue(): void
@@ -71,9 +71,9 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => BooleanType::TYPE_NO]));
 
-        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterNoWithTreatNullAsFalse(): void
@@ -88,9 +88,9 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => BooleanType::TYPE_NO]));
 
-        $this->assertSameQuery(['WHERE alias.field IS NULL OR alias.field = :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IS NULL OR alias.field = :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterYes(): void
@@ -102,9 +102,9 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => BooleanType::TYPE_YES]));
 
-        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => 1], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => 1], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterYesWithTreatNullAsFalse(): void
@@ -119,9 +119,9 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => BooleanType::TYPE_YES]));
 
-        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => 1], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => 1], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterYesWithTreatNullAsTrue(): void
@@ -136,9 +136,9 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => BooleanType::TYPE_YES]));
 
-        $this->assertSameQuery(['WHERE alias.field IS NULL OR alias.field = :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => 1], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IS NULL OR alias.field = :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => 1], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterArray(): void
@@ -150,8 +150,8 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => [BooleanType::TYPE_NO]]));
 
-        $this->assertSameQuery(['WHERE alias.field IN ("0")'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IN ("0")'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterArrayWithTreatNullAsFalse(): void
@@ -166,8 +166,8 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => [BooleanType::TYPE_NO]]));
 
-        $this->assertSameQuery(['WHERE alias.field IS NULL OR alias.field IN ("0")'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IS NULL OR alias.field IN ("0")'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterArrayWithTreatNullAsTrue(): void
@@ -182,7 +182,7 @@ final class BooleanFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => null, 'value' => [BooleanType::TYPE_NO]]));
 
-        $this->assertSameQuery(['WHERE alias.field IN ("0")'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IN ("0")'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/CallbackFilterTest.php
+++ b/tests/Filter/CallbackFilterTest.php
@@ -27,8 +27,8 @@ final class CallbackFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
         $options = $filter->getRenderSettings()[1];
 
-        $this->assertSame(HiddenType::class, $options['operator_type']);
-        $this->assertSame([], $options['operator_options']);
+        self::assertSame(HiddenType::class, $options['operator_type']);
+        self::assertSame([], $options['operator_options']);
     }
 
     public function testFilterClosure(): void
@@ -47,9 +47,9 @@ final class CallbackFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => 'myValue']));
 
-        $this->assertSameQuery(['WHERE CUSTOM QUERY alias.field'], $proxyQuery);
-        $this->assertSameQueryParameters(['value' => 'myValue'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE CUSTOM QUERY alias.field'], $proxyQuery);
+        self::assertSameQueryParameters(['value' => 'myValue'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterMethod(): void
@@ -63,9 +63,9 @@ final class CallbackFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => 'myValue']));
 
-        $this->assertSameQuery(['WHERE CUSTOM QUERY alias.field'], $proxyQuery);
-        $this->assertSameQueryParameters(['value' => 'myValue'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE CUSTOM QUERY alias.field'], $proxyQuery);
+        self::assertSameQueryParameters(['value' => 'myValue'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function customCallback(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): bool
@@ -104,8 +104,8 @@ final class CallbackFilterTest extends FilterTestCase
 
         $filter->apply($proxyQuery, FilterData::fromArray(['value' => 'myValue']));
 
-        $this->assertSameQuery(['WHERE CUSTOM QUERY o.field_name_test'], $proxyQuery);
-        $this->assertSameQueryParameters(['value' => 'myValue'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE CUSTOM QUERY o.field_name_test'], $proxyQuery);
+        self::assertSameQueryParameters(['value' => 'myValue'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/ChoiceFilterTest.php
+++ b/tests/Filter/ChoiceFilterTest.php
@@ -26,8 +26,8 @@ final class ChoiceFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
         $options = $filter->getRenderSettings()[1];
 
-        $this->assertSame(EqualOperatorType::class, $options['operator_type']);
-        $this->assertSame([], $options['operator_options']);
+        self::assertSame(EqualOperatorType::class, $options['operator_type']);
+        self::assertSame([], $options['operator_options']);
     }
 
     public function testFilterEmpty(): void
@@ -39,8 +39,8 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilterArrayEqual(): void
@@ -52,9 +52,9 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_EQUAL, 'value' => ['1', '2']]));
 
-        $this->assertSameQuery(['WHERE alias.field IN :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IN :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterArrayNotEqual(): void
@@ -66,9 +66,9 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', '2']]));
 
-        $this->assertSameQuery(['WHERE alias.field NOT IN :field_name_0 OR alias.field IS NULL'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field NOT IN :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterArrayEqualWithNullValue(): void
@@ -80,9 +80,9 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_EQUAL, 'value' => ['1', null]]));
 
-        $this->assertSameQuery(['WHERE alias.field IN :field_name_0 OR alias.field IS NULL'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => ['1', null]], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IN :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => ['1', null]], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterArrayNotEqualWithNullValue(): void
@@ -94,9 +94,9 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => ['1', null]]));
 
-        $this->assertSameQuery(['WHERE alias.field NOT IN :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => ['1', null]], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field NOT IN :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => ['1', null]], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterEqualScalar(): void
@@ -108,9 +108,9 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_EQUAL, 'value' => '1']));
 
-        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => '1'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => '1'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterNotEqualScalar(): void
@@ -122,9 +122,9 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => '1']));
 
-        $this->assertSameQuery(['WHERE alias.field != :field_name_0 OR alias.field IS NULL'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => '1'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field != :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => '1'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterEqualNull(): void
@@ -136,9 +136,9 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_EQUAL, 'value' => null]));
 
-        $this->assertSameQuery(['WHERE alias.field IS NULL'], $proxyQuery);
-        $this->assertSameQueryParameters([], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IS NULL'], $proxyQuery);
+        self::assertSameQueryParameters([], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterNotEqualNull(): void
@@ -150,9 +150,9 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => null]));
 
-        $this->assertSameQuery(['WHERE alias.field IS NOT NULL'], $proxyQuery);
-        $this->assertSameQueryParameters([], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field IS NOT NULL'], $proxyQuery);
+        self::assertSameQueryParameters([], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterZero(): void
@@ -164,8 +164,8 @@ final class ChoiceFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 0]));
 
-        $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => 0], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/ClassFilterTest.php
+++ b/tests/Filter/ClassFilterTest.php
@@ -26,8 +26,8 @@ final class ClassFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
         $options = $filter->getRenderSettings()[1];
 
-        $this->assertSame(EqualOperatorType::class, $options['operator_type']);
-        $this->assertSame([], $options['operator_options']);
+        self::assertSame(EqualOperatorType::class, $options['operator_type']);
+        self::assertSame([], $options['operator_options']);
     }
 
     public function testFilterEmpty(): void
@@ -39,8 +39,8 @@ final class ClassFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => '']));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilterInvalidOperator(): void
@@ -52,8 +52,8 @@ final class ClassFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => 42]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilter(): void
@@ -73,7 +73,7 @@ final class ClassFilterTest extends FilterTestCase
             'WHERE alias INSTANCE OF type',
         ];
 
-        $this->assertSameQuery($expected, $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery($expected, $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/CountFilterTest.php
+++ b/tests/Filter/CountFilterTest.php
@@ -29,8 +29,8 @@ final class CountFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilterInvalidOperator(): void
@@ -42,8 +42,8 @@ final class CountFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => 42]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     /**
@@ -58,8 +58,8 @@ final class CountFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => $type, 'value' => 42]));
 
-        $this->assertSameQuery(['GROUP BY o', $expected], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['GROUP BY o', $expected], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     /**

--- a/tests/Filter/DateFilterTest.php
+++ b/tests/Filter/DateFilterTest.php
@@ -32,8 +32,8 @@ final class DateFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testGetType(): void
@@ -41,7 +41,7 @@ final class DateFilterTest extends FilterTestCase
         $filter = new DateFilter();
         $filter->initialize('foo');
 
-        $this->assertSame(DateType::class, $filter->getFieldType());
+        self::assertSame(DateType::class, $filter->getFieldType());
     }
 
     public function testFilterRecordsWholeDay(): void
@@ -52,14 +52,14 @@ final class DateFilterTest extends FilterTestCase
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => new \DateTime()]));
 
-        $this->assertSameQuery([
+        self::assertSameQuery([
             'WHERE alias.field < :field_name_0',
             'WHERE alias.field >= :field_name_1',
         ], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertTrue($filter->isActive());
 
         $builder = $proxyQuery->getQueryBuilder();
         \assert($builder instanceof TestQueryBuilder);
-        $this->assertCount(2, $builder->queryParameters);
+        self::assertCount(2, $builder->queryParameters);
     }
 }

--- a/tests/Filter/DateRangeFilterTest.php
+++ b/tests/Filter/DateRangeFilterTest.php
@@ -41,8 +41,8 @@ final class DateRangeFilterTest extends FilterTestCase
             'value' => ['start' => '', 'end' => ''],
         ]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilterStartDateAndEndDate(): void
@@ -63,12 +63,12 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]));
 
-        $this->assertSameQuery(['WHERE alias.field >= :field_name_0', 'WHERE alias.field <= :field_name_1'], $proxyQuery);
-        $this->assertSameQueryParameters([
+        self::assertSameQuery(['WHERE alias.field >= :field_name_0', 'WHERE alias.field <= :field_name_1'], $proxyQuery);
+        self::assertSameQueryParameters([
             'field_name_0' => $startDateTime,
             'field_name_1' => $endDateTime,
         ], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterStartDate(): void
@@ -88,9 +88,9 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]));
 
-        $this->assertSameQuery(['WHERE alias.field >= :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => $startDateTime], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field >= :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => $startDateTime], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterEndDate(): void
@@ -110,9 +110,9 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]));
 
-        $this->assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_1' => $endDateTime], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_1' => $endDateTime], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     /**
@@ -131,8 +131,8 @@ final class DateRangeFilterTest extends FilterTestCase
         $modelEndDateTime = clone $viewEndDateTime;
         $modelEndDateTime->setTimezone($modelTimeZone);
 
-        $this->assertSame($modelTimeZone->getName(), $modelEndDateTime->getTimezone()->getName());
-        $this->assertNotSame($modelTimeZone->getName(), $viewEndDateTime->getTimezone()->getName());
+        self::assertSame($modelTimeZone->getName(), $modelEndDateTime->getTimezone()->getName());
+        self::assertNotSame($modelTimeZone->getName(), $viewEndDateTime->getTimezone()->getName());
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
             'type' => null,
@@ -142,10 +142,10 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]));
 
-        $this->assertTrue($filter->isActive());
-        $this->assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_1' => $modelEndDateTime], $proxyQuery);
-        $this->assertSame($expectedEndDateTime->getTimestamp(), $modelEndDateTime->getTimestamp());
+        self::assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_1' => $modelEndDateTime], $proxyQuery);
+        self::assertSame($expectedEndDateTime->getTimestamp(), $modelEndDateTime->getTimestamp());
     }
 
     /**
@@ -201,13 +201,13 @@ final class DateRangeFilterTest extends FilterTestCase
             ],
         ]));
 
-        $this->assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field <= :field_name_1'], $proxyQuery);
+        self::assertTrue($filter->isActive());
 
         $builder = $proxyQuery->getQueryBuilder();
         \assert($builder instanceof TestQueryBuilder);
-        $this->assertCount(1, $builder->queryParameters);
-        $this->assertSame(
+        self::assertCount(1, $builder->queryParameters);
+        self::assertSame(
             $endDateTime->modify('+23 hours 59 minutes 59 seconds')->getTimestamp(),
             $builder->queryParameters['field_name_1']->getTimestamp()
         );

--- a/tests/Filter/DateTimeFilterTest.php
+++ b/tests/Filter/DateTimeFilterTest.php
@@ -32,8 +32,8 @@ final class DateTimeFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => '']));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testGetType(): void
@@ -41,6 +41,6 @@ final class DateTimeFilterTest extends FilterTestCase
         $filter = new DateTimeFilter();
         $filter->initialize('foo');
 
-        $this->assertSame(DateTimeType::class, $filter->getFieldType());
+        self::assertSame(DateTimeType::class, $filter->getFieldType());
     }
 }

--- a/tests/Filter/DateTimeRangeFilterTest.php
+++ b/tests/Filter/DateTimeRangeFilterTest.php
@@ -32,8 +32,8 @@ final class DateTimeRangeFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testGetType(): void
@@ -41,6 +41,6 @@ final class DateTimeRangeFilterTest extends FilterTestCase
         $filter = new DateTimeRangeFilter();
         $filter->initialize('foo');
 
-        $this->assertSame(DateTimeRangeType::class, $filter->getFieldType());
+        self::assertSame(DateTimeRangeType::class, $filter->getFieldType());
     }
 }

--- a/tests/Filter/EmptyFilterTest.php
+++ b/tests/Filter/EmptyFilterTest.php
@@ -31,8 +31,8 @@ final class EmptyFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     /**
@@ -47,12 +47,12 @@ final class EmptyFilterTest extends FilterTestCase
         ]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value]));
 
-        $this->assertSameQuery([$expectedQuery], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery([$expectedQuery], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testRenderSettings(): void
@@ -63,7 +63,7 @@ final class EmptyFilterTest extends FilterTestCase
         ]);
         $options = $filter->getRenderSettings()[1];
 
-        $this->assertSame(BooleanType::class, $options['field_type']);
+        self::assertSame(BooleanType::class, $options['field_type']);
     }
 
     /**

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -46,7 +46,7 @@ final class FilterTest extends FilterTestCase
             )
             ->setParameter('parameter_1', 3);
 
-        $this->assertSame('SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)', $queryBuilder->getDQL());
+        self::assertSame('SELECT e FROM MyEntity e WHERE 1 = 2 AND (:parameter_1 = 4 OR 5 = 6)', $queryBuilder->getDQL());
 
         $proxyQuery = new ProxyQuery($queryBuilder);
 
@@ -64,7 +64,7 @@ final class FilterTest extends FilterTestCase
         // More custom conditions set after the filters.
         $queryBuilder->andWhere($queryBuilder->expr()->eq(7, 8));
 
-        $this->assertSame($expected, $queryBuilder->getDQL());
+        self::assertSame($expected, $queryBuilder->getDQL());
     }
 
     /**

--- a/tests/Filter/FilterTestCase.php
+++ b/tests/Filter/FilterTestCase.php
@@ -32,7 +32,7 @@ abstract class FilterTestCase extends TestCase
             throw new \InvalidArgumentException('The query builder should be build with "createQueryBuilderStub()".');
         }
 
-        $this->assertSame($expected, $queryBuilder->query);
+        self::assertSame($expected, $queryBuilder->query);
     }
 
     /**
@@ -45,7 +45,7 @@ abstract class FilterTestCase extends TestCase
             throw new \InvalidArgumentException('The query builder should be build with "createQueryBuilderStub()".');
         }
 
-        $this->assertSame($expected, $queryBuilder->queryParameters);
+        self::assertSame($expected, $queryBuilder->queryParameters);
     }
 
     final protected function createQueryBuilderStub(): TestQueryBuilder

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -30,8 +30,8 @@ final class ModelFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilterArray(): void
@@ -47,9 +47,9 @@ final class ModelFilterTest extends FilterTestCase
         ]));
 
         // the alias is now computer by the entityJoin method
-        $this->assertSameQuery(['WHERE alias IN :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias IN :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterArrayTypeIsNotEqual(): void
@@ -65,12 +65,12 @@ final class ModelFilterTest extends FilterTestCase
         ]));
 
         // the alias is now computer by the entityJoin method
-        $this->assertSameQuery(
+        self::assertSameQuery(
             ['WHERE alias NOT IN :field_name_0 OR IDENTITY('.current(($proxyQuery->getRootAliases())).'.field_name) IS NULL'],
             $proxyQuery
         );
-        $this->assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQueryParameters(['field_name_0' => ['1', '2']], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterScalar(): void
@@ -82,9 +82,9 @@ final class ModelFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 2]));
 
-        $this->assertSameQuery(['WHERE alias IN :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => [2]], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias IN :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => [2]], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testFilterScalarTypeIsNotEqual(): void
@@ -96,13 +96,13 @@ final class ModelFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => EqualOperatorType::TYPE_NOT_EQUAL, 'value' => 2]));
 
-        $this->assertSameQuery(
+        self::assertSameQuery(
             ['WHERE alias NOT IN :field_name_0 OR IDENTITY('.current(($proxyQuery->getRootAliases())).'.field_name) IS NULL'],
             $proxyQuery
         );
 
-        $this->assertSameQueryParameters(['field_name_0' => [2]], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQueryParameters(['field_name_0' => [2]], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testAssociationWithInvalidMapping(): void
@@ -127,7 +127,7 @@ final class ModelFilterTest extends FilterTestCase
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
 
         $filter->apply($proxyQuery, FilterData::fromArray(['value' => 'asd']));
-        $this->assertTrue($filter->isActive());
+        self::assertTrue($filter->isActive());
     }
 
     public function testAssociationWithValidMapping(): void
@@ -145,11 +145,11 @@ final class ModelFilterTest extends FilterTestCase
 
         $filter->apply($proxyQuery, FilterData::fromArray(['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 'asd']));
 
-        $this->assertSameQuery([
+        self::assertSameQuery([
             'LEFT JOIN o.association_mapping AS s_association_mapping',
             'WHERE s_association_mapping IN :field_name_0',
         ], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertTrue($filter->isActive());
     }
 
     public function testAssociationWithValidParentAssociationMappings(): void
@@ -175,12 +175,12 @@ final class ModelFilterTest extends FilterTestCase
 
         $filter->apply($proxyQuery, FilterData::fromArray(['type' => EqualOperatorType::TYPE_EQUAL, 'value' => 'asd']));
 
-        $this->assertSameQuery([
+        self::assertSameQuery([
             'LEFT JOIN o.association_mapping AS s_association_mapping',
             'LEFT JOIN s_association_mapping.sub_association_mapping AS s_association_mapping_sub_association_mapping',
             'LEFT JOIN s_association_mapping_sub_association_mapping.sub_sub_association_mapping AS s_association_mapping_sub_association_mapping_sub_sub_association_mapping',
             'WHERE s_association_mapping_sub_association_mapping_sub_sub_association_mapping IN :field_name_0',
         ], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/NullFilterTest.php
+++ b/tests/Filter/NullFilterTest.php
@@ -31,8 +31,8 @@ final class NullFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     /**
@@ -47,12 +47,12 @@ final class NullFilterTest extends FilterTestCase
         ]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value]));
 
-        $this->assertSameQuery([$expectedQuery], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery([$expectedQuery], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testRenderSettings(): void
@@ -63,7 +63,7 @@ final class NullFilterTest extends FilterTestCase
         ]);
         $options = $filter->getRenderSettings()[1];
 
-        $this->assertSame(BooleanType::class, $options['field_type']);
+        self::assertSame(BooleanType::class, $options['field_type']);
     }
 
     /**

--- a/tests/Filter/NumberFilterTest.php
+++ b/tests/Filter/NumberFilterTest.php
@@ -29,8 +29,8 @@ final class NumberFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilterInvalidOperator(): void
@@ -42,8 +42,8 @@ final class NumberFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['type' => 42]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilter(): void
@@ -69,7 +69,7 @@ final class NumberFilterTest extends FilterTestCase
             'WHERE alias.field = :field_name_5',
         ];
 
-        $this->assertSameQuery($expected, $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery($expected, $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 }

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -293,7 +293,6 @@ final class StringFilterTest extends FilterTestCase
     public function caseSensitiveDataProvider(): iterable
     {
         yield [[], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
-        yield [['force_case_insensitivity' => null], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
         yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_CONTAINS, 'WHERE alias.field LIKE :field_name_0', '%FooBar%'];
         yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_NOT_CONTAINS, 'WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL', '%FooBar%'];
         yield [['force_case_insensitivity' => false], StringOperatorType::TYPE_EQUAL, 'WHERE alias.field = :field_name_0', 'FooBar'];

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -24,11 +24,11 @@ final class StringFilterTest extends FilterTestCase
     {
         $filter = new StringFilter();
         $filter->initialize('field_name', []);
-        $this->assertTrue($filter->isSearchEnabled());
+        self::assertTrue($filter->isSearchEnabled());
 
         $filter = new StringFilter();
         $filter->initialize('field_name', ['global_search' => false]);
-        $this->assertFalse($filter->isSearchEnabled());
+        self::assertFalse($filter->isSearchEnabled());
     }
 
     public function testEmpty(): void
@@ -40,8 +40,8 @@ final class StringFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     /**
@@ -83,17 +83,17 @@ final class StringFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value, 'type' => null]));
 
         if ($shouldBeActive) {
-            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
-            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value ?? '')], $proxyQuery);
-            $this->assertTrue($filter->isActive());
+            self::assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            self::assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value ?? '')], $proxyQuery);
+            self::assertTrue($filter->isActive());
         } else {
-            $this->assertSameQuery([], $proxyQuery);
-            $this->assertFalse($filter->isActive());
+            self::assertSameQuery([], $proxyQuery);
+            self::assertFalse($filter->isActive());
         }
     }
 
@@ -106,17 +106,17 @@ final class StringFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value, 'type' => StringOperatorType::TYPE_CONTAINS]));
 
         if ($shouldBeActive) {
-            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
-            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value ?? '')], $proxyQuery);
-            $this->assertTrue($filter->isActive());
+            self::assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            self::assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value ?? '')], $proxyQuery);
+            self::assertTrue($filter->isActive());
         } else {
-            $this->assertSameQuery([], $proxyQuery);
-            $this->assertFalse($filter->isActive());
+            self::assertSameQuery([], $proxyQuery);
+            self::assertFalse($filter->isActive());
         }
     }
 
@@ -129,17 +129,17 @@ final class StringFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value, 'type' => StringOperatorType::TYPE_STARTS_WITH]));
 
         if ($shouldBeActive) {
-            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
-            $this->assertSameQueryParameters(['field_name_0' => sprintf('%s%%', $value ?? '')], $proxyQuery);
-            $this->assertTrue($filter->isActive());
+            self::assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            self::assertSameQueryParameters(['field_name_0' => sprintf('%s%%', $value ?? '')], $proxyQuery);
+            self::assertTrue($filter->isActive());
         } else {
-            $this->assertSameQuery([], $proxyQuery);
-            $this->assertFalse($filter->isActive());
+            self::assertSameQuery([], $proxyQuery);
+            self::assertFalse($filter->isActive());
         }
     }
 
@@ -152,17 +152,17 @@ final class StringFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value, 'type' => StringOperatorType::TYPE_ENDS_WITH]));
 
         if ($shouldBeActive) {
-            $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
-            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s', $value ?? '')], $proxyQuery);
-            $this->assertTrue($filter->isActive());
+            self::assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+            self::assertSameQueryParameters(['field_name_0' => sprintf('%%%s', $value ?? '')], $proxyQuery);
+            self::assertTrue($filter->isActive());
         } else {
-            $this->assertSameQuery([], $proxyQuery);
-            $this->assertFalse($filter->isActive());
+            self::assertSameQuery([], $proxyQuery);
+            self::assertFalse($filter->isActive());
         }
     }
 
@@ -175,17 +175,17 @@ final class StringFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value, 'type' => StringOperatorType::TYPE_NOT_CONTAINS]));
 
         if ($shouldBeActive) {
-            $this->assertSameQuery(['WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL'], $proxyQuery);
-            $this->assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value ?? '')], $proxyQuery);
-            $this->assertTrue($filter->isActive());
+            self::assertSameQuery(['WHERE alias.field NOT LIKE :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+            self::assertSameQueryParameters(['field_name_0' => sprintf('%%%s%%', $value ?? '')], $proxyQuery);
+            self::assertTrue($filter->isActive());
         } else {
-            $this->assertSameQuery([], $proxyQuery);
-            $this->assertFalse($filter->isActive());
+            self::assertSameQuery([], $proxyQuery);
+            self::assertFalse($filter->isActive());
         }
     }
 
@@ -198,17 +198,17 @@ final class StringFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value, 'type' => StringOperatorType::TYPE_EQUAL]));
 
         if ($shouldBeActive) {
-            $this->assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
-            $this->assertSameQueryParameters(['field_name_0' => $value ?? ''], $proxyQuery);
-            $this->assertTrue($filter->isActive());
+            self::assertSameQuery(['WHERE alias.field = :field_name_0'], $proxyQuery);
+            self::assertSameQueryParameters(['field_name_0' => $value ?? ''], $proxyQuery);
+            self::assertTrue($filter->isActive());
         } else {
-            $this->assertSameQuery([], $proxyQuery);
-            $this->assertFalse($filter->isActive());
+            self::assertSameQuery([], $proxyQuery);
+            self::assertFalse($filter->isActive());
         }
     }
 
@@ -221,17 +221,17 @@ final class StringFilterTest extends FilterTestCase
         $filter->initialize('field_name', ['allow_empty' => $allowEmpty]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value, 'type' => StringOperatorType::TYPE_NOT_EQUAL]));
 
         if ($shouldBeActive) {
-            $this->assertSameQuery(['WHERE alias.field <> :field_name_0 OR alias.field IS NULL'], $proxyQuery);
-            $this->assertSameQueryParameters(['field_name_0' => $value ?? ''], $proxyQuery);
-            $this->assertTrue($filter->isActive());
+            self::assertSameQuery(['WHERE alias.field <> :field_name_0 OR alias.field IS NULL'], $proxyQuery);
+            self::assertSameQueryParameters(['field_name_0' => $value ?? ''], $proxyQuery);
+            self::assertTrue($filter->isActive());
         } else {
-            $this->assertSameQuery([], $proxyQuery);
-            $this->assertFalse($filter->isActive());
+            self::assertSameQuery([], $proxyQuery);
+            self::assertFalse($filter->isActive());
         }
     }
 
@@ -254,18 +254,18 @@ final class StringFilterTest extends FilterTestCase
         ]);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->apply($proxyQuery, FilterData::fromArray(['type' => StringOperatorType::TYPE_EQUAL, 'value' => 'asd']));
 
-        $this->assertSameQuery([
+        self::assertSameQuery([
             'LEFT JOIN o.association_mapping AS s_association_mapping',
             'LEFT JOIN s_association_mapping.sub_association_mapping AS s_association_mapping_sub_association_mapping',
             'LEFT JOIN s_association_mapping_sub_association_mapping.sub_sub_association_mapping AS s_association_mapping_sub_association_mapping_sub_sub_association_mapping',
             'WHERE s_association_mapping_sub_association_mapping_sub_sub_association_mapping.field_name = :field_name_0',
         ], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => 'asd'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQueryParameters(['field_name_0' => 'asd'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     /**
@@ -279,12 +279,12 @@ final class StringFilterTest extends FilterTestCase
         $filter->initialize('field_name', $options);
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => 'FooBar', 'type' => $operatorType]));
-        $this->assertSameQuery([$expectedQuery], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => $expectedParameter], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery([$expectedQuery], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => $expectedParameter], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     /**

--- a/tests/Filter/StringListFilterTest.php
+++ b/tests/Filter/StringListFilterTest.php
@@ -29,8 +29,8 @@ final class StringListFilterTest extends FilterTestCase
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testFilteringWithNullReturnsArraysThatContainNull(): void
@@ -39,12 +39,12 @@ final class StringListFilterTest extends FilterTestCase
         $filter->initialize('field_name');
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => null, 'type' => null]));
-        $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => '%N;%'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => '%N;%'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     /**
@@ -56,12 +56,12 @@ final class StringListFilterTest extends FilterTestCase
         $filter->initialize('field_name');
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => 'asd', 'type' => $type]));
-        $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field LIKE :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     /**
@@ -79,12 +79,12 @@ final class StringListFilterTest extends FilterTestCase
         $filter->initialize('field_name');
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => 'asd', 'type' => ContainsOperatorType::TYPE_NOT_CONTAINS]));
-        $this->assertSameQuery(['WHERE alias.field NOT LIKE :field_name_0'], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field NOT LIKE :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     public function testEquals(): void
@@ -93,12 +93,12 @@ final class StringListFilterTest extends FilterTestCase
         $filter->initialize('field_name');
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => 'asd', 'type' => ContainsOperatorType::TYPE_EQUAL]));
-        $this->assertSameQuery(['WHERE alias.field LIKE :field_name_0 AND alias.field LIKE \'a:1:%\''], $proxyQuery);
-        $this->assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery(['WHERE alias.field LIKE :field_name_0 AND alias.field LIKE \'a:1:%\''], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => '%s:3:"asd";%'], $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     /**
@@ -114,12 +114,12 @@ final class StringListFilterTest extends FilterTestCase
         $filter->initialize('field_name');
 
         $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
-        $this->assertSameQuery([], $proxyQuery);
+        self::assertSameQuery([], $proxyQuery);
 
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => $value, 'type' => $type]));
-        $this->assertSameQuery($query, $proxyQuery);
-        $this->assertSameQueryParameters($parameters, $proxyQuery);
-        $this->assertTrue($filter->isActive());
+        self::assertSameQuery($query, $proxyQuery);
+        self::assertSameQueryParameters($parameters, $proxyQuery);
+        self::assertTrue($filter->isActive());
     }
 
     /**

--- a/tests/Filter/TimeFilterTest.php
+++ b/tests/Filter/TimeFilterTest.php
@@ -33,8 +33,8 @@ final class TimeFilterTest extends FilterTestCase
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([]));
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray(['value' => '']));
 
-        $this->assertSameQuery([], $proxyQuery);
-        $this->assertFalse($filter->isActive());
+        self::assertSameQuery([], $proxyQuery);
+        self::assertFalse($filter->isActive());
     }
 
     public function testGetType(): void
@@ -42,6 +42,6 @@ final class TimeFilterTest extends FilterTestCase
         $filter = new TimeFilter();
         $filter->initialize('foo');
 
-        $this->assertSame(TimeType::class, $filter->getFieldType());
+        self::assertSame(TimeType::class, $filter->getFieldType());
     }
 }

--- a/tests/Functional/CRUDTest.php
+++ b/tests/Functional/CRUDTest.php
@@ -38,9 +38,9 @@ final class CRUDTest extends BaseFunctionalTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/category/create');
 
         $attributeId = $crawler->filter('.category_id')->attr('name');
-        $this->assertNotNull($attributeId);
+        self::assertNotNull($attributeId);
         $attributeName = $crawler->filter('.category_name')->attr('name');
-        $this->assertNotNull($attributeName);
+        self::assertNotNull($attributeName);
 
         $this->client->submitForm('Create and return to list', [
             $attributeId => 'new id',
@@ -55,7 +55,7 @@ final class CRUDTest extends BaseFunctionalTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/category/category_novel/edit');
 
         $attributeName = $crawler->filter('.category_name')->attr('name');
-        $this->assertNotNull($attributeName);
+        self::assertNotNull($attributeName);
 
         $this->client->submitForm('Update and close', [
             $attributeName => 'edited name',

--- a/tests/Functional/EmbeddedMappingTest.php
+++ b/tests/Functional/EmbeddedMappingTest.php
@@ -36,11 +36,11 @@ final class EmbeddedMappingTest extends BasePantherTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/author/create');
 
         $attributeId = $crawler->filter('.author_id')->attr('name');
-        $this->assertNotNull($attributeId);
+        self::assertNotNull($attributeId);
         $attributeName = $crawler->filter('.author_name')->attr('name');
-        $this->assertNotNull($attributeName);
+        self::assertNotNull($attributeName);
         $attributeAddressStreet = $crawler->filter('.author_address')->attr('name');
-        $this->assertNotNull($attributeAddressStreet);
+        self::assertNotNull($attributeAddressStreet);
 
         $form = $crawler->selectButton('Create and return to list')->form();
         $form[$attributeId] = 'new_id';

--- a/tests/Functional/ManyToOneMappingTest.php
+++ b/tests/Functional/ManyToOneMappingTest.php
@@ -24,9 +24,9 @@ final class ManyToOneMappingTest extends BasePantherTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/book/create');
 
         $attributeId = $crawler->filter('.book_id')->attr('name');
-        $this->assertNotNull($attributeId);
+        self::assertNotNull($attributeId);
         $attributeName = $crawler->filter('.book_name')->attr('name');
-        $this->assertNotNull($attributeName);
+        self::assertNotNull($attributeName);
 
         $form = $crawler->selectButton('Create and return to list')->form();
         $form[$attributeId] = 'book_new_id';
@@ -51,11 +51,11 @@ final class ManyToOneMappingTest extends BasePantherTestCase
     private function createAuthorForm(Crawler $crawler): Form
     {
         $authorAttributeId = $crawler->filter('.author_id')->attr('name');
-        $this->assertNotNull($authorAttributeId);
+        self::assertNotNull($authorAttributeId);
         $authorAttributeName = $crawler->filter('.author_name')->attr('name');
-        $this->assertNotNull($authorAttributeName);
+        self::assertNotNull($authorAttributeName);
         $addressAttributeName = $crawler->filter('.author_address')->attr('name');
-        $this->assertNotNull($addressAttributeName);
+        self::assertNotNull($addressAttributeName);
 
         $authorForm = $crawler->filter('.modal-content button[name="btn_create"]')->form();
         $authorForm[$authorAttributeId] = 'Wonderful Id';

--- a/tests/Functional/SimplePagerTest.php
+++ b/tests/Functional/SimplePagerTest.php
@@ -25,6 +25,6 @@ final class SimplePagerTest extends BaseFunctionalTestCase
 
         $crawlerWithSimplePager = $this->client->request(Request::METHOD_GET, '/admin/author-with-simple-pager/list');
 
-        $this->assertCount($numberOfAuthors, $crawlerWithSimplePager->filter('.js-author-item'));
+        self::assertCount($numberOfAuthors, $crawlerWithSimplePager->filter('.js-author-item'));
     }
 }

--- a/tests/Model/AuditReaderTest.php
+++ b/tests/Model/AuditReaderTest.php
@@ -45,7 +45,7 @@ final class AuditReaderTest extends TestCase
         $id = 1;
         $revision = 2;
 
-        $this->simpleThingsAuditReader->expects($this->once())->method('find')->with($className, $id, $revision);
+        $this->simpleThingsAuditReader->expects(self::once())->method('find')->with($className, $id, $revision);
 
         $this->auditReader->find($className, $id, $revision);
     }
@@ -57,12 +57,12 @@ final class AuditReaderTest extends TestCase
         $revision = 2;
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('find')
             ->with($className, $id, $revision)
             ->willThrowException(new \Exception());
 
-        $this->assertNull($this->auditReader->find($className, $id, $revision));
+        self::assertNull($this->auditReader->find($className, $id, $revision));
     }
 
     public function testFindRevisionHistory(): void
@@ -71,7 +71,7 @@ final class AuditReaderTest extends TestCase
         $offset = 0;
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('findRevisionHistory')
             ->with($limit, $offset)
             ->willReturn([]);
@@ -83,7 +83,7 @@ final class AuditReaderTest extends TestCase
     {
         $revision = 2;
 
-        $this->simpleThingsAuditReader->expects($this->once())->method('findRevision')->with($revision);
+        $this->simpleThingsAuditReader->expects(self::once())->method('findRevision')->with($revision);
 
         $this->auditReader->findRevision(\stdClass::class, $revision);
     }
@@ -93,12 +93,12 @@ final class AuditReaderTest extends TestCase
         $revision = 2;
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('findRevision')
             ->with($revision)
             ->willThrowException(new \Exception());
 
-        $this->assertNull($this->auditReader->findRevision(\stdClass::class, $revision));
+        self::assertNull($this->auditReader->findRevision(\stdClass::class, $revision));
     }
 
     public function testFindRevisions(): void
@@ -107,7 +107,7 @@ final class AuditReaderTest extends TestCase
         $id = 2;
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('findRevisions')
             ->with($className, $id)
             ->willReturn([]);
@@ -121,12 +121,12 @@ final class AuditReaderTest extends TestCase
         $id = 2;
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('findRevisions')
             ->with($className, $id)
             ->willThrowException(new \Exception());
 
-        $this->assertSame([], $this->auditReader->findRevisions($className, $id));
+        self::assertSame([], $this->auditReader->findRevisions($className, $id));
     }
 
     public function testDiff(): void
@@ -137,7 +137,7 @@ final class AuditReaderTest extends TestCase
         $newRevision = 2;
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('diff')
             ->with($className, $id, $oldRevision, $newRevision)
             ->willReturn([]);
@@ -153,11 +153,11 @@ final class AuditReaderTest extends TestCase
         $newRevision = 2;
 
         $this->simpleThingsAuditReader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('diff')
             ->with($className, $id, $oldRevision, $newRevision)
             ->willThrowException(new \Exception());
 
-        $this->assertSame([], $this->auditReader->diff($className, $id, $oldRevision, $newRevision));
+        self::assertSame([], $this->auditReader->diff($className, $id, $oldRevision, $newRevision));
     }
 }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -72,7 +72,7 @@ final class ModelManagerTest extends TestCase
         }
     }
 
-    protected function setup(): void
+    protected function setUp(): void
     {
         $this->registry = $this->createMock(ManagerRegistry::class);
         $this->modelManager = new ModelManager($this->registry, PropertyAccess::createPropertyAccessor());
@@ -113,7 +113,7 @@ final class ModelManagerTest extends TestCase
 
         $this->registry->method('getManagerForClass')->willReturn($entityManager);
 
-        $this->assertSame(
+        self::assertSame(
             ['a7ef873a-e7b5-11e9-81b4-2a2ae2dbcce4'],
             $this->modelManager->getIdentifierValues($entity)
         );
@@ -123,11 +123,11 @@ final class ModelManagerTest extends TestCase
     {
         $em = $this->createMock(EntityManagerInterface::class);
 
-        $this->registry->expects($this->once())
+        $this->registry->expects(self::once())
             ->method('getManagerForClass')
             ->with(\stdClass::class)
             ->willReturn($em);
-        $this->assertSame($em, $this->modelManager->getEntityManager(\stdClass::class));
+        self::assertSame($em, $this->modelManager->getEntityManager(\stdClass::class));
     }
 
     /**
@@ -135,7 +135,7 @@ final class ModelManagerTest extends TestCase
      */
     public function testSupportsQuery(bool $expected, object $object): void
     {
-        $this->assertSame($expected, $this->modelManager->supportsQuery($object));
+        self::assertSame($expected, $this->modelManager->supportsQuery($object));
     }
 
     /**
@@ -171,9 +171,9 @@ final class ModelManagerTest extends TestCase
         if ($isVersioned) {
             $object->version = 123;
 
-            $this->assertNotNull($this->modelManager->getLockVersion($object));
+            self::assertNotNull($this->modelManager->getLockVersion($object));
         } else {
-            $this->assertNull($this->modelManager->getLockVersion($object));
+            self::assertNull($this->modelManager->getLockVersion($object));
         }
     }
 
@@ -200,13 +200,13 @@ final class ModelManagerTest extends TestCase
 
         $em = $this->setGetMetadataExpectation(\get_class($object), $metadata);
 
-        $em->expects($isVersioned ? $this->once() : $this->never())
+        $em->expects($isVersioned ? self::once() : self::never())
             ->method('lock');
 
         if ($expectsException) {
-            $em->expects($this->once())
+            $em->expects(self::once())
                 ->method('lock')
-                ->will($this->throwException(OptimisticLockException::lockFailed($object)));
+                ->will(self::throwException(OptimisticLockException::lockFailed($object)));
 
             $this->expectException(LockException::class);
         }
@@ -221,43 +221,43 @@ final class ModelManagerTest extends TestCase
         $entity = new UuidEntity($uuid);
 
         $meta = $this->createMock(ClassMetadata::class);
-        $meta->expects($this->any())
+        $meta->expects(self::any())
             ->method('getIdentifierValues')
             ->willReturn([$entity->getId()]);
-        $meta->expects($this->any())
+        $meta->expects(self::any())
             ->method('getTypeOfField')
             ->willReturn(UuidBinaryType::NAME); //'uuid_binary'
 
         $platform = $this->createMock(PostgreSQL94Platform::class);
-        $platform->expects($this->any())
+        $platform->expects(self::any())
             ->method('hasDoctrineTypeMappingFor')
             ->with(UuidBinaryType::NAME)
             ->willReturn(true);
-        $platform->expects($this->any())
+        $platform->expects(self::any())
             ->method('getDoctrineTypeMapping')
             ->with(UuidBinaryType::NAME)
             ->willReturn('binary');
 
         $conn = $this->createMock(Connection::class);
-        $conn->expects($this->any())
+        $conn->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->any())
+        $em->expects(self::any())
             ->method('getClassMetadata')
             ->willReturn($meta);
-        $em->expects($this->any())
+        $em->expects(self::any())
             ->method('getConnection')
             ->willReturn($conn);
 
-        $this->registry->expects($this->any())
+        $this->registry->expects(self::any())
             ->method('getManagerForClass')
             ->willReturn($em);
 
         $result = $this->modelManager->getIdentifierValues($entity);
 
-        $this->assertSame($entity->getId()->toString(), $result[0]);
+        self::assertSame($entity->getId()->toString(), $result[0]);
     }
 
     public function testNonIntegerIdentifierType(): void
@@ -266,41 +266,41 @@ final class ModelManagerTest extends TestCase
         $entity = new UuidEntity($uuid);
 
         $meta = $this->createMock(ClassMetadata::class);
-        $meta->expects($this->any())
+        $meta->expects(self::any())
             ->method('getIdentifierValues')
             ->willReturn([$entity->getId()]);
-        $meta->expects($this->any())
+        $meta->expects(self::any())
             ->method('getTypeOfField')
             ->willReturn(UuidType::NAME);
 
         $platform = $this->createMock(PostgreSQL94Platform::class);
-        $platform->expects($this->any())
+        $platform->expects(self::any())
             ->method('hasDoctrineTypeMappingFor')
             ->with(UuidType::NAME)
             ->willReturn(false);
-        $platform->expects($this->never())
+        $platform->expects(self::never())
             ->method('getDoctrineTypeMapping');
 
         $conn = $this->createMock(Connection::class);
-        $conn->expects($this->any())
+        $conn->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->any())
+        $em->expects(self::any())
             ->method('getClassMetadata')
             ->willReturn($meta);
-        $em->expects($this->any())
+        $em->expects(self::any())
             ->method('getConnection')
             ->willReturn($conn);
 
-        $this->registry->expects($this->any())
+        $this->registry->expects(self::any())
             ->method('getManagerForClass')
             ->willReturn($em);
 
         $result = $this->modelManager->getIdentifierValues($entity);
 
-        $this->assertSame($entity->getId()->toString(), $result[0]);
+        self::assertSame($entity->getId()->toString(), $result[0]);
     }
 
     public function testIntegerIdentifierType(): void
@@ -309,41 +309,41 @@ final class ModelManagerTest extends TestCase
         $entity = new Product($id, 'Some product');
 
         $meta = $this->createMock(ClassMetadata::class);
-        $meta->expects($this->any())
+        $meta->expects(self::any())
             ->method('getIdentifierValues')
             ->willReturn([$entity->getId()]);
-        $meta->expects($this->any())
+        $meta->expects(self::any())
             ->method('getTypeOfField')
             ->willReturn(ProductIdType::NAME);
 
         $platform = $this->createMock(PostgreSQL94Platform::class);
-        $platform->expects($this->any())
+        $platform->expects(self::any())
             ->method('hasDoctrineTypeMappingFor')
             ->with(ProductIdType::NAME)
             ->willReturn(false);
-        $platform->expects($this->never())
+        $platform->expects(self::never())
             ->method('getDoctrineTypeMapping');
 
         $conn = $this->createMock(Connection::class);
-        $conn->expects($this->any())
+        $conn->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->any())
+        $em->expects(self::any())
             ->method('getClassMetadata')
             ->willReturn($meta);
-        $em->expects($this->any())
+        $em->expects(self::any())
             ->method('getConnection')
             ->willReturn($conn);
 
-        $this->registry->expects($this->any())
+        $this->registry->expects(self::any())
             ->method('getManagerForClass')
             ->willReturn($em);
 
         $result = $this->modelManager->getIdentifierValues($entity);
 
-        $this->assertSame((string) $entity->getId()->getId(), $result[0]);
+        self::assertSame((string) $entity->getId()->getId(), $result[0]);
     }
 
     public function testAssociationIdentifierType(): void
@@ -351,37 +351,37 @@ final class ModelManagerTest extends TestCase
         $entity = new ContainerEntity(new AssociatedEntity(new EmbeddedEntity(), 42), new EmbeddedEntity());
 
         $meta = $this->createMock(ClassMetadata::class);
-        $meta->expects($this->any())
+        $meta->expects(self::any())
             ->method('getIdentifierValues')
             ->willReturn([$entity->getAssociatedEntity()->getPlainField()]);
-        $meta->expects($this->any())
+        $meta->expects(self::any())
             ->method('getTypeOfField')
             ->willReturn(null);
 
         $platform = $this->createMock(PostgreSQL94Platform::class);
-        $platform->expects($this->never())
+        $platform->expects(self::never())
             ->method('hasDoctrineTypeMappingFor');
 
         $conn = $this->createMock(Connection::class);
-        $conn->expects($this->any())
+        $conn->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects($this->any())
+        $em->expects(self::any())
             ->method('getClassMetadata')
             ->willReturn($meta);
-        $em->expects($this->any())
+        $em->expects(self::any())
             ->method('getConnection')
             ->willReturn($conn);
 
-        $this->registry->expects($this->any())
+        $this->registry->expects(self::any())
             ->method('getManagerForClass')
             ->willReturn($em);
 
         $result = $this->modelManager->getIdentifierValues($entity);
 
-        $this->assertSame(42, $result[0]);
+        self::assertSame(42, $result[0]);
     }
 
     public function testReverseTransform(): void
@@ -394,11 +394,11 @@ final class ModelManagerTest extends TestCase
         $classMetadata = new ClassMetadata($class);
         $classMetadata->reflClass = new \ReflectionClass($class);
 
-        $objectManager->expects($this->once())
+        $objectManager->expects(self::once())
             ->method('getClassMetadata')
             ->with($class)
             ->willReturn($classMetadata);
-        $this->registry->expects($this->once())
+        $this->registry->expects(self::once())
             ->method('getManagerForClass')
             ->with($class)
             ->willReturn($objectManager);
@@ -407,8 +407,8 @@ final class ModelManagerTest extends TestCase
             'schmeckles' => 42,
             'multi_word_property' => 'hello',
         ]);
-        $this->assertSame(42, $object->getSchmeckles());
-        $this->assertSame('hello', $object->getMultiWordProperty());
+        self::assertSame(42, $object->getSchmeckles());
+        self::assertSame('hello', $object->getMultiWordProperty());
     }
 
     public function testGetEntityManagerException(): void
@@ -425,14 +425,14 @@ final class ModelManagerTest extends TestCase
     {
         $entityManger = $this->createMock(EntityManagerInterface::class);
 
-        $this->registry->expects($this->once())
+        $this->registry->expects(self::once())
             ->method('getManagerForClass')
             ->willReturn($entityManger);
 
-        $entityManger->expects($this->once())
+        $entityManger->expects(self::once())
             ->method('persist');
 
-        $entityManger->expects($this->once())
+        $entityManger->expects(self::once())
             ->method('flush')
             ->willThrowException($exception);
 
@@ -463,14 +463,14 @@ final class ModelManagerTest extends TestCase
     {
         $entityManger = $this->createMock(EntityManagerInterface::class);
 
-        $this->registry->expects($this->once())
+        $this->registry->expects(self::once())
             ->method('getManagerForClass')
             ->willReturn($entityManger);
 
-        $entityManger->expects($this->once())
+        $entityManger->expects(self::once())
             ->method('persist');
 
-        $entityManger->expects($this->once())
+        $entityManger->expects(self::once())
             ->method('flush')
             ->willThrowException($exception);
 
@@ -486,14 +486,14 @@ final class ModelManagerTest extends TestCase
     {
         $entityManger = $this->createMock(EntityManagerInterface::class);
 
-        $this->registry->expects($this->once())
+        $this->registry->expects(self::once())
             ->method('getManagerForClass')
             ->willReturn($entityManger);
 
-        $entityManger->expects($this->once())
+        $entityManger->expects(self::once())
             ->method('remove');
 
-        $entityManger->expects($this->once())
+        $entityManger->expects(self::once())
             ->method('flush')
             ->willThrowException($exception);
 
@@ -524,29 +524,29 @@ final class ModelManagerTest extends TestCase
             ->getMock();
 
         $queryBuilder
-            ->expects($this->exactly(\count($expectedParameters)))
+            ->expects(self::exactly(\count($expectedParameters)))
             ->method('getRootAliases')
             ->willReturn(['p']);
 
         $queryBuilder
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('andWhere')
-            ->with($this->stringContains(sprintf('( p.%s = :field_', $identifierFieldNames[0])));
+            ->with(self::stringContains(sprintf('( p.%s = :field_', $identifierFieldNames[0])));
 
         $proxyQuery = new ProxyQuery($queryBuilder);
 
         $metadata = $this->createMock(ClassMetadata::class);
-        $metadata->expects($this->once())
+        $metadata->expects(self::once())
             ->method('getIdentifierFieldNames')
             ->willReturn($identifierFieldNames);
         $this->setGetMetadataExpectation(Product::class, $metadata);
 
         $this->modelManager->addIdentifiersToQuery(Product::class, $proxyQuery, $ids);
 
-        $this->assertCount(\count($expectedParameters), $proxyQuery->getQueryBuilder()->getParameters());
+        self::assertCount(\count($expectedParameters), $proxyQuery->getQueryBuilder()->getParameters());
 
         foreach ($proxyQuery->getParameters() as $offset => $parameter) {
-            $this->assertSame($expectedParameters[$offset], $parameter->getValue());
+            self::assertSame($expectedParameters[$offset], $parameter->getValue());
         }
     }
 
@@ -631,12 +631,12 @@ final class ModelManagerTest extends TestCase
     private function setGetMetadataExpectation(string $class, ClassMetadata $classMetadata): EntityManagerInterface
     {
         $em = $this->createMock(EntityManagerInterface::class);
-        $this->registry->expects($this->atLeastOnce())
+        $this->registry->expects(self::atLeastOnce())
             ->method('getManagerForClass')
             ->with($class)
             ->willReturn($em);
 
-        $em->expects($this->atLeastOnce())
+        $em->expects(self::atLeastOnce())
             ->method('getClassMetadata')
             ->with($class)
             ->willReturn($classMetadata);

--- a/tests/SonataDoctrineORMAdminBundleTest.php
+++ b/tests/SonataDoctrineORMAdminBundleTest.php
@@ -29,10 +29,10 @@ class SonataDoctrineORMAdminBundleTest extends TestCase
     {
         $containerBuilder = $this->createMock(ContainerBuilder::class);
 
-        $containerBuilder->expects($this->exactly(3))->method('addCompilerPass')->withConsecutive(
-            [$this->isInstanceOf(AddGuesserCompilerPass::class)],
-            [$this->isInstanceOf(AddTemplatesCompilerPass::class)],
-            [$this->isInstanceOf(AddAuditEntityCompilerPass::class)]
+        $containerBuilder->expects(self::exactly(3))->method('addCompilerPass')->withConsecutive(
+            [self::isInstanceOf(AddGuesserCompilerPass::class)],
+            [self::isInstanceOf(AddTemplatesCompilerPass::class)],
+            [self::isInstanceOf(AddAuditEntityCompilerPass::class)]
         );
 
         $bundle = new SonataDoctrineORMAdminBundle();

--- a/tests/Util/SmartPaginatorFactoryTest.php
+++ b/tests/Util/SmartPaginatorFactoryTest.php
@@ -40,7 +40,7 @@ final class SmartPaginatorFactoryTest extends TestCase
 
         $paginator = SmartPaginatorFactory::create($proxyQuery);
 
-        $this->assertSame($expected, $paginator->getFetchJoinCollection());
+        self::assertSame($expected, $paginator->getFetchJoinCollection());
     }
 
     /**
@@ -90,7 +90,7 @@ final class SmartPaginatorFactoryTest extends TestCase
 
         $paginator = SmartPaginatorFactory::create($proxyQuery);
 
-        $this->assertSame($expected, $paginator->getUseOutputWalkers());
+        self::assertSame($expected, $paginator->getUseOutputWalkers());
     }
 
     /**
@@ -149,8 +149,8 @@ final class SmartPaginatorFactoryTest extends TestCase
 
         SmartPaginatorFactory::create($proxyQuery);
 
-        $this->assertSame($hasHint, $query->hasHint(CountWalker::HINT_DISTINCT));
-        $this->assertSame($expected, $query->getHint(CountWalker::HINT_DISTINCT));
+        self::assertSame($hasHint, $query->hasHint(CountWalker::HINT_DISTINCT));
+        self::assertSame($expected, $query->getHint(CountWalker::HINT_DISTINCT));
     }
 
     /**


### PR DESCRIPTION
I have two issue to fix
```
 ------ --------------------------------------------------------------- 
  Line   src/Filter/ModelAutocompleteFilter.php                         
 ------ --------------------------------------------------------------- 
  89     Construct empty() is not allowed. Use more strict comparison.  
 ------ --------------------------------------------------------------- 

 ------ --------------------------------------------------------------- 
  Line   src/Filter/ModelFilter.php                                     
 ------ --------------------------------------------------------------- 
  28     Construct empty() is not allowed. Use more strict comparison.  
 ------ --------------------------------------------------------------- 
```

But I'm not sure how to replace the empty checks of `$data->getValue()`.

I never used those filter, what can be the values @sonata-project/contributors ?