### PR TITLE
Added an example to filter with custom values

### DIFF
--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -254,7 +254,7 @@ ChoiceFilter
         {
             $datagrid
                 ->add('title')
-                ->add('state',   ChoiceFilter::class, [
+                ->add('state', ChoiceFilter::class, [
                     'label' => 'State',
                     'field_type' => ChoiceType::class,
                     'field_options' => [

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -261,7 +261,8 @@ ChoiceFilter
                         'choices' => [
                             'new' => 'new',
                             'open' => 'open',
-                            'closed' => 'closed'],                        
+                            'closed' => 'closed',
+                        ],                        
                     ]
                 ])
             ;

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -237,6 +237,7 @@ The ``inverse`` option can be used to filter values that are not empty.
 
 ChoiceFilter
 -----------
+
 ``Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter`` supports filtering for custom values::
 
     // src/Admin/BlogPostAdmin.php

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -263,7 +263,7 @@ ChoiceFilter
                             'open' => 'open',
                             'closed' => 'closed',
                         ],                        
-                    ]
+                    ],
                 ])
             ;
         }

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -235,6 +235,38 @@ EmptyFilter
 
 The ``inverse`` option can be used to filter values that are not empty.
 
+ChoiceFilter
+-----------
+``Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter`` supports filtering for custom values::
+
+    // src/Admin/BlogPostAdmin.php
+
+    namespace App\Admin;
+
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter;
+    use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+    final class BlogPostAdmin extends AbstractAdmin
+    {
+        protected function configureDatagridFilters(DatagridMapper $datagrid): void
+        {
+            $datagrid
+                ->add('title')
+                ->add('state',   ChoiceFilter::class, [
+                    'label' => 'State',
+                    'field_type' => ChoiceType::class,
+                    'field_options' => [
+                        'choices' => [
+                            'new' => 'new',
+                            'open' => 'open',
+                            'closed' => 'closed'],                        
+                    ]
+                ])
+            ;
+        }
+    }
+
 Advanced usage
 --------------
 

--- a/docs/reference/filter_field_definition.rst
+++ b/docs/reference/filter_field_definition.rst
@@ -236,7 +236,7 @@ EmptyFilter
 The ``inverse`` option can be used to filter values that are not empty.
 
 ChoiceFilter
------------
+------------
 
 ``Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter`` supports filtering for custom values::
 


### PR DESCRIPTION
## New example for the filter section in the docs

While upgrading to 4.x, I couldn't find any example to replace 'doctrine_orm_choice', I think an example could be a nice addition to the docs.

I am targeting this branch, because this is a feature ? (Really not sure here)

- [x] Update the documentation;

