### PR TITLE
Fix batch delete on entities with json columns (PostgreSQL)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.17",
         "psalm/plugin-symfony": "^3.0",
-        "rector/rector": "^0.13",
+        "rector/rector": "^0.14",
         "sonata-project/block-bundle": "^4.2",
         "sonata-project/entity-audit-bundle": "^1.1",
         "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -345,14 +345,11 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
             throw new \TypeError(sprintf('The query MUST implement %s.', ProxyQueryInterface::class));
         }
 
-        $qb = $query->getQueryBuilder();
-        $qb->select('DISTINCT '.current($qb->getRootAliases()));
-
         try {
             $entityManager = $this->getEntityManager($class);
 
             $i = 0;
-            foreach ($qb->getQuery()->toIterable() as $object) {
+            foreach ($query->execute() as $object) {
                 $entityManager->remove($object);
 
                 if (0 === (++$i % 20)) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes issues related with batch delete on entities with json columns. Will still need to remove the jsonb from media-bundle to avoid problem for non postgres users.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix batch delete on entities with json columns on PostgreSQL.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
