### PR TITLE
Fix detection of use of output walkers in pagination (#1616) (Backport commit from 4.x to 3.x) 

### DIFF
--- a/tests/App/Entity/ProductAttribute.php
+++ b/tests/App/Entity/ProductAttribute.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class ProductAttribute
+{
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Product")
+     *
+     * @var Product
+     */
+    private $product;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $name;
+
+    public function __construct(Product $product, string $name)
+    {
+        $this->product = $product;
+        $this->name = $name;
+    }
+
+    public function getProduct(): Product
+    {
+        return $this->product;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Util/SmartPaginatorFactoryTest.php
+++ b/tests/Util/SmartPaginatorFactoryTest.php
@@ -17,8 +17,10 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Address;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Item;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\ProductAttribute;
 use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\TestEntityManagerFactory;
 use Sonata\DoctrineORMAdminBundle\Util\SmartPaginatorFactory;
 
@@ -127,6 +129,48 @@ final class SmartPaginatorFactoryTest extends TestCase
                 ->createQueryBuilder()
                 ->from(Item::class, 'item')
                 ->leftJoin('item.product', 'product'),
+            null,
+        ];
+
+        yield 'With order by not from join field' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(Author::class, 'author')
+                ->leftJoin('author.books', 'book')
+                ->orderBy('author.name'),
+            false,
+        ];
+
+        yield 'With order by not from join field using an alias contained in order by' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(Author::class, 'author')
+                ->leftJoin('author.books', 'a')
+                ->orderBy('author.name'),
+            false,
+        ];
+
+        yield 'With order by from join field' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(Author::class, 'author')
+                ->leftJoin('author.books', 'book')
+                ->orderBy('book.title'),
+            null,
+        ];
+
+        yield 'With foreign key as identifier' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(ProductAttribute::class, 'productAttribute'),
+            null,
+        ];
+
+        yield 'With multiple FROM' => [
+            TestEntityManagerFactory::create()
+                ->createQueryBuilder()
+                ->from(Author::class, 'author')
+                ->from(Address::class, 'address'),
             null,
         ];
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

(cherry picked from commit 2b95684e6368b2dcd3f5efb235f89626455fc72b)

PR description: #[1616](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1616)

I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Disabling output walkers when paginating with order by from an association
```