### PR TITLE
Catch possible null value error in ModelFilter

### DIFF
--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -94,7 +94,9 @@ final class ModelFilter extends Filter
             );
         }
 
-        $this->applyWhere($query, $inExpression);
+        if ($inExpression->count() > 0) {
+            $this->applyWhere($query, $inExpression);
+        }
     }
 
     protected function association(ProxyQueryInterface $query, FilterData $data): array
@@ -147,6 +149,10 @@ final class ModelFilter extends Filter
         $orX = $queryBuilder->expr()->orX();
 
         foreach ($data->getValue() as $value) {
+            if (!\is_object($value)) {
+                continue;
+            }
+
             $andX = $queryBuilder->expr()->andX();
 
             foreach ($metadata->getIdentifierValues($value) as $fieldName => $identifierValue) {

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -53,6 +53,25 @@ final class ModelFilterTest extends FilterTestCase
         static::assertTrue($filter->isActive());
     }
 
+    public function testFilterNonObject(): void
+    {
+        $filter = new ModelFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+
+        $objects = [new \stdClass(), new \stdClass()];
+        $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
+            'type' => EqualOperatorType::TYPE_EQUAL,
+            'value' => null,
+        ]));
+
+        // the alias is now computer by the entityJoin method
+        self::assertSameQuery([], $proxyQuery);
+        self::assertSameQueryParameters([], $proxyQuery);
+        static::assertFalse($filter->isActive());
+    }
+
     public function testFilterArrayTypeIsNotEqual(): void
     {
         $filter = new ModelFilter();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject



<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Catch possible null value error in `ModelFilter`
```

Got the error when using the `ModelFilter` in combination with a `ModelAutocompleteType`. 

The error might show up if you bookmark a link (e.g. /list?filter[user][value]=entityID123) and you than remove the referenced entity. The `hasValue` check passes, because you provide a valid value, but there is no entity so you receive a null error.
