### PR TITLE
remove block-bundle v4 leftovers

### DIFF
--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -18,7 +18,6 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle;
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Sonata\AdminBundle\SonataAdminBundle;
-use Sonata\BlockBundle\Cache\HttpCacheHandler;
 use Sonata\BlockBundle\SonataBlockBundle;
 use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle;
@@ -87,10 +86,6 @@ final class AppKernel extends Kernel
 
         if (!class_exists(IsGranted::class)) {
             $loader->load(__DIR__.'/config/config_symfony_v5.yml');
-        }
-
-        if (class_exists(HttpCacheHandler::class)) {
-            $loader->load($this->getProjectDir().'/config/config_sonata_block_v4.yaml');
         }
 
         $loader->load(__DIR__.'/config/services.php');

--- a/tests/App/config/config_sonata_block_v4.yaml
+++ b/tests/App/config/config_sonata_block_v4.yaml
@@ -1,2 +1,0 @@
-sonata_block:
-    http_cache: false


### PR DESCRIPTION
Overlooked this in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1776