### PR TITLE
Fix AbstractDateFilter::filterRange()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,12 +9,6 @@ parameters:
         - # https://github.com/phpstan/phpstan-strict-rules/issues/130
             message: '#^Call to static method PHPUnit\\Framework\\Assert::.* will always evaluate to true\.$#'
             path: tests/
-        - # https://github.com/doctrine/orm/pull/8767
-            message: '#Method Sonata\\DoctrineORMAdminBundle\\FieldDescription\\FieldDescriptionFactory::getMetadata\(\) should return Doctrine\\ORM\\Mapping\\ClassMetadata\<TObject of object\> but returns Doctrine\\ORM\\Mapping\\ClassMetadata\<object\>\.$#'
-            path: src/FieldDescription/FieldDescriptionFactory.php
-        - # https://github.com/doctrine/orm/pull/8767
-            message: '#Method Sonata\\DoctrineORMAdminBundle\\Model\\ModelManager::getMetadata\(\) should return Doctrine\\ORM\\Mapping\\ClassMetadata\<TObject of object\> but returns Doctrine\\ORM\\Mapping\\ClassMetadata\<object\>\.$#'
-            path: src/Model/ModelManager.php
         - # https://github.com/doctrine/orm/pull/9778
             message: '#Parameter \#1 \$className of method Doctrine\\Persistence\\Mapping\\AbstractClassMetadataFactory<Doctrine\\ORM\\Mapping\\ClassMetadata>::getMetadataFor\(\) expects class-string, string given.#'
             path: src/Datagrid/ProxyQuery.php

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -160,11 +160,11 @@ abstract class AbstractDateFilter extends Filter
         $endDateParameterName = $this->getNewParameterName($query);
 
         if (DateRangeOperatorType::TYPE_NOT_BETWEEN === $type) {
-            if (null !== $value['start']) {
+            if (null !== $value['start'] && null !== $value['end']) {
+                $this->applyWhere($query, sprintf('%s.%s < :%s OR %s.%s > :%s', $alias, $field, $startDateParameterName, $alias, $field, $endDateParameterName));
+            } elseif (null !== $value['start']) {
                 $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '<', $startDateParameterName));
-            }
-
-            if (null !== $value['end']) {
+            } elseif (null !== $value['end']) {
                 $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '>', $endDateParameterName));
             }
         } else {

--- a/tests/Filter/DateTimeRangeFilterTest.php
+++ b/tests/Filter/DateTimeRangeFilterTest.php
@@ -88,4 +88,27 @@ final class DateTimeRangeFilterTest extends FilterTestCase
         self::assertSameQueryParameters(['field_name_1' => $endDateTime], $proxyQuery);
         static::assertTrue($filter->isActive());
     }
+
+    public function testFilterNotBetweenStartAndEndDate(): void
+    {
+        $filter = new DateTimeRangeFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+
+        $startDateTime = new \DateTime('2023-10-03T11:00:01');
+        $endDateTime = new \DateTime('2023-10-03T12:00:01');
+
+        $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
+            'type' => DateRangeOperatorType::TYPE_NOT_BETWEEN,
+            'value' => [
+                'start' => $startDateTime,
+                'end' => $endDateTime,
+            ],
+        ]));
+
+        self::assertSameQuery(['WHERE alias.field < :field_name_0 OR alias.field > :field_name_1'], $proxyQuery);
+        self::assertSameQueryParameters(['field_name_0' => $startDateTime, 'field_name_1' => $endDateTime], $proxyQuery);
+        static::assertTrue($filter->isActive());
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

```markdown
### Fixed
- DateTimeRangeFilter when both the `start` or `end` field are not empty.
```