### PR TITLE
Deprecate ModelAutocompleteFilter

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,0 +1,20 @@
+UPGRADE 4.x
+===========
+
+UPGRADE FROM 4.x to 4.x
+=======================
+
+### Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter
+
+The `Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter` filter is deprecated.
+
+Instead of
+```php
+->add('foo', ModelAutocompleteFilter::class)
+```
+use
+```php
+->add('foo', ModelFilter::class, [
+     'field_type' => ModelAutocompleteType::class,
+])
+```

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -22,9 +22,12 @@ use Sonata\AdminBundle\Datagrid\SimplePager;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\FieldDescription\TypeGuesserInterface;
 use Sonata\AdminBundle\Filter\FilterFactoryInterface;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\Pager;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter;
+use Sonata\DoctrineORMAdminBundle\Filter\ModelFilter;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -81,7 +84,20 @@ final class DatagridBuilder implements DatagridBuilderInterface
 
         $fieldDescription->setOption('field_name', $fieldDescription->getOption('field_name', $fieldDescription->getFieldName()));
 
-        if (ModelAutocompleteFilter::class === $fieldDescription->getType()) {
+        if (
+            ModelFilter::class === $fieldDescription->getType()
+            || EntityType::class === $fieldDescription->getOption('field_type')
+        ) {
+            $fieldDescription->mergeOption('field_options', [
+                'class' => $fieldDescription->getTargetModel(),
+            ]);
+        }
+
+        // NEXT_MAJOR: Remove the ModelAutocompleteFilter::class check
+        if (
+            ModelAutocompleteFilter::class === $fieldDescription->getType()
+            || ModelAutocompleteType::class === $fieldDescription->getOption('field_type')
+        ) {
             $fieldDescription->mergeOption('field_options', [
                 'class' => $fieldDescription->getTargetModel(),
                 'model_manager' => $fieldDescription->getAdmin()->getModelManager(),

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -85,7 +85,7 @@ final class DatagridBuilder implements DatagridBuilderInterface
         $fieldDescription->setOption('field_name', $fieldDescription->getOption('field_name', $fieldDescription->getFieldName()));
 
         if (
-            ModelFilter::class === $fieldDescription->getType()
+            ModelFilter::class === $fieldDescription->getType() && null === $fieldDescription->getOption('field_type')
             || EntityType::class === $fieldDescription->getOption('field_type')
         ) {
             $fieldDescription->mergeOption('field_options', [
@@ -95,7 +95,7 @@ final class DatagridBuilder implements DatagridBuilderInterface
 
         // NEXT_MAJOR: Remove the ModelAutocompleteFilter::class check
         if (
-            ModelAutocompleteFilter::class === $fieldDescription->getType()
+            ModelAutocompleteFilter::class === $fieldDescription->getType() && null === $fieldDescription->getOption('field_type')
             || ModelAutocompleteType::class === $fieldDescription->getOption('field_type')
         ) {
             $fieldDescription->mergeOption('field_options', [

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Filter;
 
 use Doctrine\ORM\Query\Expr\Composite;
-use Doctrine\ORM\Query\Expr\Orx;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter as BaseFilter;
 use Sonata\AdminBundle\Filter\Model\FilterData;
@@ -126,8 +125,6 @@ abstract class Filter extends BaseFilter implements GroupableConditionAwareInter
      */
     private function addOrParameter(ProxyQueryInterface $query, $parameter): void
     {
-        $conditionGroup = null;
-
         if ($this->hasPreviousFilter()) {
             $previousFilter = $this->getPreviousFilter();
 

--- a/src/Filter/ModelAutocompleteFilter.php
+++ b/src/Filter/ModelAutocompleteFilter.php
@@ -20,6 +20,12 @@ use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 
+/**
+ * NEXT_MAJOR: Remove this filter.
+ *
+ * @deprecated since sonata-project/doctrine-orm-admin-bundle version 4.x and will be removed in 5.0.
+ *             use the ModelFilter instead with the option `'field_type' => ModelAutocompleteType::class`
+ */
 final class ModelAutocompleteFilter extends Filter
 {
     public function filter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void

--- a/src/Resources/config/doctrine_orm_filter_types.xml
+++ b/src/Resources/config/doctrine_orm_filter_types.xml
@@ -28,6 +28,7 @@
         <service id="sonata.admin.orm.filter.type.datetime_range" class="Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter">
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_datetime_range"/>
         </service>
+        <!-- NEXT_MAJOR: Remove the sonata.admin.orm.filter.type.model_autocomplete service -->
         <service id="sonata.admin.orm.filter.type.model_autocomplete" class="Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter">
             <tag name="sonata.admin.filter.type" alias="doctrine_orm_model_autocomplete"/>
         </service>

--- a/tests/App/Admin/BookAdmin.php
+++ b/tests/App/Admin/BookAdmin.php
@@ -17,7 +17,9 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\DoctrineORMAdminBundle\Filter\ModelFilter;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
@@ -37,7 +39,10 @@ final class BookAdmin extends AbstractAdmin
     protected function configureDatagridFilters(DatagridMapper $filter): void
     {
         $filter
-            ->add('author')
+            ->add('author', ModelFilter::class, [
+                'field_type' => ModelAutocompleteType::class,
+                'field_options' => ['property' => 'name'],
+            ])
             ->add('categories');
     }
 

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -29,7 +29,7 @@ use Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy;
 use Sonata\DoctrineORMAdminBundle\Builder\DatagridBuilder;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineORMAdminBundle\FieldDescription\FieldDescription;
-use Sonata\DoctrineORMAdminBundle\Filter\ModelAutocompleteFilter;
+use Sonata\DoctrineORMAdminBundle\Filter\ModelFilter;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Guess\TypeGuess;
@@ -161,11 +161,11 @@ final class DatagridBuilderTest extends TestCase
         $this->admin->method('getCode')->willReturn('someFakeCode');
         $this->admin->method('getLabelTranslatorStrategy')->willReturn(new FormLabelTranslatorStrategy());
         $this->typeGuesser->method('guess')->willReturn($guessType);
-        $this->filterFactory->method('create')->willReturn(new ModelAutocompleteFilter());
+        $this->filterFactory->method('create')->willReturn(new ModelFilter());
 
         $guessType->method('getOptions')->willReturn(['name' => 'value']);
-        $guessType->method('getType')->willReturn(ModelAutocompleteFilter::class);
-        $datagrid->method('addFilter')->with(static::isInstanceOf(ModelAutocompleteFilter::class));
+        $guessType->method('getType')->willReturn(ModelFilter::class);
+        $datagrid->method('addFilter')->with(static::isInstanceOf(ModelFilter::class));
 
         $this->datagridBuilder->addFilter($datagrid, null, $fieldDescription);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

Closes #1513.
Closes #1526.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `field_options` are automatically passed to the Filter when an `EntityType` or a `ModelAutocompleteType` is used.

### Deprecated
- `ModelAutocompleteFilter` in favor of `ModelFilter` with a `field_type` `ModelAutocompleteType`
```