### PR TITLE
Add tests for collection removal without triggering validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/persistence": "^3.0.2",
         "sonata-project/admin-bundle": "^4.18",
         "sonata-project/exporter": "^2.0 || ^3.0",
-        "sonata-project/form-extensions": "^1.4",
+        "sonata-project/form-extensions": "1.x-dev",
         "symfony/config": "^4.4 || ^5.4 || ^6.2",
         "symfony/console": "^4.4 || ^5.4 || ^6.2",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/persistence": "^3.0.2",
         "sonata-project/admin-bundle": "^4.18",
         "sonata-project/exporter": "^2.0 || ^3.0",
-        "sonata-project/form-extensions": "1.x-dev",
+        "sonata-project/form-extensions": "^1.19",
         "symfony/config": "^4.4 || ^5.4 || ^6.2",
         "symfony/console": "^4.4 || ^5.4 || ^6.2",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.2",

--- a/tests/App/Admin/ChildAdmin.php
+++ b/tests/App/Admin/ChildAdmin.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Child;
+
+/**
+ * @phpstan-extends AbstractAdmin<Child>
+ */
+final class ChildAdmin extends AbstractAdmin
+{
+    protected function configureListFields(ListMapper $list): void
+    {
+        $list
+            ->add('id')
+            ->addIdentifier('name')
+            ->add('anotherName');
+    }
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+        $form
+            ->add('name')
+            ->add('anotherName');
+    }
+}

--- a/tests/App/Admin/MotherAdmin.php
+++ b/tests/App/Admin/MotherAdmin.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Mother;
+use Sonata\Form\Type\CollectionType;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @phpstan-extends AbstractAdmin<Mother>
+ */
+final class MotherAdmin extends AbstractAdmin
+{
+    protected function configureListFields(ListMapper $list): void
+    {
+        $list->addIdentifier('id');
+    }
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+        $form->add('children', CollectionType::class, [
+            'by_reference' => false,
+            'constraints' => [
+                new Assert\Valid(),
+            ],
+        ], [
+            'edit' => 'inline',
+            'inline' => 'table',
+        ]);
+    }
+}

--- a/tests/App/DataFixtures/MotherFixtures.php
+++ b/tests/App/DataFixtures/MotherFixtures.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Child;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Mother;
+
+final class MotherFixtures extends Fixture implements FixtureInterface
+{
+    public const MOTHER = 'mother';
+
+    public function load(ObjectManager $manager): void
+    {
+        $mother = new Mother();
+        $this->addChildren($mother, 1);
+
+        $manager->persist($mother);
+        $manager->flush();
+
+        $this->addReference(self::MOTHER, $mother);
+    }
+
+    private function addChildren(Mother $mother, int $children): void
+    {
+        for ($i = 0; $i < $children; ++$i) {
+            $child = new Child();
+            $child->setName('Child '.$i);
+            $child->setAnotherName('Another Name '.$i);
+
+            $mother->addChild($child);
+        }
+    }
+}

--- a/tests/App/DataFixtures/MotherFixtures.php
+++ b/tests/App/DataFixtures/MotherFixtures.php
@@ -26,7 +26,7 @@ final class MotherFixtures extends Fixture implements FixtureInterface
     public function load(ObjectManager $manager): void
     {
         $mother = new Mother();
-        $this->addChildren($mother, 1);
+        $this->addChildren($mother, 2);
 
         $manager->persist($mother);
         $manager->flush();

--- a/tests/App/Entity/Child.php
+++ b/tests/App/Entity/Child.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity]
+class Child implements \Stringable
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING)]
+    #[Assert\NotBlank]
+    private ?string $name = null;
+
+    #[ORM\Column(type: Types::STRING)]
+    #[Assert\NotBlank]
+    private ?string $anotherName = null;
+
+    public function __toString(): string
+    {
+        return $this->name ?? '-';
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getAnotherName(): ?string
+    {
+        return $this->anotherName;
+    }
+
+    public function setAnotherName(?string $anotherName): void
+    {
+        $this->anotherName = $anotherName;
+    }
+}

--- a/tests/App/Entity/Mother.php
+++ b/tests/App/Entity/Mother.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Mother implements \Stringable
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    /**
+     * @var Collection<array-key, Child>
+     */
+    #[ORM\ManyToMany(targetEntity: Child::class, cascade: ['persist', 'remove'])]
+    private Collection $children;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->id;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function addChild(Child $child): void
+    {
+        $this->children->add($child);
+    }
+
+    public function removeChild(Child $child): void
+    {
+        $this->children->removeElement($child);
+    }
+
+    /**
+     * @return Collection<array-key, Child>
+     */
+    public function getChildren(): Collection
+    {
+        return $this->children;
+    }
+}

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -3,7 +3,7 @@ framework:
         enabled: true
     form:
         enabled: true
-    secret: '%env(APP_SECRET)%'
+    secret: secret
     http_method_override: false
     test: true
     translator:
@@ -28,3 +28,7 @@ doctrine:
                 dir: "%kernel.project_dir%/Entity"
                 is_bundle: false
                 prefix: Sonata\DoctrineORMAdminBundle\Tests\App\Entity
+
+sonata_admin:
+    options:
+        html5_validate: false

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -18,13 +18,17 @@ use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\BookWithAuthorAutocompleteAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CarAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\CategoryAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\ChildAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\ItemAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\MotherAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\SubAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Car;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Category;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Child;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Item;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Mother;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Sub;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -94,5 +98,19 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'manager_type' => 'orm',
                 'model_class' => Sub::class,
                 'label' => 'Inheritance',
+            ])
+
+        ->set(MotherAdmin::class)
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'model_class' => Mother::class,
+                'label' => 'Mother',
+            ])
+
+        ->set(ChildAdmin::class)
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'model_class' => Child::class,
+                'label' => 'Child',
             ]);
 };

--- a/tests/Functional/CollectionItemRemovalTest.php
+++ b/tests/Functional/CollectionItemRemovalTest.php
@@ -43,6 +43,6 @@ final class CollectionItemRemovalTest extends BasePantherTestCase
 
         $this->client->submit($form);
 
-        self::assertSelectorTextContains('.alert-error', 'Item "1" has been successfully updated.');
+        self::assertSelectorTextContains('.alert-danger', 'Item "1" has been successfully updated.');
     }
 }

--- a/tests/Functional/CollectionItemRemovalTest.php
+++ b/tests/Functional/CollectionItemRemovalTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Panther\DomCrawler\Crawler;
+
+final class CollectionItemRemovalTest extends BasePantherTestCase
+{
+    public function testRemoveCollectionItemWithoutValidation(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/mother/1/edit?uniqid=mother');
+
+        $form = $crawler->selectButton('Update')->form();
+        $form['mother[children][0][name]'] = '';
+
+        $crawler->filter('.icheckbox_square-blue')->each(static function (Crawler $label): void {
+            $label->click();
+        });
+
+        $this->client->submit($form);
+
+        self::assertSelectorTextContains('.alert-success', 'Item "1" has been successfully updated.');
+    }
+}

--- a/tests/Functional/CollectionItemRemovalTest.php
+++ b/tests/Functional/CollectionItemRemovalTest.php
@@ -33,4 +33,16 @@ final class CollectionItemRemovalTest extends BasePantherTestCase
 
         self::assertSelectorTextContains('.alert-success', 'Item "1" has been successfully updated.');
     }
+
+    public function testTriggerCollectionValidation(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/tests/app/mother/1/edit?uniqid=mother');
+
+        $form = $crawler->selectButton('Update')->form();
+        $form['mother[children][0][name]'] = '';
+
+        $this->client->submit($form);
+
+        self::assertSelectorTextContains('.alert-error', 'Item "1" has been successfully updated.');
+    }
 }

--- a/tests/Functional/CollectionTypeTest.php
+++ b/tests/Functional/CollectionTypeTest.php
@@ -16,7 +16,7 @@ namespace Sonata\DoctrineORMAdminBundle\Tests\Functional;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Panther\DomCrawler\Crawler;
 
-final class CollectionItemRemovalTest extends BasePantherTestCase
+final class CollectionTypeTest extends BasePantherTestCase
 {
     public function testRemoveCollectionItemWithoutValidation(): void
     {
@@ -25,8 +25,8 @@ final class CollectionItemRemovalTest extends BasePantherTestCase
         $form = $crawler->selectButton('Update')->form();
         $form['mother[children][0][name]'] = '';
 
-        $crawler->filter('.icheckbox_square-blue')->each(static function (Crawler $label): void {
-            $label->click();
+        $crawler->filter('#mother_children_0__delete + ins')->each(static function (Crawler $checkbox): void {
+            $checkbox->click();
         });
 
         $this->client->submit($form);
@@ -43,6 +43,6 @@ final class CollectionItemRemovalTest extends BasePantherTestCase
 
         $this->client->submit($form);
 
-        self::assertSelectorTextContains('.alert-danger', 'Item "1" has been successfully updated.');
+        self::assertSelectorTextContains('.alert-danger', 'An error has occurred during update of item "1".');
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
- Bump `sonata-project/form-extensions` to ^1.19
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
