### PR TITLE
fix missing 'operator_type' returned value in getFormOptions()

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -105,6 +105,7 @@ abstract class AbstractDateFilter extends Filter
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),
+            'operator_type' => $this->range ? DateRangeOperatorType::class : DateOperatorType::class,
         ];
     }
 


### PR DESCRIPTION
## Subject
Fix missing 'operator_type' returned array value in AbstractDateFilter getFormOptions method. 

Aafter [sonata-project](https://github.com/sonata-project)/[SonataAdminBundle](https://github.com/sonata-project/SonataAdminBundle) v4.14.0 upgrade I’ve discovered that some Datagrid advanced filters have stopped to render the complex options.

![Captura de pantalla 2022-07-21 a les 11 36 51](https://user-images.githubusercontent.com/698779/180228087-3b935cf2-e14d-483f-9d9b-5e2e25281ea8.png)

```
// use Sonata\DoctrineORMAdminBundle\Filter\DateFilter;
// use Sonata\Form\Type\DatePickerType;

->add(
    'incomingDate',
    DateFilter::class,
    [
        'field_type' => DatePickerType::class,
        'format' => 'd-m-Y',
        'field_options' => [
            'widget' => 'single_text',
            'format' => 'dd-MM-yyyy',
        ],
    ]
)
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I'm targeting this branch, because it's related with a problem after [sonata-project](https://github.com/sonata-project)/[SonataAdminBundle](https://github.com/sonata-project/SonataAdminBundle) upgrade 4.12.0.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix missing 'operator_type' array value returned in `AbstractDateFilter:: getFormOptions()` bug to avoid not rendered advanced filter options in DateFilter or DateTimeFilter.

```


