### PR TITLE
AbstractDateFilter::filterRange() applies a `WHERE` condition separately for the `start` and `end` values in the case of DateRangeOperatorType::TYPE_NOT_BETWEEN

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -160,7 +160,13 @@ abstract class AbstractDateFilter extends Filter
         $endDateParameterName = $this->getNewParameterName($query);
 
         if (DateRangeOperatorType::TYPE_NOT_BETWEEN === $type) {
-            $this->applyWhere($query, sprintf('%s.%s < :%s OR %s.%s > :%s', $alias, $field, $startDateParameterName, $alias, $field, $endDateParameterName));
+            if (null !== $value['start']) {
+                $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '<', $startDateParameterName));
+            }
+
+            if (null !== $value['end']) {
+                $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '>', $endDateParameterName));
+            }
         } else {
             if (null !== $value['start']) {
                 $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '>=', $startDateParameterName));

--- a/tests/Filter/DateTimeRangeFilterTest.php
+++ b/tests/Filter/DateTimeRangeFilterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\DoctrineORMAdminBundle\Tests\Filter;
 
 use Sonata\AdminBundle\Filter\Model\FilterData;
+use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter;
 use Sonata\Form\Type\DateTimeRangeType;
@@ -42,5 +43,49 @@ final class DateTimeRangeFilterTest extends FilterTestCase
         $filter->initialize('foo');
 
         static::assertSame(DateTimeRangeType::class, $filter->getFieldType());
+    }
+
+    public function testFilterNotBetweenStartDate(): void
+    {
+        $filter = new DateTimeRangeFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+
+        $startDateTime = new \DateTime('2023-10-03T12:00:01');
+
+        $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
+            'type' => DateRangeOperatorType::TYPE_NOT_BETWEEN,
+            'value' => [
+                'start' => $startDateTime,
+                'end' => null,
+            ],
+        ]));
+
+        self::assertSameQuery(['WHERE alias.field < :field_name_0'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => $startDateTime], $proxyQuery);
+        static::assertTrue($filter->isActive());
+    }
+
+    public function testFilterNotBetweenEndDate(): void
+    {
+        $filter = new DateTimeRangeFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+
+        $endDateTime = new \DateTime('2023-10-03T12:00:01');
+
+        $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
+            'type' => DateRangeOperatorType::TYPE_NOT_BETWEEN,
+            'value' => [
+                'start' => null,
+                'end' => $endDateTime,
+            ],
+        ]));
+
+        self::assertSameQuery(['WHERE alias.field > :field_name_1'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_1' => $endDateTime], $proxyQuery);
+        static::assertTrue($filter->isActive());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
AbstractDateFilter::filterRange() applies a `WHERE` condition separately for the `start` and `end` values in the case of DateRangeOperatorType::TYPE_NOT_BETWEEN.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it fixes bug in 4.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
This fixes a bug that arises when one of this range borders is not set.

Closes #1766.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- DateTimeRangeFilter exception occurs when either the `start` or `end` field is empty.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
