### PR TITLE
Paginator with useOutputWalkers=false allows query with joins (#1583) (Backport commit from 4.x to 3.x) 

### DIFF
--- a/src/Util/SmartPaginatorFactory.php
+++ b/src/Util/SmartPaginatorFactory.php
@@ -58,7 +58,7 @@ final class SmartPaginatorFactory
         $hasHavingPart = null !== $queryBuilder->getDQLPart('having');
 
         // it is only safe to disable output walkers for really simple queries
-        if (!$hasHavingPart && !$hasJoins && $hasSingleIdentifierName) {
+        if (!$hasHavingPart && $hasSingleIdentifierName) {
             $paginator->setUseOutputWalkers(false);
         }
 

--- a/tests/Util/SmartPaginatorFactoryTest.php
+++ b/tests/Util/SmartPaginatorFactoryTest.php
@@ -119,7 +119,7 @@ final class SmartPaginatorFactoryTest extends TestCase
                 ->createQueryBuilder()
                 ->from(Author::class, 'author')
                 ->leftJoin('author.books', 'book'),
-            null,
+            false,
         ];
 
         yield 'With joins and composite identifier' => [


### PR DESCRIPTION
(cherry picked from commit 77cd79f925d069435593ca72599a2e4cf1b3b8df)

PR description: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1583

Since the new paginator was introduced in 3.x I have backported this fix via git cherry-pick as suggested by https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1583#issuecomment-977863640

I hope this is what you meant when you told me to backport it, if not please correct me in the comments

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Paginator set useOutputWalkers to false for query with joins
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
