### PR TITLE
Update ModelManager to support Doctrine\ORM\Query directly

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -218,7 +218,11 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
             return $query->getQuery()->execute();
         }
 
-        if ($query instanceof Query || $query instanceof ProxyQuery) {
+        if ($query instanceof Query) {
+            return $query->execute();
+        }
+
+        if ($query instanceof ProxyQuery) {
             /** @phpstan-var Paginator<T> $results */
             $results = $query->execute();
 

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -18,10 +18,10 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\ORM\UnitOfWork;
@@ -209,7 +209,7 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
 
     public function supportsQuery(object $query): bool
     {
-        return $query instanceof ProxyQuery || $query instanceof Query || $query instanceof QueryBuilder;
+        return $query instanceof ProxyQuery || $query instanceof AbstractQuery || $query instanceof QueryBuilder;
     }
 
     public function executeQuery(object $query)
@@ -218,7 +218,7 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
             return $query->getQuery()->execute();
         }
 
-        if ($query instanceof Query) {
+        if ($query instanceof AbstractQuery) {
             return $query->execute();
         }
 
@@ -233,7 +233,7 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
             'Argument 1 passed to %s() must be an instance of %s, %s, or %s',
             __METHOD__,
             QueryBuilder::class,
-            Query::class,
+            AbstractQuery::class,
             ProxyQuery::class
         ));
     }

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\ORM\UnitOfWork;
@@ -208,7 +209,7 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
 
     public function supportsQuery(object $query): bool
     {
-        return $query instanceof ProxyQuery || $query instanceof QueryBuilder;
+        return $query instanceof ProxyQuery || $query instanceof Query || $query instanceof QueryBuilder;
     }
 
     public function executeQuery(object $query)
@@ -217,7 +218,7 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
             return $query->getQuery()->execute();
         }
 
-        if ($query instanceof ProxyQuery) {
+        if ($query instanceof Query || $query instanceof ProxyQuery) {
             /** @phpstan-var Paginator<T> $results */
             $results = $query->execute();
 
@@ -225,10 +226,11 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
         }
 
         throw new \InvalidArgumentException(sprintf(
-            'Argument 1 passed to %s() must be an instance of %s or %s',
+            'Argument 1 passed to %s() must be an instance of %s, %s, or %s',
             __METHOD__,
             QueryBuilder::class,
-            ProxyQuery::class,
+            Query::class,
+            ProxyQuery::class
         ));
     }
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -149,6 +149,7 @@ final class ModelManagerTest extends TestCase
     public function supportsQueryDataProvider(): iterable
     {
         yield [true, new ProxyQuery($this->createMock(QueryBuilder::class))];
+        yield [true, $this->createMock(Query::class)];
         yield [true, $this->createMock(QueryBuilder::class)];
         yield [false, new \stdClass()];
     }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -17,10 +17,10 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -150,7 +150,7 @@ final class ModelManagerTest extends TestCase
     public function supportsQueryDataProvider(): iterable
     {
         yield [true, new ProxyQuery($this->createMock(QueryBuilder::class))];
-        yield [true, $this->createMock(Query::class)];
+        yield [true, $this->createMock(AbstractQuery::class)];
         yield [true, $this->createMock(QueryBuilder::class)];
         yield [false, new \stdClass()];
     }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;


### PR DESCRIPTION
Makes life easier when you want to set sorting, caching, etc. directly from an admin, e.g. in configureFormFields

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am hitting use cases in admins where I want to change sort order, add caching, etc. which requires modifying the actual Doctrine query object, not the QueryBuilder, and I need to then be able to pass it in. This worked previously in 3.X because there was a default call to execute() which just happened to work on Doctrine's Query class; I think it should be explicitly supported in ModelManager, to make things easier.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it does not break BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->
```markdown
### Added
 - ModelManager::supportsQuery now supports AbstractQuery
 - ModelManager::execute now supports AbstractQuery
```
