### PR TITLE
doc(configuration): remove `sonata_doctrine_orm_admin.templates.form` and `sonata_doctrine_orm_admin.templates.filter`

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -21,10 +21,6 @@ Full configuration options
             force: true
 
         templates:
-            form:
-                - "@SonataDoctrineORMAdmin/Form/form_admin_fields.html.twig"
-            filter:
-                - "@SonataDoctrineORMAdmin/Form/filter_admin_fields.html.twig"
             types:
                 list:
                     array:      "@SonataAdmin/CRUD/list_array.html.twig"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
remove `sonata_doctrine_orm_admin.templates.form` and `sonata_doctrine_orm_admin.templates.filter`

I am targeting this branch, because this configuration was removed in v4 major upgrade, in this PR https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1421/files#diff-ebe00144d6cecb5ca8a2860883e01147f42bbed2b12a3a7f44915908a4829faaL49-L56 

