### PR TITLE
Stop using deprecated const

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -180,7 +180,7 @@ final class ProxyQuery implements ProxyQueryInterface
         foreach ($queryBuilder->getDQLPart('orderBy') as $order) {
             foreach ($order->getParts() as $part) {
                 \assert(\is_string($part));
-                $existingOrders[] = trim(str_replace([Criteria::DESC, Criteria::ASC], '', $part));
+                $existingOrders[] = trim(str_replace(['DESC', 'ASC'], '', $part));
             }
         }
 


### PR DESCRIPTION
## Subject

Looking at doctrine/orm they don't have any constant for ASC and DESC,
see https://github.com/doctrine/orm/blob/cbb6c897de4dd4e215c7005505b381c5927e5f4a/src/Query/Expr.php#L74 for example

I'm not sure it's right to use the one from doctrine/collections.

## Changelog

Pedantic