### PR TITLE
Do not set last page to 0 when there is no results

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -66,8 +66,10 @@ final class Pager extends BasePager
         $query->setFirstResult(null);
         $query->setMaxResults(null);
 
-        if (0 === $this->getPage() || 0 === $this->getMaxPerPage() || 0 === $this->countResults()) {
+        if (0 === $this->getPage() || 0 === $this->getMaxPerPage()) {
             $this->setLastPage(0);
+        } elseif (0 === $this->countResults()) {
+            $this->setLastPage(1);
         } else {
             $offset = ($this->getPage() - 1) * $this->getMaxPerPage();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Related to https://github.com/sonata-project/SonataAdminBundle/issues/7774

The page is 1, but the lastPage is 0.

You can see that in the SimplePager, the lastPage is set to 1 when there is no result
https://github.com/sonata-project/SonataAdminBundle/blob/4.x/src/Datagrid/SimplePager.php#L100-L116

I am targeting this branch, because bugfix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- The lastpage is correctly set to 1 when there is no results.
```