### PR TITLE
Allow Symfony uid as primary key for Entities managed with Sonata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "symfony/panther": "^2.0.1",
         "symfony/phpunit-bridge": "^6.2",
         "symfony/templating": "^5.4 || ^6.2",
+        "symfony/uid": "^5.4 || ^6.2",
         "symfony/yaml": "^5.4 || ^6.2",
         "vimeo/psalm": "^5.7",
         "weirdan/doctrine-psalm-plugin": "^2.0"

--- a/src/FieldDescription/FilterTypeGuesser.php
+++ b/src/FieldDescription/FilterTypeGuesser.php
@@ -24,6 +24,7 @@ use Sonata\DoctrineORMAdminBundle\Filter\ModelFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\NumberFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\TimeFilter;
+use Sonata\DoctrineORMAdminBundle\Filter\UidFilter;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Guess\Guess;
@@ -75,6 +76,9 @@ final class FilterTypeGuesser implements TypeGuesserInterface
                 $options['field_options'] = ['class' => $fieldDescription->getTargetModel()];
 
                 return new TypeGuess(ModelFilter::class, $options, Guess::HIGH_CONFIDENCE);
+            case 'uuid':
+            case 'ulid':
+                return new TypeGuess(UidFilter::class, $options, Guess::HIGH_CONFIDENCE);
             default:
                 return new TypeGuess(StringFilter::class, $options, Guess::LOW_CONFIDENCE);
         }

--- a/src/Filter/UidFilter.php
+++ b/src/Filter/UidFilter.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Filter;
+
+use Doctrine\DBAL\Types\Types;
+use Sonata\AdminBundle\Filter\Model\FilterData;
+use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
+use Sonata\AdminBundle\Search\SearchableFilterInterface;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
+
+final class UidFilter extends Filter implements SearchableFilterInterface
+{
+    public const CHOICES = [
+        EqualOperatorType::TYPE_EQUAL => '=',
+        EqualOperatorType::TYPE_NOT_EQUAL => '<>',
+    ];
+
+    public function filter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void
+    {
+        if (!$data->hasValue()) {
+            return;
+        }
+
+        if ('' === $data->getValue()) {
+            return;
+        }
+
+        $uidValue = $this->convertToUid($data->getValue()) ?? $data->getValue();
+        $operator = $this->getOperator($data->getType() ?? EqualOperatorType::TYPE_EQUAL);
+        $parameterName = $this->getNewParameterName($query);
+
+        $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, $operator, $parameterName));
+        $query->getQueryBuilder()->setParameter($parameterName, $uidValue, $this->getParameterType($uidValue));
+    }
+
+    public function isSearchEnabled(): bool
+    {
+        return $this->getOption('global_search');
+    }
+
+    public function getDefaultOptions(): array
+    {
+        return [
+            'field_type' => TextType::class,
+            'operator_type' => EqualOperatorType::class,
+            'operator_options' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFormOptions(): array
+    {
+        return [
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
+            'label' => $this->getLabel(),
+        ];
+    }
+
+    private function convertToUid(string $value): ?AbstractUid
+    {
+        if (Uuid::isValid($value)) {
+            return Uuid::fromString($value);
+        }
+
+        if (Ulid::isValid($value)) {
+            return Ulid::fromString($value);
+        }
+
+        return null;
+    }
+
+    private function getOperator(int $type): string
+    {
+        if (!isset(self::CHOICES[$type])) {
+            throw new \OutOfRangeException(sprintf(
+                'The type "%s" is not supported, allowed one are "%s".',
+                $type,
+                implode('", "', array_keys(self::CHOICES))
+            ));
+        }
+
+        return self::CHOICES[$type];
+    }
+
+    private function getParameterType(AbstractUid|string $parameter): string
+    {
+        if ($parameter instanceof Uuid) {
+            return 'uuid';
+        }
+
+        if ($parameter instanceof Ulid) {
+            return 'ulid';
+        }
+
+        return Types::STRING;
+    }
+}

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -328,6 +328,8 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
 
         $fieldNames = $this->getIdentifierFieldNames($class);
         $qb = $query->getQueryBuilder();
+        $rootAlias = current($qb->getRootAliases());
+        $metadata = $this->getMetadata($class);
 
         $prefix = uniqid();
         $sqls = [];
@@ -335,10 +337,14 @@ final class ModelManager implements ModelManagerInterface, LockInterface, ProxyR
             $ids = explode(self::ID_SEPARATOR, (string) $id);
 
             $ands = [];
-            foreach ($fieldNames as $posName => $name) {
+            foreach ($fieldNames as $index => $name) {
                 $parameterName = sprintf('field_%s_%s_%d', $prefix, $name, $pos);
-                $ands[] = sprintf('%s.%s = :%s', current($qb->getRootAliases()), $name, $parameterName);
-                $qb->setParameter($parameterName, $ids[$posName]);
+                $ands[] = sprintf('%s.%s = :%s', $rootAlias, $name, $parameterName);
+                $qb->setParameter(
+                    $parameterName,
+                    $ids[$index],
+                    $metadata->getTypeOfField($name)
+                );
             }
 
             $sqls[] = implode(' AND ', $ands);

--- a/src/Resources/config/doctrine_orm_filter_types.php
+++ b/src/Resources/config/doctrine_orm_filter_types.php
@@ -30,6 +30,7 @@ use Sonata\DoctrineORMAdminBundle\Filter\NumberFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\StringFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\StringListFilter;
 use Sonata\DoctrineORMAdminBundle\Filter\TimeFilter;
+use Sonata\DoctrineORMAdminBundle\Filter\UidFilter;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
@@ -80,7 +81,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin.filter.type', ['alias' => 'doctrine_orm_string_list'])
 
         ->set('sonata.admin.orm.filter.type.time', TimeFilter::class)
-            ->tag('sonata.admin.filter.type', ['alias' => 'doctrine_orm_time']);
+            ->tag('sonata.admin.filter.type', ['alias' => 'doctrine_orm_time'])
+
+        ->set('sonata.admin.orm.filter.type.uid', UidFilter::class)
+            ->tag('sonata.admin.filter.type', ['alias' => 'doctrine_orm_uid']);
 
     /**
      * NEXT_MAJOR: Remove this service definition.

--- a/tests/App/Admin/UlidChildEntityAdmin.php
+++ b/tests/App/Admin/UlidChildEntityAdmin.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\UlidChildEntity;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @phpstan-extends AbstractAdmin<UlidChildEntity>
+ */
+final class UlidChildEntityAdmin extends AbstractAdmin
+{
+    protected function createNewInstance(): UlidChildEntity
+    {
+        return new UlidChildEntity(new Ulid());
+    }
+
+    protected function configureDatagridFilters(DatagridMapper $filter): void
+    {
+        $filter
+            ->add('id')
+            ->add('name')
+            ->add('parent', null, [
+                'field_type' => ModelAutocompleteType::class,
+                'field_options' => [
+                    'property' => 'name',
+                    'multiple' => true,
+                ],
+            ]);
+    }
+
+    protected function configureShowFields(ShowMapper $show): void
+    {
+        $show
+            ->add('id')
+            ->add('name')
+            ->add('parent');
+    }
+
+    protected function configureListFields(ListMapper $list): void
+    {
+        $list
+            ->addIdentifier('id')
+            ->add('name')
+            ->add('parent');
+    }
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+        $form
+            ->add('name')
+            ->add('parent');
+    }
+}

--- a/tests/App/Admin/UuidEntityAdmin.php
+++ b/tests/App/Admin/UuidEntityAdmin.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Car;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\UuidEntity;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @phpstan-extends AbstractAdmin<UuidEntity>
+ */
+final class UuidEntityAdmin extends AbstractAdmin
+{
+    protected function createNewInstance(): UuidEntity
+    {
+        return new UuidEntity(Uuid::v4());
+    }
+
+    protected function configureDatagridFilters(DatagridMapper $filter): void
+    {
+        $filter
+            ->add('id')
+            ->add('name')
+            ->add('child', null, [
+                'field_options' => ['multiple' => true],
+            ])
+            ->add('car', null, [
+                'field_options' => ['choice_value' => static fn (?Car $choice): ?string => null !== $choice ? $choice->getName().'~'.$choice->getYear() : null,
+                ],
+            ]);
+    }
+
+    protected function configureShowFields(ShowMapper $show): void
+    {
+        $show
+            ->add('id')
+            ->add('name')
+            ->add('child')
+            ->add('car');
+    }
+
+    protected function configureListFields(ListMapper $list): void
+    {
+        $list
+            ->addIdentifier('id')
+            ->add('name')
+            ->add('child')
+            ->add('car');
+    }
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+        $form
+            ->add('name')
+            ->add('child')
+            ->add('car');
+    }
+}

--- a/tests/App/DataFixtures/CarFixtures.php
+++ b/tests/App/DataFixtures/CarFixtures.php
@@ -19,6 +19,9 @@ use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Car;
 
 final class CarFixtures extends Fixture
 {
+    public const CAR = 'car';
+    public const CAR_FROM_2010 = 'car_from_2010';
+
     public function load(ObjectManager $manager): void
     {
         $foo2000 = new Car('Foo', 2000);
@@ -29,5 +32,8 @@ final class CarFixtures extends Fixture
         $manager->persist($foo2010);
         $manager->persist($bar2000);
         $manager->flush();
+
+        $this->addReference(self::CAR, $foo2000);
+        $this->addReference(self::CAR_FROM_2010, $foo2010);
     }
 }

--- a/tests/App/DataFixtures/MotherFixtures.php
+++ b/tests/App/DataFixtures/MotherFixtures.php
@@ -21,8 +21,6 @@ use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Mother;
 
 final class MotherFixtures extends Fixture implements FixtureInterface
 {
-    public const MOTHER = 'mother';
-
     public function load(ObjectManager $manager): void
     {
         $mother = new Mother();
@@ -30,8 +28,6 @@ final class MotherFixtures extends Fixture implements FixtureInterface
 
         $manager->persist($mother);
         $manager->flush();
-
-        $this->addReference(self::MOTHER, $mother);
     }
 
     private function addChildren(Mother $mother, int $children): void

--- a/tests/App/DataFixtures/UlidChildEntityFixtures.php
+++ b/tests/App/DataFixtures/UlidChildEntityFixtures.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\UlidChildEntity;
+use Symfony\Component\Uid\Ulid;
+
+final class UlidChildEntityFixtures extends Fixture implements FixtureInterface
+{
+    public const ULID_FOO = 'foo';
+    public const ULID_BAR = 'bar';
+    public const ULID_BAZ = 'baz';
+    public const ULID_QUX = 'qux';
+
+    public function load(ObjectManager $manager): void
+    {
+        $foo = new UlidChildEntity(Ulid::fromString('01GY4D6JYD2KCVDCJS0JF17X90'), 'foo');
+        $bar = new UlidChildEntity(Ulid::fromString('01GY4D6JYD2KCVDCJS0JF17X91'), 'bar');
+        $baz = new UlidChildEntity(Ulid::fromString('01GY4D6JYD2KCVDCJS0JF17X92'), 'baz');
+        $qux = new UlidChildEntity(Ulid::fromString('01GY4D6JYD2KCVDCJS0JF17X93'), 'qux');
+        $more = new UlidChildEntity(Ulid::fromString('01GYC5KGQ737PJVKRKD4NXW6VP'), 'more');
+
+        $manager->persist($foo);
+        $manager->persist($bar);
+        $manager->persist($baz);
+        $manager->persist($qux);
+        $manager->persist($more);
+
+        $manager->flush();
+
+        $this->addReference(self::ULID_FOO, $foo);
+        $this->addReference(self::ULID_BAR, $bar);
+        $this->addReference(self::ULID_BAZ, $baz);
+        $this->addReference(self::ULID_QUX, $qux);
+    }
+}

--- a/tests/App/DataFixtures/UuidEntityFixtures.php
+++ b/tests/App/DataFixtures/UuidEntityFixtures.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Car;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\UlidChildEntity;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\UuidEntity;
+use Symfony\Component\Uid\Uuid;
+
+final class UuidEntityFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+        $car = $this->getReference(CarFixtures::CAR, Car::class);
+        $carFrom2010 = $this->getReference(CarFixtures::CAR_FROM_2010, Car::class);
+        $carFrom2010 = $this->getReference(CarFixtures::CAR_FROM_2010, Car::class);
+
+        $foo = $this->getReference(UlidChildEntityFixtures::ULID_FOO, UlidChildEntity::class);
+        $bar = $this->getReference(UlidChildEntityFixtures::ULID_BAR, UlidChildEntity::class);
+        $baz = $this->getReference(UlidChildEntityFixtures::ULID_BAZ, UlidChildEntity::class);
+        $qux = $this->getReference(UlidChildEntityFixtures::ULID_QUX, UlidChildEntity::class);
+
+        $uuidEntity = new UuidEntity(Uuid::fromString('018788d3-4bcd-79d7-8acf-b14b787c7e04'));
+        $uuidEntity->setName('2000 foo');
+        $uuidEntity->setCar($car);
+        $uuidEntity->setChild($foo);
+
+        $uuidEntity2 = new UuidEntity(Uuid::fromString('018788d3-4bcd-79d7-8acf-b14b7976583e'));
+        $uuidEntity2->setName('2000 bar');
+        $uuidEntity2->setCar($car);
+        $uuidEntity2->setChild($bar);
+
+        $uuidEntity3 = new UuidEntity(Uuid::fromString('018788d3-4bcd-79d7-8acf-b14b7a3d8247'));
+        $uuidEntity3->setName('2010 baz');
+        $uuidEntity3->setCar($carFrom2010);
+        $uuidEntity3->setChild($baz);
+
+        $uuidEntity4 = new UuidEntity(Uuid::fromString('018788d3-4bcd-79d7-8acf-b14b7afa1674'));
+        $uuidEntity4->setName('2010');
+        $uuidEntity3->setCar($carFrom2010);
+
+        $uuidEntity5 = new UuidEntity(Uuid::fromString('018788d3-4bcd-79d7-8acf-b14b7b87b53c'));
+        $uuidEntity5->setName('qux');
+        $uuidEntity5->setChild($qux);
+
+        $uuidEntity6 = new UuidEntity(Uuid::fromString('018788d3-4bcd-79d7-8acf-b14b7b92d176'));
+        $uuidEntity6->setName('nothing');
+
+        $manager->persist($uuidEntity);
+        $manager->persist($uuidEntity2);
+        $manager->persist($uuidEntity3);
+        $manager->persist($uuidEntity4);
+        $manager->persist($uuidEntity5);
+        $manager->persist($uuidEntity6);
+
+        $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [
+            CarFixtures::class,
+            UlidChildEntityFixtures::class,
+        ];
+    }
+}

--- a/tests/App/Entity/UlidChildEntity.php
+++ b/tests/App/Entity/UlidChildEntity.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Ulid;
+
+#[ORM\Entity]
+class UlidChildEntity implements \Stringable
+{
+    #[ORM\OneToOne(targetEntity: UuidEntity::class, mappedBy: 'child')]
+    private ?UuidEntity $parent = null;
+
+    public function __construct(
+        #[ORM\Id]
+        #[ORM\Column(type: 'ulid')]
+        private Ulid $id,
+        #[ORM\Column(type: Types::STRING)]
+        private ?string $name = null
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->name;
+    }
+
+    public function getId(): Ulid
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getParent(): ?UuidEntity
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?UuidEntity $parent): void
+    {
+        $this->parent = $parent;
+    }
+}

--- a/tests/App/Entity/UuidEntity.php
+++ b/tests/App/Entity/UuidEntity.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity]
+class UuidEntity implements \Stringable
+{
+    #[ORM\Column(type: Types::STRING)]
+    private ?string $name = null;
+
+    #[ORM\OneToOne(targetEntity: UlidChildEntity::class, inversedBy: 'parent', cascade: ['persist'])]
+    #[ORM\JoinColumn(referencedColumnName: 'id', onDelete: 'SET NULL')]
+    private ?UlidChildEntity $child = null;
+
+    #[ORM\ManyToOne(targetEntity: Car::class)]
+    #[ORM\JoinColumn(name: 'car_name', referencedColumnName: 'name')]
+    #[ORM\JoinColumn(name: 'car_year', referencedColumnName: 'year')]
+    private ?Car $car = null;
+
+    public function __construct(
+        #[ORM\Id]
+        #[ORM\Column(type: 'uuid')]
+        private Uuid $id
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->name;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getChild(): ?UlidChildEntity
+    {
+        return $this->child;
+    }
+
+    public function setChild(?UlidChildEntity $child): void
+    {
+        $this->child = $child;
+    }
+
+    public function getCar(): ?Car
+    {
+        return $this->car;
+    }
+
+    public function setCar(?Car $car): void
+    {
+        $this->car = $car;
+    }
+}

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -22,6 +22,8 @@ use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\ChildAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\ItemAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\MotherAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\SubAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\UlidChildEntityAdmin;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Admin\UuidEntityAdmin;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Author;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Book;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Car;
@@ -30,6 +32,8 @@ use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Child;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Item;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Mother;
 use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\Sub;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\UlidChildEntity;
+use Sonata\DoctrineORMAdminBundle\Tests\App\Entity\UuidEntity;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -112,5 +116,19 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'manager_type' => 'orm',
                 'model_class' => Child::class,
                 'label' => 'Child',
+            ])
+
+        ->set(UuidEntityAdmin::class)
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'model_class' => UuidEntity::class,
+                'label' => 'UuidEntity',
+            ])
+
+        ->set(UlidChildEntityAdmin::class)
+            ->tag('sonata.admin', [
+                'manager_type' => 'orm',
+                'model_class' => UlidChildEntity::class,
+                'label' => 'UlidChildEntity',
             ]);
 };

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -30,8 +30,8 @@ final class ProxyQueryTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        if (!Type::hasType('uuid')) {
-            Type::addType('uuid', UuidType::class);
+        if (!Type::hasType(UuidType::NAME)) {
+            Type::addType(UuidType::NAME, UuidType::class);
         }
     }
 

--- a/tests/Fixtures/DoctrineType/UuidBinaryType.php
+++ b/tests/Fixtures/DoctrineType/UuidBinaryType.php
@@ -25,7 +25,7 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestCl
  */
 final class UuidBinaryType extends StringType
 {
-    public const NAME = 'uuid_binary';
+    public const NAME = 'sonata_uuid_binary';
 
     public function getName(): string
     {

--- a/tests/Fixtures/DoctrineType/UuidType.php
+++ b/tests/Fixtures/DoctrineType/UuidType.php
@@ -25,7 +25,7 @@ use Sonata\DoctrineORMAdminBundle\Tests\Fixtures\Util\NonIntegerIdentifierTestCl
  */
 final class UuidType extends StringType
 {
-    public const NAME = 'uuid';
+    public const NAME = 'sonata_uuid';
 
     public function getName(): string
     {

--- a/tests/Functional/Admin/BaseAdminTestCase.php
+++ b/tests/Functional/Admin/BaseAdminTestCase.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional\Admin;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+abstract class BaseAdminTestCase extends WebTestCase
+{
+    /**
+     * @dataProvider provideCrudUrlsCases
+     *
+     * @param array<string, mixed> $parameters
+     */
+    public function testCrudUrls(string $url, array $parameters = []): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', $this->provideAdminBaseUrl().'/'.$url, $parameters);
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @dataProvider provideFormUrlsCases
+     *
+     * @param array<string, mixed> $parameters
+     * @param array<string, mixed> $fieldValues
+     */
+    public function testFormsUrls(string $url, array $parameters, string $button, array $fieldValues = []): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', $this->provideAdminBaseUrl().'/'.$url, $parameters);
+        $client->submitForm($button, $fieldValues);
+        $client->followRedirect();
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @dataProvider provideBatchActionsCases
+     *
+     * @param array<string> $idx
+     */
+    public function testBatchActions(string $action, array $idx = [], ?int $rowsAfter = null): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $client->request('GET', $this->provideAdminBaseUrl().'/list');
+
+        $client->submitForm('OK', [
+            'action' => $action,
+            (0 === \count($idx) ? 'all_elements' : 'idx') => 0 === \count($idx) ? true : $idx,
+        ]);
+        $client->submitForm('Yes, execute');
+        $crawler = $client->followRedirect();
+
+        if (null !== $rowsAfter) {
+            static::assertCount($rowsAfter, $crawler->filter('.sonata-ba-list tbody tr'));
+        }
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @dataProvider provideFilterActionCases
+     *
+     * @param array<string, array{value: string|array<string>}> $filters
+     */
+    public function testFilterAction(array $filters, int $count): void
+    {
+        $client = self::createClient();
+
+        $this->prepareData();
+
+        $crawler = $client->request('GET', $this->provideAdminBaseUrl().'/list', [
+            'filter' => $filters,
+        ]);
+
+        self::assertResponseIsSuccessful();
+        static::assertCount($count, $crawler->filter('.sonata-ba-list tbody tr'));
+    }
+
+    abstract public function provideAdminBaseUrl(): string;
+
+    /**
+     * @return iterable<array<string|array<string, mixed>>>
+     *
+     * @phpstan-return iterable<array{0: string, 1?: array<string, mixed>}>
+     */
+    abstract public static function provideCrudUrlsCases(): iterable;
+
+    /**
+     * @return iterable<array<string|array<string, mixed>>>
+     *
+     * @phpstan-return iterable<array{0: string, 1: array<string, mixed>, 2: string, 3?: array<string, mixed>}>
+     */
+    abstract public static function provideFormUrlsCases(): iterable;
+
+    /**
+     * @return iterable<array<string|array|integer>>
+     *
+     * @phpstan-return iterable<array{0: string, 1?: array<string>, 2?: integer}>
+     */
+    abstract public static function provideBatchActionsCases(): iterable;
+
+    /**
+     * @return iterable<array<int|array>>
+     *
+     * @phpstan-return iterable<array{0: array<string, array{value: string|array<string>, type?: integer}>, 1: integer}>
+     */
+    abstract public static function provideFilterActionCases(): iterable;
+
+    abstract protected function prepareData(): void;
+}

--- a/tests/Functional/Admin/UlidChildEntityAdminTest.php
+++ b/tests/Functional/Admin/UlidChildEntityAdminTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional\Admin;
+
+use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
+
+final class UlidChildEntityAdminTest extends BaseAdminTestCase
+{
+    public function provideAdminBaseUrl(): string
+    {
+        return '/admin/tests/app/ulidchildentity';
+    }
+
+    public static function provideCrudUrlsCases(): iterable
+    {
+        yield 'List Ulid Child Entity' => ['list'];
+        yield 'Create Ulid Child Entity' => ['create'];
+        yield 'Edit Ulid Child Entity' => ['01GY4D6JYD2KCVDCJS0JF17X90/edit'];
+        yield 'Show Ulid Child Entity' => ['01GY4D6JYD2KCVDCJS0JF17X90/show'];
+        yield 'Remove Ulid Child Entity' => ['01GY4D6JYD2KCVDCJS0JF17X90/delete'];
+    }
+
+    public static function provideFormUrlsCases(): iterable
+    {
+        yield 'Create Ulid Child Entity' => ['create', [
+            'uniqid' => 'ulidchildentity',
+        ], 'btn_create_and_list', [
+            'ulidchildentity[name]' => 'Name',
+        ]];
+    }
+
+    public static function provideBatchActionsCases(): iterable
+    {
+        yield 'Delete all items' => ['delete', [], 0];
+        yield 'Delete one item' => ['delete', ['01GY4D6JYD2KCVDCJS0JF17X90'], 4];
+        yield 'Delete two items' => [
+            'delete',
+            ['01GY4D6JYD2KCVDCJS0JF17X90', '01GY4D6JYD2KCVDCJS0JF17X91'],
+            3,
+        ];
+    }
+
+    public static function provideFilterActionCases(): iterable
+    {
+        yield 'Filter by id' => [['id' => ['value' => '01GY4D6JYD2KCVDCJS0JF17X90']], 1];
+        yield 'Filter by not id' => [['id' => [
+            'value' => '01GY4D6JYD2KCVDCJS0JF17X90',
+            'type' => EqualOperatorType::TYPE_NOT_EQUAL,
+        ]], 4];
+
+        yield 'Filter by name' => [['name' => ['value' => 'foo']], 1];
+
+        yield 'Filter by parent' => [['parent' => [
+            'value' => ['018788d3-4bcd-79d7-8acf-b14b787c7e04'],
+        ]], 1];
+        yield 'Filter by not parent' => [['parent' => [
+            'value' => [
+                '018788d3-4bcd-79d7-8acf-b14b787c7e04',
+                '018788d3-4bcd-79d7-8acf-b14b7976583e',
+                '018788d3-4bcd-79d7-8acf-b14b7a3d8247',
+            ],
+            'type' => EqualOperatorType::TYPE_NOT_EQUAL,
+        ]], 2];
+    }
+
+    protected function prepareData(): void
+    {
+    }
+}

--- a/tests/Functional/Admin/UuidEntityAdminTest.php
+++ b/tests/Functional/Admin/UuidEntityAdminTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Functional\Admin;
+
+use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
+
+final class UuidEntityAdminTest extends BaseAdminTestCase
+{
+    public function provideAdminBaseUrl(): string
+    {
+        return '/admin/tests/app/uuidentity';
+    }
+
+    public static function provideCrudUrlsCases(): iterable
+    {
+        yield 'List Uuid Entity' => ['list'];
+        yield 'Create Uuid Entity' => ['create'];
+        yield 'Edit Uuid Entity' => ['018788d3-4bcd-79d7-8acf-b14b787c7e04/edit'];
+        yield 'Show Uuid Entity' => ['018788d3-4bcd-79d7-8acf-b14b787c7e04/show'];
+        yield 'Remove Uuid Entity' => ['018788d3-4bcd-79d7-8acf-b14b787c7e04/delete'];
+    }
+
+    public static function provideFormUrlsCases(): iterable
+    {
+        yield 'Create Uuid Entity' => ['create', [
+            'uniqid' => 'uuidentity',
+        ], 'btn_create_and_list', [
+            'uuidentity[name]' => 'Name',
+        ]];
+    }
+
+    public static function provideBatchActionsCases(): iterable
+    {
+        yield 'Delete all items' => ['delete', [], 0];
+        yield 'Delete one item' => ['delete', ['018788d3-4bcd-79d7-8acf-b14b787c7e04'], 5];
+        yield 'Delete two items' => [
+            'delete',
+            ['018788d3-4bcd-79d7-8acf-b14b787c7e04', '018788d3-4bcd-79d7-8acf-b14b7976583e'],
+            4,
+        ];
+    }
+
+    public static function provideFilterActionCases(): iterable
+    {
+        yield 'Filter by id' => [['id' => ['value' => '018788d3-4bcd-79d7-8acf-b14b787c7e04']], 1];
+        yield 'Filter by not id' => [['id' => [
+            'value' => '018788d3-4bcd-79d7-8acf-b14b787c7e04',
+            'type' => EqualOperatorType::TYPE_NOT_EQUAL,
+        ]], 5];
+
+        yield 'Filter by name' => [['name' => ['value' => '2000 foo']], 1];
+
+        yield 'Filter by child' => [['child' => [
+            'value' => [
+                '01GY4D6JYD2KCVDCJS0JF17X90',
+                '01GY4D6JYD2KCVDCJS0JF17X93',
+            ],
+        ]], 2];
+        yield 'Filter by not child' => [['child' => [
+            'value' => ['01GY4D6JYD2KCVDCJS0JF17X90'],
+            'type' => EqualOperatorType::TYPE_NOT_EQUAL,
+        ]], 5];
+
+        yield 'Filter by car' => [['car' => [
+            'value' => 'Foo~2000',
+        ]], 2];
+        yield 'Filter by not car' => [['car' => [
+            'value' => 'Foo~2010',
+            'type' => EqualOperatorType::TYPE_NOT_EQUAL,
+        ]], 5];
+    }
+
+    protected function prepareData(): void
+    {
+    }
+}

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -721,7 +721,7 @@ final class ModelManagerTest extends TestCase
             ->getMock();
 
         $queryBuilder
-            ->expects(static::exactly(\count($expectedParameters)))
+            ->expects(static::once())
             ->method('getRootAliases')
             ->willReturn(['p']);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/7327.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- Support for `symfony/uid` as primary keys using `Uuid` or `Ulid`

### Fixed
- `ModelFilter` for related entities using compound ids
- `ModelFilter` when filtering for not equals and using an inverse side relation
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
