### PR TITLE
make `symfony/security-acl` dependency optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "symfony/http-kernel": "^6.4 || ^7.3 || ^8.0",
         "symfony/options-resolver": "^6.4 || ^7.3 || ^8.0",
         "symfony/property-access": "^6.4 || ^7.3 || ^8.0",
-        "symfony/security-acl": "^3.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {
@@ -65,12 +64,14 @@
         "symfony/browser-kit": "^6.4 || ^7.3 || ^8.0",
         "symfony/css-selector": "^6.4 || ^7.3 || ^8.0",
         "symfony/panther": "dev-symfony-8-support",
+        "symfony/security-acl": "^3.0",
         "symfony/uid": "^6.4 || ^7.3 || ^8.0",
         "symfony/yaml": "^6.4 || ^7.3 || ^8.0"
     },
     "conflict": {
         "sonata-project/block-bundle": "<4.2",
-        "sonata-project/entity-audit-bundle": ">=2.0"
+        "sonata-project/entity-audit-bundle": ">=2.0",
+        "symfony/security-acl": "<3.0 >=4.0"
     },
     "provide": {
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"

--- a/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
+++ b/src/DependencyInjection/SonataDoctrineORMAdminExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -46,7 +47,10 @@ final class SonataDoctrineORMAdminExtension extends AbstractSonataAdminExtension
             $container->setParameter('sonata_doctrine_orm_admin.audit.force', $config['audit']['force']);
         }
 
-        $loader->load('security.php');
+        if (interface_exists(ObjectIdentityInterface::class)) {
+            // only load this in case the optional symfony/security-acl package is installed
+            $loader->load('security.php');
+        }
 
         $container->setParameter('sonata_doctrine_orm_admin.entity_manager', $config['entity_manager']);
 


### PR DESCRIPTION
Related to https://github.com/sonata-project/SonataAdminBundle/pull/8369

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
- the `symfony/security-acl` dependency is now optional. You need to explicitly require it as a dependency if you are using ACL. 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
