### PR TITLE
Fix detection of output walkers in pagination

### DIFF
--- a/src/Util/SmartPaginatorFactory.php
+++ b/src/Util/SmartPaginatorFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Util;
 
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
@@ -60,13 +61,91 @@ final class SmartPaginatorFactory
         // To stay safe fetch join only when we have single primary key and joins
         $paginator = new Paginator($query, $hasSingleIdentifierName && $hasJoins);
 
-        $hasHavingPart = null !== $queryBuilder->getDQLPart('having');
-
         // it is only safe to disable output walkers for really simple queries
-        if (!$hasHavingPart && $hasSingleIdentifierName) {
+        if (self::canDisableOutPutWalkers($queryBuilder)) {
             $paginator->setUseOutputWalkers(false);
         }
 
         return $paginator;
+    }
+
+    /**
+     * @see https://github.com/doctrine/orm/issues/8278#issue-705517756
+     */
+    private static function canDisableOutPutWalkers(QueryBuilder $queryBuilder): bool
+    {
+        // does not support queries using HAVING
+        if (null !== $queryBuilder->getDQLPart('having')) {
+            return false;
+        }
+
+        $fromParts = $queryBuilder->getDQLPart('from');
+
+        // does not support queries using multiple entities in FROM
+        if (1 !== \count($fromParts)) {
+            return false;
+        }
+
+        $fromPart = current($fromParts);
+
+        $classMetadata = $queryBuilder
+            ->getEntityManager()
+            ->getClassMetadata($fromPart->getFrom());
+
+        $identifierFieldNames = $classMetadata->getIdentifierFieldNames();
+
+        // does not support entities using a composite identifier
+        if (1 !== \count($identifierFieldNames)) {
+            return false;
+        }
+
+        $identifierName = current($identifierFieldNames);
+
+        // does not support entities using a foreign key as identifier
+        if ($classMetadata->hasAssociation($identifierName)) {
+            return false;
+        }
+
+        // does not support queries using a field from a toMany relation in the ORDER BY clause
+        if (self::hasOrderByWithToManyAssociation($queryBuilder)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function hasOrderByWithToManyAssociation(QueryBuilder $queryBuilder): bool
+    {
+        $joinParts = $queryBuilder->getDQLPart('join');
+
+        if (0 === \count($joinParts)) {
+            return false;
+        }
+
+        $orderByParts = $queryBuilder->getDQLPart('orderBy');
+
+        if (0 === \count($orderByParts)) {
+            return false;
+        }
+
+        $joinAliases = [];
+
+        foreach ($joinParts as $joinPart) {
+            foreach ($joinPart as $join) {
+                $joinAliases[] = $join->getAlias();
+            }
+        }
+
+        foreach ($orderByParts as $orderByPart) {
+            foreach ($orderByPart->getParts() as $part) {
+                foreach ($joinAliases as $joinAlias) {
+                    if (0 === strpos($part, $joinAlias.'.')) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/App/Entity/ProductAttribute.php
+++ b/tests/App/Entity/ProductAttribute.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class ProductAttribute
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Product")
+     *
+     * @var Product
+     */
+    private $product;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $name;
+
+    public function __construct(Product $product, string $name)
+    {
+        $this->product = $product;
+        $this->name = $name;
+    }
+
+    public function getProduct(): Product
+    {
+        return $this->product;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Util/SmartPaginatorFactoryTest.php
+++ b/tests/Util/SmartPaginatorFactoryTest.php
@@ -17,8 +17,10 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Address;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Item;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\ProductAttribute;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\TestEntityManagerFactory;
 use Sonata\DoctrineORMAdminBundle\Util\SmartPaginatorFactory;
 
@@ -127,6 +129,48 @@ final class SmartPaginatorFactoryTest extends TestCase
                 ->createQueryBuilder()
                 ->from(Item::class, 'item')
                 ->leftJoin('item.product', 'product'),
+            null,
+        ];
+
+        yield 'With order by not from join field' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(Author::class, 'author')
+                ->leftJoin('author.books', 'book')
+                ->orderBy('author.name'),
+            false,
+        ];
+
+        yield 'With order by not from join field using an alias contained in order by' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(Author::class, 'author')
+                ->leftJoin('author.books', 'a')
+                ->orderBy('author.name'),
+            false,
+        ];
+
+        yield 'With order by from join field' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(Author::class, 'author')
+                ->leftJoin('author.books', 'book')
+                ->orderBy('book.title'),
+            null,
+        ];
+
+        yield 'With foreign key as identifier' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(ProductAttribute::class, 'productAttribute'),
+            null,
+        ];
+
+        yield 'With multiple FROM' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(Author::class, 'author')
+                ->from(Address::class, 'address'),
             null,
         ];
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

After https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1583, queries with an order by using a field from a join association failed throwing an `RuntimeException`. So something like:

```php
->createQueryBuilder()
->from(Author::class, 'author')
->leftJoin('author.books', 'book')
->orderBy('book.title')
```

results in:

```
"Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers."
```

This PR tries to disable output walkers when possible according to https://github.com/doctrine/orm/issues/8278#issue-705517756.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Disabling output walkers when paginating with order by from an association
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
