### PR TITLE
Fixed custom exporter DataSource service definition

### DIFF
--- a/docs/reference/data_source.rst
+++ b/docs/reference/data_source.rst
@@ -48,5 +48,6 @@ Here's one way to do it:
           ...
           App\Service\Admin\DecoratingDataSource:
               decorates: 'sonata.admin.data_source.orm'
+              arguments: ['@App\Services\Admin\DecoratingDataSource.inner']              
 
 


### PR DESCRIPTION
added arguments key, as it is required since 4.0-rc.2

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Minor docs update

<!-- Describe your Pull Request content here -->
Fixed custom exporter DataSource service definition

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.
