### PR TITLE
Fix overriding the built-in form theme

### DIFF
--- a/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
@@ -61,7 +61,7 @@ final class AddTemplatesCompilerPass implements CompilerPassInterface
                     continue;
                 }
 
-                $call = [array_merge($call[0], $value)];
+                $call = [array_merge($value, $call[0])];
             }
         }
 

--- a/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
@@ -42,7 +42,7 @@ final class AddTemplatesCompilerPassTest extends TestCase
         $compilerPass->process($container);
 
         $expected = [
-            ['setFilterTheme', [['custom_call.twig.html', '@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig']]],
+            ['setFilterTheme', [['@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig', 'custom_call.twig.html']]],
             ['setFormTheme', [['@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig']]],
         ];
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
Right now overriding the default form theme is not possible using the `sonata_admin.templates.form_theme`
config paramater because `@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig` will always be the last one
(and because it extends `@SonataAdmin/Form/form_admin_fields.html.twig` my theme is useless).

I am targeting this branch, because https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1421.


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Overrideing the built-in form and filter theme
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
