### PR TITLE
Add bleeding edge and precise literal string param

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,9 +5,14 @@
         <TypeDoesNotContainType occurrences="1">
             <code>[] === $idx</code>
         </TypeDoesNotContainType>
-        <!-- https://github.com/vimeo/psalm/issues/4295 -->
-        <InvalidScalarArgument occurrences="1">
-            <code>$exception-&gt;getCode()</code>
-        </InvalidScalarArgument>
+    </file>
+    <!-- https://github.com/vimeo/psalm/issues/7995 -->
+    <file src="src/Datagrid/ProxyQuery.php">
+        <MoreSpecificReturnType occurrences="1">
+            <code>string</code>
+        </MoreSpecificReturnType>
+        <LessSpecificReturnStatement occurrences="1">
+            <code>$alias</code>
+        </LessSpecificReturnStatement>
     </file>
 </files>

--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -30,9 +30,6 @@ final class AuditBlockService extends AbstractBlockService
      */
     private $auditReader;
 
-    /**
-     * @param AuditReader $auditReader
-     */
     public function __construct(Environment $twig, AuditReader $auditReader)
     {
         parent::__construct($twig);

--- a/src/Block/AuditBlockService.php
+++ b/src/Block/AuditBlockService.php
@@ -26,12 +26,12 @@ use Twig\Environment;
 final class AuditBlockService extends AbstractBlockService
 {
     /**
-     * @var AuditReader<object>
+     * @var AuditReader
      */
     private $auditReader;
 
     /**
-     * @param AuditReader<object> $auditReader
+     * @param AuditReader $auditReader
      */
     public function __construct(Environment $twig, AuditReader $auditReader)
     {

--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -28,6 +28,8 @@ interface ProxyQueryInterface extends BaseProxyQueryInterface
 
     /**
      * @param mixed[] $associationMappings
+     *
+     * @phpstan-return literal-string
      */
     public function entityJoin(array $associationMappings): string;
 

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -156,8 +156,8 @@ abstract class AbstractDateFilter extends Filter
 
         // transform types
         if ('timestamp' === $this->getOption('input_type')) {
-            $value['start'] = $value['start'] instanceof \DateTimeInterface ? $value['start']->getTimestamp() : 0;
-            $value['end'] = $value['end'] instanceof \DateTimeInterface ? $value['end']->getTimestamp() : 0;
+            $value['start'] = $value['start'] instanceof \DateTimeInterface ? $value['start']->getTimestamp() : null;
+            $value['end'] = $value['end'] instanceof \DateTimeInterface ? $value['end']->getTimestamp() : null;
         }
 
         // default type for range filter
@@ -169,16 +169,16 @@ abstract class AbstractDateFilter extends Filter
         if (DateRangeOperatorType::TYPE_NOT_BETWEEN === $type) {
             $this->applyWhere($query, sprintf('%s.%s < :%s OR %s.%s > :%s', $alias, $field, $startDateParameterName, $alias, $field, $endDateParameterName));
         } else {
-            if ($value['start']) {
+            if (null !== $value['start']) {
                 $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '>=', $startDateParameterName));
             }
 
-            if ($value['end']) {
+            if (null !== $value['end']) {
                 $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '<=', $endDateParameterName));
             }
         }
 
-        if ($value['start']) {
+        if (null !== $value['start']) {
             $query->getQueryBuilder()->setParameter(
                 $startDateParameterName,
                 $value['start'],
@@ -186,7 +186,7 @@ abstract class AbstractDateFilter extends Filter
             );
         }
 
-        if ($value['end']) {
+        if (null !== $value['end']) {
             $query->getQueryBuilder()->setParameter(
                 $endDateParameterName,
                 $value['end'],

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -61,9 +61,11 @@ final class CallbackFilter extends Filter
 
     protected function association(ProxyQueryInterface $query, FilterData $data): array
     {
+        /** @var literal-string $alias */
         $alias = $this->getOption('alias', $query->entityJoin($this->getParentAssociationMappings()));
-        \assert(\is_string($alias));
+        /** @var literal-string $fieldName */
+        $fieldName = $this->getFieldName();
 
-        return [$alias, $this->getFieldName()];
+        return [$alias, $fieldName];
     }
 }

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -28,6 +28,9 @@ abstract class Filter extends BaseFilter implements GroupableConditionAwareInter
 
     /**
      * Apply the filter to the QueryBuilder instance.
+     *
+     * @phpstan-param literal-string $alias
+     * @phpstan-param literal-string $field
      */
     abstract public function filter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void;
 
@@ -67,13 +70,15 @@ abstract class Filter extends BaseFilter implements GroupableConditionAwareInter
     /**
      * @return string[]
      *
-     * @phpstan-return array{string, string}
+     * @phpstan-return array{literal-string, literal-string}
      */
     protected function association(ProxyQueryInterface $query, FilterData $data): array
     {
         $alias = $query->entityJoin($this->getParentAssociationMappings());
+        /** @var literal-string $fieldName */
+        $fieldName = $this->getFieldName();
 
-        return [$alias, $this->getFieldName()];
+        return [$alias, $fieldName];
     }
 
     /**

--- a/src/Model/AuditReader.php
+++ b/src/Model/AuditReader.php
@@ -26,18 +26,21 @@ final class AuditReader implements AuditReaderInterface
 {
     /**
      * @var SimpleThingsAuditReader
-     * @phpstan-var SimpleThingsAuditReader
      */
     private $auditReader;
 
-    /**
-     * @phpstan-param SimpleThingsAuditReader $auditReader
-     */
     public function __construct(SimpleThingsAuditReader $auditReader)
     {
         $this->auditReader = $auditReader;
     }
 
+    /**
+     * @param int|string $id
+     * @param int|string $revisionId
+     *
+     * @phpstan-param class-string<T> $className
+     * @phpstan-return T|null
+     */
     public function find(string $className, $id, $revisionId): ?object
     {
         try {

--- a/src/Model/AuditReader.php
+++ b/src/Model/AuditReader.php
@@ -25,13 +25,13 @@ use Sonata\AdminBundle\Model\Revision;
 final class AuditReader implements AuditReaderInterface
 {
     /**
-     * @var SimpleThingsAuditReader<object>
-     * @phpstan-var SimpleThingsAuditReader<T>
+     * @var SimpleThingsAuditReader
+     * @phpstan-var SimpleThingsAuditReader
      */
     private $auditReader;
 
     /**
-     * @phpstan-param SimpleThingsAuditReader<T> $auditReader
+     * @phpstan-param SimpleThingsAuditReader $auditReader
      */
     public function __construct(SimpleThingsAuditReader $auditReader)
     {

--- a/tests/Block/AuditBlockServiceTest.php
+++ b/tests/Block/AuditBlockServiceTest.php
@@ -27,7 +27,7 @@ use Sonata\DoctrineORMAdminBundle\Block\AuditBlockService;
 final class AuditBlockServiceTest extends BlockServiceTestCase
 {
     /**
-     * @var SimpleThingsAuditReader<object>&MockObject
+     * @var SimpleThingsAuditReader&MockObject
      */
     private $simpleThingsAuditReader;
 

--- a/tests/Filter/DateRangeFilterTest.php
+++ b/tests/Filter/DateRangeFilterTest.php
@@ -36,10 +36,6 @@ final class DateRangeFilterTest extends FilterTestCase
             'type' => null,
             'value' => ['start' => null, 'end' => null],
         ]));
-        $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
-            'type' => null,
-            'value' => ['start' => '', 'end' => ''],
-        ]));
 
         self::assertSameQuery([], $proxyQuery);
         static::assertFalse($filter->isActive());
@@ -84,7 +80,7 @@ final class DateRangeFilterTest extends FilterTestCase
             'type' => null,
             'value' => [
                 'start' => $startDateTime,
-                'end' => '',
+                'end' => null,
             ],
         ]));
 
@@ -105,7 +101,7 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
             'type' => null,
             'value' => [
-                'start' => '',
+                'start' => null,
                 'end' => $endDateTime,
             ],
         ]));
@@ -137,7 +133,7 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
             'type' => null,
             'value' => [
-                'start' => '',
+                'start' => null,
                 'end' => $modelEndDateTime,
             ],
         ]));
@@ -196,7 +192,7 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
             'type' => null,
             'value' => [
-                'start' => '',
+                'start' => null,
                 'end' => $endDateTime,
             ],
         ]));

--- a/tests/Model/AuditReaderTest.php
+++ b/tests/Model/AuditReaderTest.php
@@ -24,7 +24,7 @@ use Sonata\DoctrineORMAdminBundle\Model\AuditReader;
 final class AuditReaderTest extends TestCase
 {
     /**
-     * @var MockObject&SimpleThingsAuditReader<object>
+     * @var MockObject&SimpleThingsAuditReader
      */
     private $simpleThingsAuditReader;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Precise Filter::filter() param as literal-string.
```