### PR TITLE
In the example form docs it does not work with the serialize function

### DIFF
--- a/src/Filter/StringListFilter.php
+++ b/src/Filter/StringListFilter.php
@@ -39,7 +39,7 @@ final class StringListFilter extends Filter
             $parameterName = $this->getNewParameterName($query);
             $andConditions->add(sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
 
-            $query->getQueryBuilder()->setParameter($parameterName, '%'.serialize($item).'%');
+            $query->getQueryBuilder()->setParameter($parameterName, '%'.$item.'%');
         }
 
         if ($data->isType(ContainsOperatorType::TYPE_EQUAL)) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
When using the example from the docs on docs/reference/filter_field_definition.rst (section about the StringListFilter) it does not work with the serialize function.
When i remove it, it does work. But maybe it does need to be here for other uses of this filter?
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because not sure.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Remove serialize function form StringListFilter

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
