### PR TITLE
AbstractDateFilter::filterRange() applies where differently depending…

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -160,20 +160,22 @@ abstract class AbstractDateFilter extends Filter
         $endDateParameterName = $this->getNewParameterName($query);
 
         if (DateRangeOperatorType::TYPE_NOT_BETWEEN === $type) {
-            if (null !== $value['start']) {
-                $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '<', $startDateParameterName));
-            }
-
-            if (null !== $value['end']) {
-                $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '>', $endDateParameterName));
-            }
+            match (true) {
+                null !== $value['start'] && null !== $value['end'] => $this->applyWhere(
+                    $query,
+                    "{$alias}.{$field} < :{$startDateParameterName} OR {$alias}.{$field} > :{$endDateParameterName}"
+                ),
+                null !== $value['start'] => $this->applyWhere($query, "{$alias}.{$field} < :{$startDateParameterName}"),
+                null !== $value['end'] => $this->applyWhere($query, "{$alias}.{$field} > :{$endDateParameterName}"),
+                default => null,
+            };
         } else {
             if (null !== $value['start']) {
-                $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '>=', $startDateParameterName));
+                $this->applyWhere($query, "{$alias}.{$field} >= :{$startDateParameterName}");
             }
 
             if (null !== $value['end']) {
-                $this->applyWhere($query, sprintf('%s.%s %s :%s', $alias, $field, '<=', $endDateParameterName));
+                $this->applyWhere($query, "{$alias}.{$field} <= :{$endDateParameterName}");
             }
         }
 

--- a/tests/Filter/DateTimeRangeFilterTest.php
+++ b/tests/Filter/DateTimeRangeFilterTest.php
@@ -45,6 +45,32 @@ final class DateTimeRangeFilterTest extends FilterTestCase
         static::assertSame(DateTimeRangeType::class, $filter->getFieldType());
     }
 
+    public function testFilterNotBetweenStartAndEndDate(): void
+    {
+        $filter = new DateTimeRangeFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $proxyQuery = new ProxyQuery($this->createQueryBuilderStub());
+
+        $startDateTime = new \DateTime('2023-10-03T12:00:01');
+        $endDateTime = new \DateTime('2023-10-03T13:00:01');
+
+        $filter->filter($proxyQuery, 'alias', 'field', FilterData::fromArray([
+            'type' => DateRangeOperatorType::TYPE_NOT_BETWEEN,
+            'value' => [
+                'start' => $startDateTime,
+                'end' => $endDateTime,
+            ],
+        ]));
+
+        self::assertSameQuery(['WHERE alias.field < :field_name_0 OR alias.field > :field_name_1'], $proxyQuery);
+        self::assertSameQueryParameters([
+            'field_name_0' => $startDateTime,
+            'field_name_1' => $endDateTime,
+        ], $proxyQuery);
+        static::assertTrue($filter->isActive());
+    }
+
     public function testFilterNotBetweenStartDate(): void
     {
         $filter = new DateTimeRangeFilter();


### PR DESCRIPTION
## Subject

I am targeting this branch, because it is backwards compatible bug fix

## Changelog

### Fixed
- DateTimeRangeFilter when both the `start` or `end` field are not empty.
