### PR TITLE
Add support for the `model_class` attribute & fix compiler pass argument error

### DIFF
--- a/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -48,6 +48,7 @@ final class AddAuditEntityCompilerPass implements CompilerPassInterface
             }
 
             $definition = $container->getDefinition($id);
+            // NEXT_MAJOR: Support only model_class and remove indexed argument support
             $modelClass = $attributes[0]['model_class'] ?? $definition->getArgument(1);
             $auditedEntities[] = $this->getModelName($container, $modelClass);
         }

--- a/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php
@@ -48,7 +48,8 @@ final class AddAuditEntityCompilerPass implements CompilerPassInterface
             }
 
             $definition = $container->getDefinition($id);
-            $auditedEntities[] = $this->getModelName($container, $definition->getArgument(1));
+            $modelClass = $attributes[0]['model_class'] ?? $definition->getArgument(1);
+            $auditedEntities[] = $this->getModelName($container, $modelClass);
         }
 
         $auditedEntities = array_unique($auditedEntities);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a backwards compatible change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes

```
In Definition.php line 321:
                                                                                               
  [Symfony\Component\DependencyInjection\Exception\OutOfBoundsException]                       
  The argument "1" doesn't exist in class "My\Sonata\AdminClass".  
                                                                                               

Exception trace:
  at /src/application/core/vendor/symfony/dependency-injection/Definition.php:321
 Symfony\Component\DependencyInjection\Definition->getArgument() at /src/application/core/vendor/sonata-project/doctrine-orm-admin-bundle/src/DependencyInjection/Compiler/AddAuditEntityCompilerPass.php:52
 Sonata\DoctrineORMAdminBundle\DependencyInjection\Compiler\AddAuditEntityCompilerPass->process() at /src/application/core/vendor/symfony/dependency-injection/Compiler/Compiler.php:82
```

When using the `model_class` tag attribute, rather than using explicit indexed arguments.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Support for the `model_class` attribute for sonata admin classes in `AddAuditEntityCompilerPass`.
```
