### PR TITLE
Allow doctrine/dbal 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "doctrine/dbal": "^2.13",
+        "doctrine/dbal": "^2.13 || ^3.1",
         "doctrine/doctrine-bundle": "^2.3",
-        "doctrine/orm": "^2.8",
+        "doctrine/orm": "^2.10",
         "doctrine/persistence": "^2.1",
         "sonata-project/admin-bundle": "^4.0",
         "sonata-project/exporter": "^2.0",


### PR DESCRIPTION
## Subject
This allows doctrine/dbal 3.1. breaking changes do not affect us.

## Todos

- [ ]  A Release with https://github.com/sonata-project/EntityAuditBundle/pull/444

## Changelog
```markdown
### Added
- Added support for Doctrine DBAL 3.1.
```

## Closes

https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1548