### PR TITLE
Remove deprecations on Symfony 5.4

### DIFF
--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -31,6 +31,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\RouteCollectionBuilder;
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
 
 final class AppKernel extends Kernel
 {
@@ -41,7 +42,7 @@ final class AppKernel extends Kernel
         parent::__construct('test', true);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [
             new DoctrineBundle(),
@@ -87,7 +88,13 @@ final class AppKernel extends Kernel
     protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config/config.yml');
-        $loader->load(__DIR__.'/config/security.yml');
+
+        if (class_exists(AuthenticatorManager::class)) {
+            $loader->load(__DIR__.'/config/config_symfony_v5.yml');
+        } else {
+            $loader->load(__DIR__.'/config/config_symfony_v4.yml');
+        }
+
         $loader->load(__DIR__.'/config/services.php');
     }
 

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -4,10 +4,6 @@ framework:
     form:
         enabled: true
     secret: '%env(APP_SECRET)%'
-    session:
-        handler_id: session.handler.native_file
-        storage_id: session.storage.mock_file
-        name: MOCKSESSID
     test: true
     translator:
         enabled: true

--- a/tests/App/config/config_symfony_v4.yml
+++ b/tests/App/config/config_symfony_v4.yml
@@ -1,0 +1,8 @@
+framework:
+    session:
+        storage_id: session.storage.mock_file
+
+security:
+    firewalls:
+        main:
+            anonymous: true

--- a/tests/App/config/config_symfony_v5.yml
+++ b/tests/App/config/config_symfony_v5.yml
@@ -1,0 +1,11 @@
+framework:
+    session:
+        storage_factory_id: session.storage.factory.mock_file
+    router:
+        utf8: true
+
+security:
+    enable_authenticator_manager: true
+    firewalls:
+        main:
+            lazy: true

--- a/tests/App/config/security.yml
+++ b/tests/App/config/security.yml
@@ -1,7 +1,0 @@
-security:
-    providers:
-        in_memory:
-            memory: null
-    firewalls:
-        main:
-            anonymous: true

--- a/tests/Fixtures/Query/FooWalker.php
+++ b/tests/Fixtures/Query/FooWalker.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Query\SqlWalker;
 
 final class FooWalker extends SqlWalker
 {
-    public function walkOrderByClause($orderByClause)
+    public function walkOrderByClause($orderByClause): string
     {
         return str_replace(' ASC', ' DESC', parent::walkOrderByClause($orderByClause));
     }

--- a/tests/Functional/BasePantherTestCase.php
+++ b/tests/Functional/BasePantherTestCase.php
@@ -27,7 +27,7 @@ abstract class BasePantherTestCase extends PantherTestCase
     protected function setUp(): void
     {
         $this->client = static::createPantherClient([
-            'browser' => PantherTestCase::FIREFOX,
+            'browser' => PantherTestCase::CHROME,
             'connection_timeout_in_ms' => 5000,
             'request_timeout_in_ms' => 60000,
         ]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
