### PR TITLE
Fix pagination with ToMany sort set at ProxyQuery

### DIFF
--- a/src/Util/SmartPaginatorFactory.php
+++ b/src/Util/SmartPaginatorFactory.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineORMAdminBundle\Util;
 
-use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;

--- a/src/Util/SmartPaginatorFactory.php
+++ b/src/Util/SmartPaginatorFactory.php
@@ -122,8 +122,9 @@ final class SmartPaginatorFactory
         }
 
         $sortBy = $proxyQuery->getSortBy();
+        $orderByParts = $queryBuilder->getDQLPart('orderBy');
 
-        if (null === $sortBy) {
+        if (null === $sortBy && 0 === \count($orderByParts)) {
             return false;
         }
 
@@ -135,9 +136,21 @@ final class SmartPaginatorFactory
             }
         }
 
-        foreach ($joinAliases as $joinAlias) {
-            if (0 === strpos($sortBy, $joinAlias.'.')) {
-                return true;
+        if (null !== $sortBy) {
+            foreach ($joinAliases as $joinAlias) {
+                if (0 === strpos($sortBy, $joinAlias.'.')) {
+                    return true;
+                }
+            }
+        }
+
+        foreach ($orderByParts as $orderByPart) {
+            foreach ($orderByPart->getParts() as $part) {
+                foreach ($joinAliases as $joinAlias) {
+                    if (0 === strpos($part, $joinAlias.'.')) {
+                        return true;
+                    }
+                }
             }
         }
 

--- a/tests/Util/SmartPaginatorFactoryTest.php
+++ b/tests/Util/SmartPaginatorFactoryTest.php
@@ -90,6 +90,14 @@ final class SmartPaginatorFactoryTest extends TestCase
             ->method('getDoctrineQuery')
             ->willReturn($queryBuilder->getQuery());
 
+        $orderBy = $queryBuilder->getDQLPart('orderBy');
+
+        if ([] !== $orderBy) {
+            $orderByParts = explode(' ', $orderBy[0]->getParts()[0]);
+
+            $proxyQuery->method('getSortBy')->willReturn($orderByParts[0]);
+        }
+
         $paginator = SmartPaginatorFactory::create($proxyQuery);
 
         static::assertSame($expected, $paginator->getUseOutputWalkers());

--- a/tests/Util/SmartPaginatorFactoryTest.php
+++ b/tests/Util/SmartPaginatorFactoryTest.php
@@ -76,8 +76,6 @@ final class SmartPaginatorFactoryTest extends TestCase
 
     /**
      * @dataProvider getQueriesForOutputWalker
-     *
-     * @param bool|null $expected
      */
     public function testUseOutputWalker(QueryBuilder $queryBuilder, ?bool $expected, ?string $sortBy = null): void
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed smart pagination disabling output walkers when the orderBy is set to a ToMany at proxy level.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
