### PR TITLE
Reduce visibility from getEntityManager

### DIFF
--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -26,10 +26,13 @@ use Twig\Environment;
 final class AuditBlockService extends AbstractBlockService
 {
     /**
-     * @var AuditReader
+     * @var AuditReader<object>
      */
     private $auditReader;
 
+    /**
+     * @param AuditReader<object> $auditReader
+     */
     public function __construct(Environment $twig, AuditReader $auditReader)
     {
         parent::__construct($twig);

--- a/src/Model/AuditReader.php
+++ b/src/Model/AuditReader.php
@@ -18,13 +18,21 @@ use SimpleThings\EntityAudit\Revision as EntityAuditRevision;
 use Sonata\AdminBundle\Model\AuditReaderInterface;
 use Sonata\AdminBundle\Model\Revision;
 
+/**
+ * @phpstan-template T of object
+ * @phpstan-implements AuditReaderInterface<T>
+ */
 final class AuditReader implements AuditReaderInterface
 {
     /**
-     * @var SimpleThingsAuditReader
+     * @var SimpleThingsAuditReader<object>
+     * @phpstan-var SimpleThingsAuditReader<T>
      */
     private $auditReader;
 
+    /**
+     * @phpstan-param SimpleThingsAuditReader<T> $auditReader
+     */
     public function __construct(SimpleThingsAuditReader $auditReader)
     {
         $this->auditReader = $auditReader;

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -167,6 +167,8 @@ final class ModelManager implements ModelManagerInterface, LockInterface
     }
 
     /**
+     * NEXT_MAJOR: Change the visibility to private.
+     *
      * @param string|object $class
      *
      * @phpstan-param class-string|object $class

--- a/tests/Block/AuditBlockServiceTest.php
+++ b/tests/Block/AuditBlockServiceTest.php
@@ -27,7 +27,7 @@ use Sonata\DoctrineORMAdminBundle\Block\AuditBlockService;
 final class AuditBlockServiceTest extends BlockServiceTestCase
 {
     /**
-     * @var SimpleThingsAuditReader&MockObject
+     * @var SimpleThingsAuditReader<object>&MockObject
      */
     private $simpleThingsAuditReader;
 

--- a/tests/Model/AuditReaderTest.php
+++ b/tests/Model/AuditReaderTest.php
@@ -24,12 +24,12 @@ use Sonata\DoctrineORMAdminBundle\Model\AuditReader;
 final class AuditReaderTest extends TestCase
 {
     /**
-     * @var MockObject&SimpleThingsAuditReader
+     * @var MockObject&SimpleThingsAuditReader<object>
      */
     private $simpleThingsAuditReader;
 
     /**
-     * @var AuditReader
+     * @var AuditReader<object>
      */
     private $auditReader;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject


## Changelog

```markdown
### Deprecated
- Calling `ModelManager::getEntityManager()`
```