### PR TITLE
Remove default route in this bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/orm": "^2.8",
         "doctrine/persistence": "^2.1",
-        "sonata-project/admin-bundle": "4.x-dev as 4.0.0-rc.3",
+        "sonata-project/admin-bundle": "^4.0",
         "sonata-project/exporter": "^2.0",
         "sonata-project/form-extensions": "^1.4",
         "symfony/config": "^4.4 || ^5.2",
@@ -47,7 +47,6 @@
         "twig/twig": "^2.10 || ^3.0"
     },
     "conflict": {
-        "sonata-project/admin-bundle": "<4.0.0-rc.2",
         "sonata-project/block-bundle": "<4.2",
         "sonata-project/entity-audit-bundle": ">=2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/orm": "^2.8",
         "doctrine/persistence": "^2.1",
-        "sonata-project/admin-bundle": "^4.0@rc",
+        "sonata-project/admin-bundle": "4.x-dev as 4.0.0-rc.3",
         "sonata-project/exporter": "^2.0",
         "sonata-project/form-extensions": "^1.4",
         "symfony/config": "^4.4 || ^5.2",

--- a/src/FieldDescription/FieldDescriptionFactory.php
+++ b/src/FieldDescription/FieldDescriptionFactory.php
@@ -33,14 +33,6 @@ final class FieldDescriptionFactory implements FieldDescriptionFactoryInterface
 
     public function create(string $class, string $name, array $options = []): FieldDescriptionInterface
     {
-        if (!isset($options['route']['name'])) {
-            $options['route']['name'] = 'show';
-        }
-
-        if (!isset($options['route']['parameters'])) {
-            $options['route']['parameters'] = [];
-        }
-
         [$metadata, $propertyName, $parentAssociationMappings] = $this->getParentMetadataForProperty($class, $name);
 
         return new FieldDescription(

--- a/tests/FieldDescription/FieldDescriptionTest.php
+++ b/tests/FieldDescription/FieldDescriptionTest.php
@@ -211,13 +211,14 @@ final class FieldDescriptionTest extends TestCase
 
     public function testGetValueWhenCannotRetrieve(): void
     {
-        $this->expectException(NoValueException::class);
-
         $mockedObject = $this->getMockBuilder(\stdClass::class)->addMethods(['myMethod'])->getMock();
         $mockedObject->expects(static::never())->method('myMethod')->willReturn('myMethodValue');
 
+        $admin = $this->createStub(AdminInterface::class);
         $field = new FieldDescription('name');
+        $field->setAdmin($admin);
 
+        $this->expectException(NoValueException::class);
         static::assertSame('myMethodValue', $field->getValue($mockedObject));
     }
 


### PR DESCRIPTION
## Subject

Rely on AdminBundle

I am targeting this branch, because BC-break.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Do not set a default route option to `FieldDescription` in `FieldDescriptionFactory`
```